### PR TITLE
애플 로그인 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,9 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    // gson
+    implementation 'com.google.code.gson:gson:2.8.6'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/projectlyrics/server/domain/auth/authentication/JwtAuthenticationFilter.java
+++ b/src/main/java/com/projectlyrics/server/domain/auth/authentication/JwtAuthenticationFilter.java
@@ -11,12 +11,16 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.UrlPathHelper;
 
 @RequiredArgsConstructor
 @Component
@@ -24,7 +28,17 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
   private static final String TOKEN_PREFIX = "Bearer ";
 
+  @Value("#{'${auth.free-apis}'.split(',')}")
+  private String[] authFreeApis;
+
   private final JwtTokenProvider jwtTokenProvider;
+
+  @Override
+  protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+    String path = new UrlPathHelper().getPathWithinApplication(request);
+    return Arrays.stream(authFreeApis)
+        .anyMatch(pattern -> new AntPathMatcher().match(pattern, path));
+  }
 
   @Override
   protected void doFilterInternal(

--- a/src/main/java/com/projectlyrics/server/domain/auth/dto/request/UserLoginRequest.java
+++ b/src/main/java/com/projectlyrics/server/domain/auth/dto/request/UserLoginRequest.java
@@ -1,9 +1,12 @@
 package com.projectlyrics.server.domain.auth.dto.request;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.projectlyrics.server.domain.auth.entity.enumerate.AuthProvider;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record UserLoginRequest(
     @NotNull(message = "로그인 종류가 입력되지 않았습니다.")
     @Schema(description = "로그인 타입")

--- a/src/main/java/com/projectlyrics/server/domain/auth/dto/response/UserInfoResponse.java
+++ b/src/main/java/com/projectlyrics/server/domain/auth/dto/response/UserInfoResponse.java
@@ -5,7 +5,7 @@ import com.projectlyrics.server.domain.user.entity.User;
 
 public record UserInfoResponse(
     AuthProvider authProvider,
-    Long socialId,
+    String socialId,
     String email
 ) {
   public User toEntity() {

--- a/src/main/java/com/projectlyrics/server/domain/auth/entity/Auth.java
+++ b/src/main/java/com/projectlyrics/server/domain/auth/entity/Auth.java
@@ -32,9 +32,9 @@ public class Auth {
   private AuthProvider authProvider;
 
   @Column(nullable = false)
-  private Long socialId;
+  private String socialId;
 
-  public Auth(Long socialId, AuthProvider authProvider) {
+  public Auth(String socialId, AuthProvider authProvider) {
     this.socialId = socialId;
     this.authProvider = authProvider;
   }

--- a/src/main/java/com/projectlyrics/server/domain/auth/service/apple/ApplePublicKeysApiClient.java
+++ b/src/main/java/com/projectlyrics/server/domain/auth/service/apple/ApplePublicKeysApiClient.java
@@ -1,0 +1,11 @@
+package com.projectlyrics.server.domain.auth.service.apple;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@FeignClient(name = "applePublicKeysApiClient", url="https://appleid.apple.com")
+public interface ApplePublicKeysApiClient {
+
+  @GetMapping(value = "/auth/keys")
+  String getPublicKeys();
+}

--- a/src/main/java/com/projectlyrics/server/domain/auth/service/apple/AppleSocialService.java
+++ b/src/main/java/com/projectlyrics/server/domain/auth/service/apple/AppleSocialService.java
@@ -1,0 +1,123 @@
+package com.projectlyrics.server.domain.auth.service.apple;
+
+import com.google.gson.*;
+import com.projectlyrics.server.domain.auth.dto.response.UserInfoResponse;
+import com.projectlyrics.server.domain.auth.service.SocialService;
+import com.projectlyrics.server.domain.auth.service.apple.dto.AppleUserInfoResponse;
+import com.projectlyrics.server.global.exception.JwtValidationException;
+import com.projectlyrics.server.global.message.ErrorCode;
+import io.jsonwebtoken.Jwts;
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AppleSocialService implements SocialService {
+
+  private static final String JSON_KEY_KEYS = "keys";
+  private static final String TOKEN_DELIMITER = "\\.";
+  private static final String TOKEN_PREFIX = "Bearer ";
+  private static final String KEY_HEADER_KID = "kid";
+  private static final String KEY_HEADER_ALG = "alg";
+
+  private final ApplePublicKeysApiClient appleApiClient;
+
+  @Override
+  public UserInfoResponse getSocialData(String socialAccessToken) {
+    AppleUserInfoResponse appleUserInfo = getUserInfo(socialAccessToken);
+
+    return appleUserInfo.toUserInfo();
+  }
+
+  private AppleUserInfoResponse getUserInfo(String accessToken) {
+    // https://appleid.apple.com/auth/keys로 HTTP GET 요청을 보내 Apple이 제공하는 Public Key 리스트를 받음
+    val publicKeyList = getApplePublicKeys();
+
+    // Public Key 리스트 중 클라이언트 측에서 보낸 것과 일치하는 키를 찾음
+    // 찾은 키를 Json에서 Key 객체로 변환
+    val publicKey = makePublicKey(accessToken, publicKeyList);
+
+    // Key 객체를 복호화에 집어넣어
+    val userInfo = Jwts.parserBuilder()
+        .setSigningKey(publicKey)
+        .build()
+        .parseClaimsJws(getTokenFromBearerString(accessToken))
+        .getBody();
+
+    JsonObject userInfoObject = (JsonObject) JsonParser.parseString(new Gson().toJson(userInfo));
+
+    return new AppleUserInfoResponse(userInfoObject.get("sub").getAsString());
+  }
+
+  private JsonArray getApplePublicKeys() {
+    String result = appleApiClient.getPublicKeys();
+    val keys = (JsonObject) JsonParser.parseString(result);
+    return (JsonArray) keys.get(JSON_KEY_KEYS);
+  }
+
+  // Public key 리스트 각각과 액세스 토큰을 대조해서 kid와 alg 필드가 서로 맞으면
+  // 해당 키를 기준으로 Json에서 Key 객체로 변환해 반환하는 작업을 거친다.
+  private PublicKey makePublicKey(String accessToken, JsonArray publicKeyList) {
+    val decodeArray = accessToken.split(TOKEN_DELIMITER);
+    val header = new String(Base64.getDecoder().decode(getTokenFromBearerString(decodeArray[0])));
+
+    val kid = ((JsonObject) JsonParser.parseString(header)).get(KEY_HEADER_KID);
+    val alg = ((JsonObject) JsonParser.parseString(header)).get(KEY_HEADER_ALG);
+    val matchingPublicKey = findMatchingPublicKey(publicKeyList, kid, alg);
+
+    if (Objects.isNull(matchingPublicKey)) {
+      throw new JwtValidationException(ErrorCode.INVALID_KEY);
+    }
+
+    return getPublicKey(matchingPublicKey);
+  }
+
+  private String getTokenFromBearerString(String token) {
+    return token.substring(TOKEN_PREFIX.length());
+  }
+
+  private JsonObject findMatchingPublicKey(JsonArray publicKeyList, JsonElement kid, JsonElement alg) {
+    for (JsonElement publicKey : publicKeyList) {
+      val publicKeyObject = publicKey.getAsJsonObject();
+      val publicKid = publicKeyObject.get(KEY_HEADER_KID);
+      val publicAlg = publicKeyObject.get(KEY_HEADER_ALG);
+
+      if (Objects.equals(kid, publicKid) && Objects.equals(alg, publicAlg)) {
+        return publicKeyObject;
+      }
+    }
+
+    return null;
+  }
+
+  private PublicKey getPublicKey(JsonObject object) {
+    try {
+      val modulus = object.get("n").toString();
+      val exponent = object.get("e").toString();
+
+      val quotes = 1;
+      val modulusBytes = Base64.getUrlDecoder().decode(modulus.substring(quotes, modulus.length() - quotes));
+      val exponentBytes = Base64.getUrlDecoder().decode(exponent.substring(quotes, exponent.length() - quotes));
+
+      val positiveNumber = 1;
+      val modulusValue = new BigInteger(positiveNumber, modulusBytes);
+      val exponentValue = new BigInteger(positiveNumber, exponentBytes);
+
+      val publicKeySpec = new RSAPublicKeySpec(modulusValue, exponentValue);
+      val keyFactory = KeyFactory.getInstance("RSA");
+
+      return keyFactory.generatePublic(publicKeySpec);
+    } catch (InvalidKeySpecException | NoSuchAlgorithmException exception) {
+      throw new JwtValidationException(ErrorCode.INVALID_KEY);
+    }
+  }
+}

--- a/src/main/java/com/projectlyrics/server/domain/auth/service/apple/dto/AppleUserInfoResponse.java
+++ b/src/main/java/com/projectlyrics/server/domain/auth/service/apple/dto/AppleUserInfoResponse.java
@@ -1,0 +1,16 @@
+package com.projectlyrics.server.domain.auth.service.apple.dto;
+
+import com.projectlyrics.server.domain.auth.dto.response.UserInfoResponse;
+import com.projectlyrics.server.domain.auth.entity.enumerate.AuthProvider;
+
+public record AppleUserInfoResponse(
+    String id
+) {
+  public UserInfoResponse toUserInfo() {
+    return new UserInfoResponse(
+        AuthProvider.APPLE,
+        id,
+        ""
+    );
+  }
+}

--- a/src/main/java/com/projectlyrics/server/domain/auth/service/kakao/KakaoSocialService.java
+++ b/src/main/java/com/projectlyrics/server/domain/auth/service/kakao/KakaoSocialService.java
@@ -10,8 +10,6 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class KakaoSocialService implements SocialService {
 
-  private static final String TOKEN_TYPE = "Bearer ";
-
   private final KakaoSocialDataApiClient kakaoApiClient;
 
   @Override
@@ -22,6 +20,6 @@ public class KakaoSocialService implements SocialService {
   }
 
   private KakaoUserInfoResponse getUserInfo(String accessToken) {
-    return kakaoApiClient.getUserInfo(TOKEN_TYPE + accessToken);
+    return kakaoApiClient.getUserInfo(accessToken);
   }
 }

--- a/src/main/java/com/projectlyrics/server/domain/auth/service/kakao/dto/KakaoUserInfoResponse.java
+++ b/src/main/java/com/projectlyrics/server/domain/auth/service/kakao/dto/KakaoUserInfoResponse.java
@@ -7,7 +7,7 @@ import com.projectlyrics.server.domain.auth.entity.enumerate.AuthProvider;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record KakaoUserInfoResponse(
-        Long id,
+        String id,
         KakaoAccount kakaoAccount
 ) {
   public UserInfoResponse toUserInfo() {

--- a/src/main/java/com/projectlyrics/server/domain/user/entity/User.java
+++ b/src/main/java/com/projectlyrics/server/domain/user/entity/User.java
@@ -51,7 +51,7 @@ public class User {
   }
 
   public static User of(
-      final Long socialId,
+      final String socialId,
       final String email,
       final AuthProvider authProvider
   ) {

--- a/src/main/java/com/projectlyrics/server/domain/user/repository/QueryUserRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/user/repository/QueryUserRepository.java
@@ -6,5 +6,5 @@ import java.util.Optional;
 
 public interface QueryUserRepository {
 
-  Optional<User> findBySocialIdAndAuthProviderAndNotDeleted(long socialId, AuthProvider authProvider);
+  Optional<User> findBySocialIdAndAuthProviderAndNotDeleted(String socialId, AuthProvider authProvider);
 }

--- a/src/main/java/com/projectlyrics/server/domain/user/repository/impl/QueryDslQueryUserRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/user/repository/impl/QueryDslQueryUserRepository.java
@@ -16,7 +16,7 @@ public class QueryDslQueryUserRepository implements QueryUserRepository {
   private final JPAQueryFactory jpaQueryFactory;
 
   @Override
-  public Optional<User> findBySocialIdAndAuthProviderAndNotDeleted(long socialId, AuthProvider authProvider) {
+  public Optional<User> findBySocialIdAndAuthProviderAndNotDeleted(String socialId, AuthProvider authProvider) {
     return Optional.ofNullable(
         jpaQueryFactory
             .selectFrom(QUser.user)

--- a/src/main/java/com/projectlyrics/server/global/configuration/FeignClientConfig.java
+++ b/src/main/java/com/projectlyrics/server/global/configuration/FeignClientConfig.java
@@ -1,13 +1,11 @@
 package com.projectlyrics.server.global.configuration;
 
 import com.projectlyrics.server.domain.auth.service.kakao.KakaoSocialDataApiClient;
-import com.projectlyrics.server.domain.test.auth.kakao.KakaoAuthApiClient;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @EnableFeignClients(basePackageClasses = {
-    KakaoAuthApiClient.class,
     KakaoSocialDataApiClient.class
 })
 public class FeignClientConfig {

--- a/src/main/java/com/projectlyrics/server/global/configuration/FeignClientConfig.java
+++ b/src/main/java/com/projectlyrics/server/global/configuration/FeignClientConfig.java
@@ -1,12 +1,14 @@
 package com.projectlyrics.server.global.configuration;
 
+import com.projectlyrics.server.domain.auth.service.apple.ApplePublicKeysApiClient;
 import com.projectlyrics.server.domain.auth.service.kakao.KakaoSocialDataApiClient;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @EnableFeignClients(basePackageClasses = {
-    KakaoSocialDataApiClient.class
+    KakaoSocialDataApiClient.class,
+    ApplePublicKeysApiClient.class
 })
 public class FeignClientConfig {
 

--- a/src/main/java/com/projectlyrics/server/global/configuration/SecurityConfig.java
+++ b/src/main/java/com/projectlyrics/server/global/configuration/SecurityConfig.java
@@ -5,6 +5,7 @@ import static org.springframework.security.config.http.SessionCreationPolicy.STA
 import com.projectlyrics.server.domain.auth.authentication.JwtAuthenticationEntryPoint;
 import com.projectlyrics.server.domain.auth.authentication.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -21,6 +22,9 @@ import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 @EnableWebSecurity
 @Configuration
 public class SecurityConfig {
+
+  @Value("#{'${auth.free-apis}'.split(',')}")
+  String[] authFreeApis;
 
   private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
   private final JwtAuthenticationFilter jwtAuthenticationFilter;
@@ -70,9 +74,7 @@ public class SecurityConfig {
             exception.authenticationEntryPoint(jwtAuthenticationEntryPoint))
         .authorizeHttpRequests(requests ->
             requests
-                .requestMatchers(new AntPathRequestMatcher("/api/v1/auth/**")).permitAll()
-                .requestMatchers(new AntPathRequestMatcher("/api/v1/artists/**")).permitAll()
-                .requestMatchers(new AntPathRequestMatcher("/api/v1/test/**")).permitAll()
+                .requestMatchers(authFreeApis).permitAll()
                 .anyRequest().authenticated()
         )
         .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/projectlyrics/server/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/projectlyrics/server/global/handler/GlobalExceptionHandler.java
@@ -1,0 +1,19 @@
+package com.projectlyrics.server.global.handler;
+
+import com.projectlyrics.server.domain.common.dto.ErrorResponse;
+import com.projectlyrics.server.global.exception.JwtValidationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+  @ExceptionHandler(JwtValidationException.class)
+  public ResponseEntity<ErrorResponse> handleJwtValidationException(JwtValidationException e) {
+    return ResponseEntity
+        .status(HttpStatus.BAD_REQUEST)
+        .body(ErrorResponse.of(e.getErrorCode()));
+  }
+}

--- a/src/main/java/com/projectlyrics/server/global/message/ErrorCode.java
+++ b/src/main/java/com/projectlyrics/server/global/message/ErrorCode.java
@@ -20,6 +20,7 @@ public enum ErrorCode {
   REFRESH_TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "00601", "The refresh token could not be found."),
   WRONG_TOKEN_TYPE(HttpStatus.BAD_REQUEST, "00601", "Wrong token type is passed."),
   INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "00401", "The token is not valid."),
+  INVALID_KEY(HttpStatus.UNAUTHORIZED, "00401", "The key is not valid."),
 
   // User
   USER_NOT_FOUND(HttpStatus.NOT_FOUND, "00600", "The user data could not be found."),


### PR DESCRIPTION
## 🔥 Task
- 토큰 점검 필터링의 제외 대상 API 명시
- 애플의 정책에 맞게, 외부 서비스에서 제공하는 사용자 식별자의 타입을 문자열로 변경
- 애플 로그인 기능 추가
- 예외 핸들러 (`@RestControllerAdvice`) 추가


## 📝 Question
- 현재 애플에서 제공하는 키로 인코딩된 토큰을 클라이언트 측에서 받아 사용자 로그인을 진행하고 있는데, 이처럼 테스트하기 어려운 환경에서는 어떻게 테스트를 진행하는 것이 좋을지...? 궁금합니다!