### PR TITLE
이름, 영어 이름 기반의 아티스트 검색 API 추가

### DIFF
--- a/src/main/java/com/projectlyrics/server/domain/artist/api/ArtistController.java
+++ b/src/main/java/com/projectlyrics/server/domain/artist/api/ArtistController.java
@@ -42,7 +42,8 @@ public class ArtistController implements ArtistControllerSwagger {
 
   @PatchMapping("/{artistId}")
   public ResponseEntity<ArtistUpdateResponse> updateArtist(
-      @PathVariable Long artistId, @RequestBody ArtistUpdateRequest request
+      @PathVariable Long artistId,
+      @RequestBody ArtistUpdateRequest request
   ) {
     return ResponseEntity
         .status(HttpStatus.OK)
@@ -50,7 +51,9 @@ public class ArtistController implements ArtistControllerSwagger {
   }
 
   @DeleteMapping("/{artistId}")
-  public ResponseEntity<Void> deleteArtist(@PathVariable Long artistId) {
+  public ResponseEntity<Void> deleteArtist(
+      @PathVariable Long artistId
+  ) {
     artistCommandService.deleteArtist(artistId);
 
     return ResponseEntity
@@ -59,7 +62,9 @@ public class ArtistController implements ArtistControllerSwagger {
   }
 
   @GetMapping("/{artistId}")
-  public ResponseEntity<ArtistGetResponse> getArtist(@PathVariable Long artistId) {
+  public ResponseEntity<ArtistGetResponse> getArtist(
+      @PathVariable Long artistId
+  ) {
     return ResponseEntity
         .status(HttpStatus.OK)
         .body(artistQueryService.getArtist(artistId));
@@ -67,11 +72,22 @@ public class ArtistController implements ArtistControllerSwagger {
 
   @GetMapping
   public ResponseEntity<CursorBasePaginatedResponse<ArtistGetResponse>> getArtistList(
-      @RequestParam(required = false) Long cursor,
+      @RequestParam(defaultValue = "0L") Long cursor,
       @RequestParam(defaultValue = "10") int size
   ) {
     return ResponseEntity
         .status(HttpStatus.OK)
         .body(artistQueryService.getArtistList(cursor, PageRequest.of(0, size)));
+  }
+
+  @GetMapping("/search")
+  public ResponseEntity<CursorBasePaginatedResponse<ArtistGetResponse>> searchArtist(
+      @RequestParam(defaultValue = "0") Long cursor,
+      @RequestParam(required = false, defaultValue = "5") int size,
+      @RequestParam String query
+  ) {
+    return ResponseEntity
+        .status(HttpStatus.OK)
+        .body(artistQueryService.searchArtists(query, cursor, PageRequest.of(0, size)));
   }
 }

--- a/src/main/java/com/projectlyrics/server/domain/artist/repository/QueryArtistRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/artist/repository/QueryArtistRepository.java
@@ -9,5 +9,7 @@ public interface QueryArtistRepository {
 
   Optional<Artist> findByIdAndNotDeleted(Long artistId);
 
+  Slice<Artist> findAllByQueryAndNotDeleted(String query, Long cursor, Pageable pageable);
+
   Slice<Artist> findAllAndNotDeleted(Long cursor, Pageable pageable);
 }

--- a/src/main/java/com/projectlyrics/server/domain/artist/service/ArtistQueryService.java
+++ b/src/main/java/com/projectlyrics/server/domain/artist/service/ArtistQueryService.java
@@ -4,6 +4,7 @@ import com.projectlyrics.server.domain.artist.dto.response.ArtistGetResponse;
 import com.projectlyrics.server.domain.artist.repository.QueryArtistRepository;
 import com.projectlyrics.server.domain.common.dto.util.CursorBasePaginatedResponse;
 import com.projectlyrics.server.domain.common.message.ErrorCode;
+import com.projectlyrics.server.domain.common.util.PageUtils;
 import com.projectlyrics.server.global.exception.FeelinException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -27,8 +28,16 @@ public class ArtistQueryService {
   public CursorBasePaginatedResponse<ArtistGetResponse> getArtistList(Long cursor, Pageable pageable) {
     var artistList = queryArtistRepository.findAllAndNotDeleted(cursor, pageable)
         .map(ArtistGetResponse::from);
-    var nextCursor = artistList.getContent().getLast().id() + 1;
+    var nextCursor = PageUtils.getNextCursorOf(artistList);
 
     return CursorBasePaginatedResponse.of(artistList, nextCursor, cursor);
+  }
+
+  public CursorBasePaginatedResponse<ArtistGetResponse> searchArtists(String query, Long cursor, Pageable pageable) {
+    var searchedArtists = queryArtistRepository.findAllByQueryAndNotDeleted(query, cursor, pageable)
+        .map(ArtistGetResponse::from);
+    var nextCursor = PageUtils.getNextCursorOf(searchedArtists);
+
+    return CursorBasePaginatedResponse.of(searchedArtists, nextCursor, cursor);
   }
 }

--- a/src/main/java/com/projectlyrics/server/domain/common/dto/util/CursorBasePaginatedResponse.java
+++ b/src/main/java/com/projectlyrics/server/domain/common/dto/util/CursorBasePaginatedResponse.java
@@ -15,7 +15,7 @@ public record CursorBasePaginatedResponse<T>(
   public static <T> CursorBasePaginatedResponse<T> of(Slice<T> slice, Long nextCursor, Long cursor) {
     return new CursorBasePaginatedResponse<>(
         slice.hasNext() ? String.valueOf(nextCursor) : null,
-        cursor != null ? String.valueOf(cursor) : null,
+        cursor != null ? String.valueOf(cursor) : String.valueOf(0),
         slice.getNumberOfElements(),
         slice.getSize(),
         slice.getContent()

--- a/src/main/java/com/projectlyrics/server/domain/common/util/PageUtils.java
+++ b/src/main/java/com/projectlyrics/server/domain/common/util/PageUtils.java
@@ -1,0 +1,14 @@
+package com.projectlyrics.server.domain.common.util;
+
+import com.projectlyrics.server.domain.artist.dto.response.ArtistGetResponse;
+import org.springframework.data.domain.Slice;
+
+public class PageUtils {
+
+  public static Long getNextCursorOf(Slice<ArtistGetResponse> list) {
+    if (list.isEmpty())
+      return 0L;
+
+    return list.getContent().getLast().id() + 1;
+  }
+}

--- a/src/test/java/com/projectlyrics/server/domain/artist/repository/ArtistQueryRepositoryTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/artist/repository/ArtistQueryRepositoryTest.java
@@ -1,0 +1,39 @@
+package com.projectlyrics.server.domain.artist.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.projectlyrics.server.domain.artist.entity.Artist;
+import com.projectlyrics.server.utils.ArtistTestUtil;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@SpringBootTest
+public class ArtistQueryRepositoryTest {
+
+  @Autowired
+  private QueryArtistRepository queryArtistRepository;
+
+  @Autowired
+  private CommandArtistRepository commandArtistRepository;
+
+  @Test
+  void 아티스트의_데이터를_사용자_입력_쿼리_기반으로_조회해_반환한다() {
+    // given
+    var artist1 = ArtistTestUtil.createWithName("검정치마");
+    var artist2 = ArtistTestUtil.createWithName("구남과여라이딩스텔라");
+    commandArtistRepository.save(artist1);
+    commandArtistRepository.save(artist2);
+
+    // when
+    var searchedArtists = queryArtistRepository.findAllByQueryAndNotDeleted("검정치마", 0L,
+        PageRequest.of(0, 3));
+
+    // then
+    assertThat(searchedArtists.getContent().getFirst()).isEqualTo(artist1);
+  }
+}


### PR DESCRIPTION
## 🔥 Task
- 이름, 영어 이름 기반으로 아티스트 조회하는 QueryDsl 메서드 추가
- 스프링 환경에서 검색 메서드 검증하는 테스트 추가
- 검색 결과가  없을 경우 발생하는 예외를 처리하기 위해 PageUtils 클래스에 메서드 

&nbsp;

&nbsp;

&nbsp;

<img width="402" alt="image" src="https://github.com/project-lyrics/api-server/assets/137763434/6805ac2b-8d90-4343-b5eb-52ebb38d2789">