### PR TITLE
신고 기능 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,9 @@ dependencies {
 
     // slack
     implementation 'com.slack.api:slack-api-client:1.12.0'
+
+    // json
+    implementation 'org.json:json:20210307'
 }
 
 swaggerSources {

--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,9 @@ dependencies {
 
     // firebase cloud messaging
     implementation 'com.google.firebase:firebase-admin:9.2.0'
+
+    // slack
+    implementation 'com.slack.api:slack-api-client:1.12.0'
 }
 
 swaggerSources {

--- a/src/main/java/com/projectlyrics/server/domain/auth/authentication/SlackInterceptor.java
+++ b/src/main/java/com/projectlyrics/server/domain/auth/authentication/SlackInterceptor.java
@@ -1,0 +1,58 @@
+package com.projectlyrics.server.domain.auth.authentication;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import org.springframework.web.util.ContentCachingRequestWrapper;
+
+@Component
+@RequiredArgsConstructor
+public class SlackInterceptor implements HandlerInterceptor {
+
+    @Value("${slack.signing.secret}")
+    private String SLACK_SIGNING_SECRET;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        // ContentCachingRequestWrapper로 래핑
+        ContentCachingRequestWrapper requestWrapper = (ContentCachingRequestWrapper) request;
+
+        String method = request.getMethod();
+        String signature = request.getHeader("X-Slack-Signature");
+        String timestamp = request.getHeader("X-Slack-Request-Timestamp");
+        String payload = new String(requestWrapper.getContentAsByteArray(), StandardCharsets.UTF_8);
+
+        if (!method.equalsIgnoreCase("POST") || !isValidSlackRequest(payload, signature, timestamp)) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST); // 잘못된 요청
+            return false;
+        }
+
+        return true;
+    }
+
+    private boolean isValidSlackRequest(String payload, String signature, String timestamp) {
+        try {
+            String baseString = "v0:" + timestamp + ":" + payload;
+            Mac mac = Mac.getInstance("HmacSHA256");
+            SecretKeySpec secret = new SecretKeySpec(SLACK_SIGNING_SECRET.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+            mac.init(secret);
+            byte[] rawHmac = mac.doFinal(baseString.getBytes(StandardCharsets.UTF_8));
+            String calculatedSignature = "v0=" + Base64.getEncoder().encodeToString(rawHmac);
+
+            return calculatedSignature.equals(signature);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
+}
+
+

--- a/src/main/java/com/projectlyrics/server/domain/auth/authentication/interceptor/AdminInterceptor.java
+++ b/src/main/java/com/projectlyrics/server/domain/auth/authentication/interceptor/AdminInterceptor.java
@@ -1,4 +1,4 @@
-package com.projectlyrics.server.domain.user.authentication;
+package com.projectlyrics.server.domain.auth.authentication.interceptor;
 
 import com.projectlyrics.server.domain.auth.authentication.AuthContext;
 import com.projectlyrics.server.domain.auth.authentication.TokenExtractor;

--- a/src/main/java/com/projectlyrics/server/domain/auth/authentication/interceptor/AuthInterceptor.java
+++ b/src/main/java/com/projectlyrics/server/domain/auth/authentication/interceptor/AuthInterceptor.java
@@ -1,5 +1,7 @@
-package com.projectlyrics.server.domain.auth.authentication;
+package com.projectlyrics.server.domain.auth.authentication.interceptor;
 
+import com.projectlyrics.server.domain.auth.authentication.AuthContext;
+import com.projectlyrics.server.domain.auth.authentication.TokenExtractor;
 import com.projectlyrics.server.domain.auth.authentication.jwt.JwtClaim;
 import com.projectlyrics.server.domain.auth.authentication.jwt.JwtExtractor;
 import jakarta.servlet.http.HttpServletRequest;

--- a/src/main/java/com/projectlyrics/server/domain/auth/authentication/interceptor/SlackInterceptor.java
+++ b/src/main/java/com/projectlyrics/server/domain/auth/authentication/interceptor/SlackInterceptor.java
@@ -1,4 +1,4 @@
-package com.projectlyrics.server.domain.auth.authentication;
+package com.projectlyrics.server.domain.auth.authentication.interceptor;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;

--- a/src/main/java/com/projectlyrics/server/domain/comment/exception/CommentNotFoundException.java
+++ b/src/main/java/com/projectlyrics/server/domain/comment/exception/CommentNotFoundException.java
@@ -1,0 +1,11 @@
+package com.projectlyrics.server.domain.comment.exception;
+
+import com.projectlyrics.server.domain.common.message.ErrorCode;
+import com.projectlyrics.server.global.exception.FeelinException;
+
+public class CommentNotFoundException extends FeelinException {
+
+    public CommentNotFoundException() {
+        super(ErrorCode.COMMENT_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/projectlyrics/server/domain/common/message/ErrorCode.java
+++ b/src/main/java/com/projectlyrics/server/domain/common/message/ErrorCode.java
@@ -81,6 +81,10 @@ public enum ErrorCode {
     REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "12000", "해당 신고를 조회할 수 없습니다."),
     REPORT_TARGET_CONFLICT(HttpStatus.BAD_REQUEST, "12001", "신고 대상은 Note와 Comment 중 하나여야 합니다."),
     REPORT_TARGET_MISSING(HttpStatus.BAD_REQUEST, "12002", "신고 대상(Note 또는 Comment)가 필요합니다."),
+
+    // Slack
+    SLACK_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "13000", "슬랙 메세지 전송에 실패했습니다."),
+    SLACK_PROCESSING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "13001", "슬랙 메세지 전송 중 에러가 발생했습니다."),
     ;
 
     private final HttpStatus responseStatus;

--- a/src/main/java/com/projectlyrics/server/domain/common/message/ErrorCode.java
+++ b/src/main/java/com/projectlyrics/server/domain/common/message/ErrorCode.java
@@ -80,7 +80,7 @@ public enum ErrorCode {
     // Report
     REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "12000", "해당 신고를 조회할 수 없습니다."),
     REPORT_TARGET_CONFLICT(HttpStatus.BAD_REQUEST, "12001", "신고 대상은 Note와 Comment 중 하나여야 합니다."),
-    REPORT_TARGET_MISSING(HttpStatus.BAD_REQUEST, "12001", "신고 대상(Note 또는 Comment)가 필요합니다."),
+    REPORT_TARGET_MISSING(HttpStatus.BAD_REQUEST, "12002", "신고 대상(Note 또는 Comment)가 필요합니다."),
     ;
 
     private final HttpStatus responseStatus;

--- a/src/main/java/com/projectlyrics/server/domain/common/message/ErrorCode.java
+++ b/src/main/java/com/projectlyrics/server/domain/common/message/ErrorCode.java
@@ -85,6 +85,8 @@ public enum ErrorCode {
     // Slack
     SLACK_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "13000", "슬랙 메세지 전송에 실패했습니다."),
     SLACK_PROCESSING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "13001", "슬랙 메세지 전송 중 에러가 발생했습니다."),
+    SLACK_INTERACTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "13002", "슬랙 상호작용 인터렉션에 문제가 발생했습니다"),
+    SLACK_FEEDBACK_FAILED(HttpStatus.INTERNAL_SERVER_ERROR,"13003", "슬랙에 피드백 메세지 제공에 실패했습니다."),
     ;
 
     private final HttpStatus responseStatus;

--- a/src/main/java/com/projectlyrics/server/domain/common/message/ErrorCode.java
+++ b/src/main/java/com/projectlyrics/server/domain/common/message/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
     EMPTY_FIELD(HttpStatus.BAD_REQUEST, "00005", "Some field is empty."),
     INVALID_URL_PREFIX(HttpStatus.BAD_REQUEST, "00006", "URL should start with http:// or https://."),
     RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "00007", "Resource not found."),
+    INVALID_EMAIL(HttpStatus.BAD_REQUEST, "00008", "이메일 형식이 유효하지 않습니다."),
 
     // Auth
     TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, "01001", "토큰이 만료되었습니다."),
@@ -75,6 +76,11 @@ public enum ErrorCode {
     // Notification
     UNKNOWN_NOTIFICATION_TYPE(HttpStatus.BAD_REQUEST, "11000", "알 수 없는 알림 타입입니다."),
     NOTIFICATION_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "11001", "알림 전송에 실패했습니다."),
+
+    // Report
+    REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "12000", "해당 신고를 조회할 수 없습니다."),
+    REPORT_TARGET_CONFLICT(HttpStatus.BAD_REQUEST, "12001", "신고 대상은 Note와 Comment 중 하나여야 합니다."),
+    REPORT_TARGET_MISSING(HttpStatus.BAD_REQUEST, "12001", "신고 대상(Note 또는 Comment)가 필요합니다."),
     ;
 
     private final HttpStatus responseStatus;

--- a/src/main/java/com/projectlyrics/server/domain/report/api/ReportController.java
+++ b/src/main/java/com/projectlyrics/server/domain/report/api/ReportController.java
@@ -36,17 +36,4 @@ public class ReportController {
                 .status(HttpStatus.OK)
                 .body(new ReportCreateResponse(true));
     }
-
-    @PatchMapping("/{reportId}")
-    public ResponseEntity<ReportResolveResponse> resolve(
-            @Authenticated AuthContext authContext,
-            @PathVariable(name = "reportId") Long reportId,
-            @RequestBody @Valid ReportResolveRequest request
-    ) {
-        reportCommandService.resolve(request, reportId);
-
-        return ResponseEntity
-                .status(HttpStatus.OK)
-                .body(new ReportResolveResponse(true));
-    }
 }

--- a/src/main/java/com/projectlyrics/server/domain/report/api/ReportController.java
+++ b/src/main/java/com/projectlyrics/server/domain/report/api/ReportController.java
@@ -1,0 +1,52 @@
+package com.projectlyrics.server.domain.report.api;
+
+import com.projectlyrics.server.domain.auth.authentication.AuthContext;
+import com.projectlyrics.server.domain.auth.authentication.Authenticated;
+import com.projectlyrics.server.domain.report.dto.request.ReportCreateRequest;
+import com.projectlyrics.server.domain.report.dto.request.ReportResolveRequest;
+import com.projectlyrics.server.domain.report.dto.response.ReportCreateResponse;
+import com.projectlyrics.server.domain.report.dto.response.ReportResolveResponse;
+import com.projectlyrics.server.domain.report.service.ReportCommandService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/reports")
+@RequiredArgsConstructor
+public class ReportController {
+
+    private final ReportCommandService reportCommandService;
+
+    @PostMapping
+    public ResponseEntity<ReportCreateResponse> create(
+            @Authenticated AuthContext authContext,
+            @RequestBody @Valid ReportCreateRequest request
+    ) {
+        reportCommandService.create(request, authContext.getId());
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(new ReportCreateResponse(true));
+    }
+
+    @PatchMapping("/{reportId}")
+    public ResponseEntity<ReportResolveResponse> resolve(
+            @Authenticated AuthContext authContext,
+            @PathVariable(name = "reportId") Long reportId,
+            @RequestBody @Valid ReportResolveRequest request
+    ) {
+        reportCommandService.resolve(request, reportId);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(new ReportResolveResponse(true));
+    }
+}

--- a/src/main/java/com/projectlyrics/server/domain/report/domain/ApprovalStatus.java
+++ b/src/main/java/com/projectlyrics/server/domain/report/domain/ApprovalStatus.java
@@ -3,5 +3,5 @@ package com.projectlyrics.server.domain.report.domain;
 public enum ApprovalStatus {
     PENDING,
     ACCEPTED,
-    DISMISS
+    DISMISSED
 }

--- a/src/main/java/com/projectlyrics/server/domain/report/domain/ApprovalStatus.java
+++ b/src/main/java/com/projectlyrics/server/domain/report/domain/ApprovalStatus.java
@@ -1,0 +1,7 @@
+package com.projectlyrics.server.domain.report.domain;
+
+public enum ApprovalStatus {
+    PENDING,
+    ACCEPTED,
+    DISMISS
+}

--- a/src/main/java/com/projectlyrics/server/domain/report/domain/Report.java
+++ b/src/main/java/com/projectlyrics/server/domain/report/domain/Report.java
@@ -1,0 +1,116 @@
+package com.projectlyrics.server.domain.report.domain;
+
+import com.projectlyrics.server.domain.comment.domain.Comment;
+import com.projectlyrics.server.domain.comment.domain.CommentCreate;
+import com.projectlyrics.server.domain.common.entity.BaseEntity;
+import com.projectlyrics.server.domain.note.entity.Note;
+import com.projectlyrics.server.domain.report.exception.ReportTargetConfilctedException;
+import com.projectlyrics.server.domain.report.exception.ReportTargetMissingException;
+import com.projectlyrics.server.domain.user.entity.User;
+import jakarta.annotation.Nullable;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.aspectj.weaver.ast.Not;
+
+@Getter
+@Entity
+@Table(name = "reports")
+@EqualsAndHashCode(of = "id", callSuper = false)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Report extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User reporter;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @Nullable
+    private Note note;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @Nullable
+    private Comment comment;
+
+    @Enumerated(value = EnumType.STRING)
+    private ReportReason reportReason;
+
+    @Nullable
+    private String email;
+
+    @Enumerated(value = EnumType.STRING)
+    private ApprovalStatus approvalStatus;
+
+    private Boolean isFalseReport;
+
+    private Report(Long id, User reporter, @Nullable Note note, @Nullable Comment comment, ReportReason reportReason,
+                  @Nullable String email) {
+        checkNoteOrComment(note,comment);
+        this.id = id;
+        this.reporter = reporter;
+        this.note = note;
+        this.comment = comment;
+        this.reportReason = reportReason;
+        this.email = email;
+        this.approvalStatus = ApprovalStatus.PENDING;
+        this.isFalseReport = false;
+    }
+
+    private Report(User reporter, @Nullable Note note, @Nullable Comment comment, ReportReason reportReason,
+                   @Nullable String email) {
+        this(null, reporter, note,comment,reportReason, email);
+    }
+
+    public static Report create(ReportCreate reportCreate) {
+        return new Report(
+                reportCreate.reporter(),
+                reportCreate.note(),
+                reportCreate.comment(),
+                reportCreate.reportReason(),
+                reportCreate.email()
+        );
+    }
+
+    public static Report createWithId(Long id, ReportCreate reportCreate) {
+        return new Report(
+                id,
+                reportCreate.reporter(),
+                reportCreate.note(),
+                reportCreate.comment(),
+                reportCreate.reportReason(),
+                reportCreate.email()
+        );
+    }
+
+    private void checkNoteOrComment(Note note, Comment comment) {
+        if (note == null && comment == null) {
+            throw new ReportTargetMissingException();
+        }
+        if (note != null && comment != null) {
+            throw new ReportTargetConfilctedException();
+        }
+    }
+
+    public void setReportReason(ReportReason reportReason) {
+        this.reportReason = reportReason;
+        this.approvalStatus = ApprovalStatus.PENDING;
+        this.isFalseReport = false;
+    }
+
+    public void resolve(ApprovalStatus approvalStatus, Boolean isFalseReport) {
+        this.approvalStatus = approvalStatus;
+        this.isFalseReport = isFalseReport;
+    }
+}

--- a/src/main/java/com/projectlyrics/server/domain/report/domain/Report.java
+++ b/src/main/java/com/projectlyrics/server/domain/report/domain/Report.java
@@ -38,17 +38,14 @@ public class Report extends BaseEntity {
     private User reporter;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @Nullable
     private Note note;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @Nullable
     private Comment comment;
 
     @Enumerated(value = EnumType.STRING)
     private ReportReason reportReason;
 
-    @Nullable
     private String email;
 
     @Enumerated(value = EnumType.STRING)
@@ -56,8 +53,7 @@ public class Report extends BaseEntity {
 
     private Boolean isFalseReport;
 
-    private Report(Long id, User reporter, @Nullable Note note, @Nullable Comment comment, ReportReason reportReason,
-                  @Nullable String email) {
+    private Report(Long id, User reporter, Note note, Comment comment, ReportReason reportReason, String email) {
         checkNoteOrComment(note,comment);
         this.id = id;
         this.reporter = reporter;
@@ -69,13 +65,10 @@ public class Report extends BaseEntity {
         this.isFalseReport = false;
     }
 
-    private Report(User reporter, @Nullable Note note, @Nullable Comment comment, ReportReason reportReason,
-                   @Nullable String email) {
-        this(null, reporter, note,comment,reportReason, email);
-    }
 
     public static Report create(ReportCreate reportCreate) {
         return new Report(
+                null,
                 reportCreate.reporter(),
                 reportCreate.note(),
                 reportCreate.comment(),

--- a/src/main/java/com/projectlyrics/server/domain/report/domain/Report.java
+++ b/src/main/java/com/projectlyrics/server/domain/report/domain/Report.java
@@ -29,6 +29,7 @@ import org.aspectj.weaver.ast.Not;
 @EqualsAndHashCode(of = "id", callSuper = false)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Report extends BaseEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -109,8 +110,8 @@ public class Report extends BaseEntity {
         this.isFalseReport = false;
     }
 
-    public void resolve(ApprovalStatus approvalStatus, Boolean isFalseReport) {
-        this.approvalStatus = approvalStatus;
-        this.isFalseReport = isFalseReport;
+    public void resolve(ReportResolve reportResolve) {
+        this.approvalStatus = reportResolve.approvalStatus();
+        this.isFalseReport = reportResolve.isFalseReport();
     }
 }

--- a/src/main/java/com/projectlyrics/server/domain/report/domain/ReportCreate.java
+++ b/src/main/java/com/projectlyrics/server/domain/report/domain/ReportCreate.java
@@ -8,15 +8,12 @@ import jakarta.annotation.Nullable;
 public record ReportCreate (
         User reporter,
 
-        @Nullable
         Note note,
 
-        @Nullable
         Comment comment,
 
         ReportReason reportReason,
 
-        @Nullable
         String email
 ) {
     public static ReportCreate of(User reporter, Note note, Comment comment, ReportReason reportReason, String email) {

--- a/src/main/java/com/projectlyrics/server/domain/report/domain/ReportCreate.java
+++ b/src/main/java/com/projectlyrics/server/domain/report/domain/ReportCreate.java
@@ -1,0 +1,25 @@
+package com.projectlyrics.server.domain.report.domain;
+
+import com.projectlyrics.server.domain.comment.domain.Comment;
+import com.projectlyrics.server.domain.note.entity.Note;
+import com.projectlyrics.server.domain.user.entity.User;
+import jakarta.annotation.Nullable;
+
+public record ReportCreate (
+        User reporter,
+
+        @Nullable
+        Note note,
+
+        @Nullable
+        Comment comment,
+
+        ReportReason reportReason,
+
+        @Nullable
+        String email
+) {
+    public static ReportCreate of(User reporter, Note note, Comment comment, ReportReason reportReason, String email) {
+        return new ReportCreate(reporter, note, comment, reportReason, email);
+    }
+}

--- a/src/main/java/com/projectlyrics/server/domain/report/domain/ReportCreate.java
+++ b/src/main/java/com/projectlyrics/server/domain/report/domain/ReportCreate.java
@@ -7,13 +7,9 @@ import jakarta.annotation.Nullable;
 
 public record ReportCreate (
         User reporter,
-
         Note note,
-
         Comment comment,
-
         ReportReason reportReason,
-
         String email
 ) {
     public static ReportCreate of(User reporter, Note note, Comment comment, ReportReason reportReason, String email) {

--- a/src/main/java/com/projectlyrics/server/domain/report/domain/ReportReason.java
+++ b/src/main/java/com/projectlyrics/server/domain/report/domain/ReportReason.java
@@ -1,0 +1,11 @@
+package com.projectlyrics.server.domain.report.domain;
+
+public enum ReportReason {
+    INAPPROPRIATE_CONTENT,
+    DEFAMATION,
+    EXPLICIT_CONTENT,
+    COMMERCIAL_ADS,
+    INFO_DISCLOSURE,
+    POLITICAL_RELIGIOUS,
+    OTHER
+}

--- a/src/main/java/com/projectlyrics/server/domain/report/domain/ReportReason.java
+++ b/src/main/java/com/projectlyrics/server/domain/report/domain/ReportReason.java
@@ -1,11 +1,21 @@
 package com.projectlyrics.server.domain.report.domain;
 
 public enum ReportReason {
-    INAPPROPRIATE_CONTENT,
-    DEFAMATION,
-    EXPLICIT_CONTENT,
-    COMMERCIAL_ADS,
-    INFO_DISCLOSURE,
-    POLITICAL_RELIGIOUS,
-    OTHER
+    INAPPROPRIATE_CONTENT("커뮤니티 성격에 맞지 않음"),
+    DEFAMATION("타 유저 혹은 아티스트 비방"),
+    EXPLICIT_CONTENT("불쾌감을 조성하는 음란성/선정적인 내용"),
+    COMMERCIAL_ADS("상업적 광고"),
+    INFO_DISCLOSURE("부적절한 정보 유출"),
+    POLITICAL_RELIGIOUS("정치적인 내용/종교 포교 시도"),
+    OTHER("기타");
+
+    private final String description;
+
+    ReportReason(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
 }

--- a/src/main/java/com/projectlyrics/server/domain/report/domain/ReportResolve.java
+++ b/src/main/java/com/projectlyrics/server/domain/report/domain/ReportResolve.java
@@ -1,10 +1,12 @@
 package com.projectlyrics.server.domain.report.domain;
 
+import com.projectlyrics.server.domain.report.dto.request.ReportResolveRequest;
+
 public record ReportResolve (
         ApprovalStatus approvalStatus,
         Boolean isFalseReport
 ){
-    public static ReportResolve of(ApprovalStatus approvalStatus, Boolean isFalseReport) {
-        return new ReportResolve(approvalStatus, isFalseReport);
+    public static ReportResolve from(ReportResolveRequest request) {
+        return new ReportResolve(request.approvalStatus(), request.isFalseReport());
     }
 }

--- a/src/main/java/com/projectlyrics/server/domain/report/domain/ReportResolve.java
+++ b/src/main/java/com/projectlyrics/server/domain/report/domain/ReportResolve.java
@@ -1,0 +1,10 @@
+package com.projectlyrics.server.domain.report.domain;
+
+public record ReportResolve (
+        ApprovalStatus approvalStatus,
+        Boolean isFalseReport
+){
+    public static ReportResolve of(ApprovalStatus approvalStatus, Boolean isFalseReport) {
+        return new ReportResolve(approvalStatus, isFalseReport);
+    }
+}

--- a/src/main/java/com/projectlyrics/server/domain/report/dto/request/ReportCreateRequest.java
+++ b/src/main/java/com/projectlyrics/server/domain/report/dto/request/ReportCreateRequest.java
@@ -1,0 +1,26 @@
+package com.projectlyrics.server.domain.report.dto.request;
+
+import com.projectlyrics.server.domain.comment.domain.Comment;
+import com.projectlyrics.server.domain.note.entity.Note;
+import com.projectlyrics.server.domain.report.domain.ReportReason;
+import com.projectlyrics.server.domain.user.entity.User;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
+
+public record ReportCreateRequest (
+
+        @Nullable
+        Long noteId,
+
+        @Nullable
+        Long commentId,
+
+        @NotNull
+        ReportReason reportReason,
+
+        @Nullable
+        @Email
+        String email
+){
+}

--- a/src/main/java/com/projectlyrics/server/domain/report/dto/request/ReportCreateRequest.java
+++ b/src/main/java/com/projectlyrics/server/domain/report/dto/request/ReportCreateRequest.java
@@ -10,16 +10,13 @@ import jakarta.validation.constraints.NotNull;
 
 public record ReportCreateRequest (
 
-        @Nullable
         Long noteId,
 
-        @Nullable
         Long commentId,
 
         @NotNull
         ReportReason reportReason,
-
-        @Nullable
+        
         @Email
         String email
 ){

--- a/src/main/java/com/projectlyrics/server/domain/report/dto/request/ReportResolveRequest.java
+++ b/src/main/java/com/projectlyrics/server/domain/report/dto/request/ReportResolveRequest.java
@@ -1,5 +1,6 @@
 package com.projectlyrics.server.domain.report.dto.request;
 import com.projectlyrics.server.domain.report.domain.ApprovalStatus;
+import com.projectlyrics.server.domain.report.domain.ReportResolve;
 import jakarta.validation.constraints.NotNull;
 
 public record ReportResolveRequest(
@@ -8,4 +9,7 @@ public record ReportResolveRequest(
         @NotNull
         Boolean isFalseReport
 ){
+        public static ReportResolveRequest of(ApprovalStatus approvalStatus, Boolean isFalseReport) {
+                return new ReportResolveRequest(approvalStatus, isFalseReport);
+        }
 }

--- a/src/main/java/com/projectlyrics/server/domain/report/dto/request/ReportResolveRequest.java
+++ b/src/main/java/com/projectlyrics/server/domain/report/dto/request/ReportResolveRequest.java
@@ -1,0 +1,11 @@
+package com.projectlyrics.server.domain.report.dto.request;
+import com.projectlyrics.server.domain.report.domain.ApprovalStatus;
+import jakarta.validation.constraints.NotNull;
+
+public record ReportResolveRequest(
+        @NotNull
+        ApprovalStatus approvalStatus,
+        @NotNull
+        Boolean isFalseReport
+){
+}

--- a/src/main/java/com/projectlyrics/server/domain/report/dto/response/ReportCreateResponse.java
+++ b/src/main/java/com/projectlyrics/server/domain/report/dto/response/ReportCreateResponse.java
@@ -1,0 +1,6 @@
+package com.projectlyrics.server.domain.report.dto.response;
+
+public record ReportCreateResponse(
+        boolean success
+) {
+}

--- a/src/main/java/com/projectlyrics/server/domain/report/dto/response/ReportResolveResponse.java
+++ b/src/main/java/com/projectlyrics/server/domain/report/dto/response/ReportResolveResponse.java
@@ -1,0 +1,6 @@
+package com.projectlyrics.server.domain.report.dto.response;
+
+public record ReportResolveResponse (
+        boolean success
+){
+}

--- a/src/main/java/com/projectlyrics/server/domain/report/exception/ReportNotFoundException.java
+++ b/src/main/java/com/projectlyrics/server/domain/report/exception/ReportNotFoundException.java
@@ -1,0 +1,12 @@
+package com.projectlyrics.server.domain.report.exception;
+
+import com.projectlyrics.server.domain.common.message.ErrorCode;
+import com.projectlyrics.server.global.exception.FeelinException;
+
+public class ReportNotFoundException extends FeelinException {
+
+    public ReportNotFoundException() {
+        super(ErrorCode.REPORT_NOT_FOUND);
+    }
+}
+

--- a/src/main/java/com/projectlyrics/server/domain/report/exception/ReportTargetConfilctedException.java
+++ b/src/main/java/com/projectlyrics/server/domain/report/exception/ReportTargetConfilctedException.java
@@ -1,0 +1,9 @@
+package com.projectlyrics.server.domain.report.exception;
+
+import com.projectlyrics.server.domain.common.message.ErrorCode;
+import com.projectlyrics.server.global.exception.FeelinException;
+
+public class ReportTargetConfilctedException extends FeelinException {
+    public ReportTargetConfilctedException() {
+        super(ErrorCode.REPORT_TARGET_CONFLICT);}
+}

--- a/src/main/java/com/projectlyrics/server/domain/report/exception/ReportTargetMissingException.java
+++ b/src/main/java/com/projectlyrics/server/domain/report/exception/ReportTargetMissingException.java
@@ -1,0 +1,11 @@
+package com.projectlyrics.server.domain.report.exception;
+
+import com.projectlyrics.server.domain.common.message.ErrorCode;
+import com.projectlyrics.server.global.exception.FeelinException;
+
+public class ReportTargetMissingException extends FeelinException {
+
+    public ReportTargetMissingException() {
+        super(ErrorCode.REPORT_TARGET_MISSING);
+    }
+}

--- a/src/main/java/com/projectlyrics/server/domain/report/repository/ReportCommandRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/report/repository/ReportCommandRepository.java
@@ -1,0 +1,9 @@
+package com.projectlyrics.server.domain.report.repository;
+
+import com.projectlyrics.server.domain.report.domain.Report;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReportCommandRepository extends JpaRepository<Report, Long> {
+}

--- a/src/main/java/com/projectlyrics/server/domain/report/repository/ReportQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/report/repository/ReportQueryRepository.java
@@ -1,0 +1,10 @@
+package com.projectlyrics.server.domain.report.repository;
+
+import com.projectlyrics.server.domain.report.domain.Report;
+import java.util.Optional;
+
+public interface ReportQueryRepository {
+
+    Optional<Report> findById(Long reportId);
+    Optional<Report> findByReporterIdAndNoteIdAndCommentId(Long reporterId, Long noteId, Long commentId);
+}

--- a/src/main/java/com/projectlyrics/server/domain/report/repository/impl/QueryDslReportQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/report/repository/impl/QueryDslReportQueryRepository.java
@@ -19,6 +19,9 @@ public class QueryDslReportQueryRepository implements ReportQueryRepository {
         return Optional.ofNullable(
                 jpaQueryFactory
                         .selectFrom(report)
+                        .leftJoin(report.reporter).fetchJoin()
+                        .leftJoin(report.note).fetchJoin()
+                        .leftJoin(report.comment).fetchJoin()
                         .where(
                                 report.id.eq(reportId),
                                 report.deletedAt.isNull()
@@ -31,6 +34,9 @@ public class QueryDslReportQueryRepository implements ReportQueryRepository {
         return Optional.ofNullable(
                 jpaQueryFactory
                         .selectFrom(report)
+                        .leftJoin(report.reporter).fetchJoin()
+                        .leftJoin(report.note).fetchJoin()
+                        .leftJoin(report.comment).fetchJoin()
                         .where(
                                 report.reporter.id.eq(reporterId),
                                 commentId != null ? report.comment.id.eq(commentId) : report.comment.id.isNull(),

--- a/src/main/java/com/projectlyrics/server/domain/report/repository/impl/QueryDslReportQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/report/repository/impl/QueryDslReportQueryRepository.java
@@ -1,0 +1,42 @@
+package com.projectlyrics.server.domain.report.repository.impl;
+
+import static com.projectlyrics.server.domain.report.domain.QReport.report;
+import com.projectlyrics.server.domain.report.domain.Report;
+import com.projectlyrics.server.domain.report.repository.ReportQueryRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class QueryDslReportQueryRepository implements ReportQueryRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Optional<Report> findById(Long reportId) {
+        return Optional.ofNullable(
+                jpaQueryFactory
+                        .selectFrom(report)
+                        .where(
+                                report.id.eq(reportId),
+                                report.deletedAt.isNull()
+                        )
+                        .fetchOne());
+    }
+
+    @Override
+    public Optional<Report> findByReporterIdAndNoteIdAndCommentId(Long reporterId, Long noteId, Long commentId) {
+        return Optional.ofNullable(
+                jpaQueryFactory
+                        .selectFrom(report)
+                        .where(
+                                report.reporter.id.eq(reporterId),
+                                commentId != null ? report.comment.id.eq(commentId) : report.comment.id.isNull(),
+                                noteId != null ? report.note.id.eq(noteId) : report.note.id.isNull(),
+                                report.deletedAt.isNull()
+                        )
+                        .fetchOne());
+    }
+}

--- a/src/main/java/com/projectlyrics/server/domain/report/service/ReportCommandService.java
+++ b/src/main/java/com/projectlyrics/server/domain/report/service/ReportCommandService.java
@@ -1,0 +1,71 @@
+package com.projectlyrics.server.domain.report.service;
+
+import com.projectlyrics.server.domain.comment.domain.Comment;
+import com.projectlyrics.server.domain.comment.exception.CommentNotFoundException;
+import com.projectlyrics.server.domain.comment.repository.CommentQueryRepository;
+import com.projectlyrics.server.domain.note.entity.Note;
+import com.projectlyrics.server.domain.note.exception.NoteNotFoundException;
+import com.projectlyrics.server.domain.note.repository.NoteQueryRepository;
+import com.projectlyrics.server.domain.report.domain.Report;
+import com.projectlyrics.server.domain.report.domain.ReportCreate;
+import com.projectlyrics.server.domain.report.dto.request.ReportCreateRequest;
+import com.projectlyrics.server.domain.report.dto.request.ReportResolveRequest;
+import com.projectlyrics.server.domain.report.exception.ReportNotFoundException;
+import com.projectlyrics.server.domain.report.repository.ReportCommandRepository;
+import com.projectlyrics.server.domain.report.repository.ReportQueryRepository;
+import com.projectlyrics.server.domain.user.entity.User;
+import com.projectlyrics.server.domain.user.exception.UserNotFoundException;
+import com.projectlyrics.server.domain.user.repository.UserQueryRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ReportCommandService {
+
+    private final ReportCommandRepository reportCommandRepository;
+    private final ReportQueryRepository reportQueryRepository;
+    private final UserQueryRepository userQueryRepository;
+    private final NoteQueryRepository noteQueryRepository;
+    private final CommentQueryRepository commentQueryRepository;
+
+    public Report create(ReportCreateRequest request, Long reporterId) {
+
+        User reporter = userQueryRepository.findById(reporterId)
+                .orElseThrow(UserNotFoundException::new);
+        Note note = Optional.ofNullable(request.noteId())
+                .map(noteId -> noteQueryRepository.findById(noteId)
+                        .orElseThrow(NoteNotFoundException::new))
+                .orElse(null);
+        Comment comment = Optional.ofNullable(request.commentId())
+                .map(commentId -> commentQueryRepository.findById(commentId)
+                        .orElseThrow(CommentNotFoundException::new))
+                .orElse(null);
+
+        Optional<Report> existingReport = reportQueryRepository.findByReporterIdAndNoteIdAndCommentId(
+                reporterId, request.noteId(), request.commentId());
+
+        Report report = existingReport
+                .map(r -> {
+                    r.setReportReason(request.reportReason());
+                    return r;
+                })
+                .orElseGet(() -> {
+                    return Report.create(ReportCreate.of(reporter, note, comment, request.reportReason(), request.email()));
+                });
+
+        return reportCommandRepository.save(report);
+    }
+
+    public Long resolve(ReportResolveRequest reportResolveRequest, Long reportId) {
+
+        Report report = reportQueryRepository.findById(reportId)
+                .orElseThrow(ReportNotFoundException::new);
+        report.resolve(reportResolveRequest.approvalStatus(), reportResolveRequest.isFalseReport());
+
+        return report.getId();
+    }
+}

--- a/src/main/java/com/projectlyrics/server/domain/report/service/ReportCommandService.java
+++ b/src/main/java/com/projectlyrics/server/domain/report/service/ReportCommandService.java
@@ -75,7 +75,7 @@ public class ReportCommandService {
 
         Report report = reportQueryRepository.findById(reportId)
                 .orElseThrow(ReportNotFoundException::new);
-        report.resolve(ReportResolve.of(reportResolveRequest.approvalStatus(), reportResolveRequest.isFalseReport()));
+        report.resolve(ReportResolve.from(reportResolveRequest));
 
         return report.getId();
     }

--- a/src/main/java/com/projectlyrics/server/domain/report/service/ReportCommandService.java
+++ b/src/main/java/com/projectlyrics/server/domain/report/service/ReportCommandService.java
@@ -8,6 +8,7 @@ import com.projectlyrics.server.domain.note.exception.NoteNotFoundException;
 import com.projectlyrics.server.domain.note.repository.NoteQueryRepository;
 import com.projectlyrics.server.domain.report.domain.Report;
 import com.projectlyrics.server.domain.report.domain.ReportCreate;
+import com.projectlyrics.server.domain.report.domain.ReportResolve;
 import com.projectlyrics.server.domain.report.dto.request.ReportCreateRequest;
 import com.projectlyrics.server.domain.report.dto.request.ReportResolveRequest;
 import com.projectlyrics.server.domain.report.exception.ReportNotFoundException;
@@ -64,7 +65,7 @@ public class ReportCommandService {
 
         Report report = reportQueryRepository.findById(reportId)
                 .orElseThrow(ReportNotFoundException::new);
-        report.resolve(reportResolveRequest.approvalStatus(), reportResolveRequest.isFalseReport());
+        report.resolve(ReportResolve.of(reportResolveRequest.approvalStatus(), reportResolveRequest.isFalseReport()));
 
         return report.getId();
     }

--- a/src/main/java/com/projectlyrics/server/global/configuration/WebConfig.java
+++ b/src/main/java/com/projectlyrics/server/global/configuration/WebConfig.java
@@ -2,6 +2,7 @@ package com.projectlyrics.server.global.configuration;
 
 import com.projectlyrics.server.domain.auth.authentication.AuthArgumentResolver;
 import com.projectlyrics.server.domain.auth.authentication.AuthInterceptor;
+import com.projectlyrics.server.domain.auth.authentication.SlackInterceptor;
 import com.projectlyrics.server.domain.user.authentication.AdminInterceptor;
 import com.projectlyrics.server.global.converter.ProfileCharacterConverter;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +21,7 @@ public class WebConfig implements WebMvcConfigurer {
     private final AuthInterceptor authInterceptor;
     private final AuthArgumentResolver authArgumentResolver;
     private final AdminInterceptor adminInterceptor;
+    private final SlackInterceptor slackInterceptor;
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
@@ -32,12 +34,16 @@ public class WebConfig implements WebMvcConfigurer {
                 .excludePathPatterns("/api/v1/artists/search")
                 .excludePathPatterns("/api/v1/notes/artists")
                 .excludePathPatterns("/api/v1/notes/songs")
-                .excludePathPatterns("/api/v1/songs/search");
+                .excludePathPatterns("/api/v1/songs/search")
+                .excludePathPatterns("/api/v1/slack/interactive");
 
         registry.addInterceptor(adminInterceptor)
                 .addPathPatterns("/api/v1/artists/**")
                 .addPathPatterns("/api/v1/notifications/public")
                 .excludePathPatterns("/api/v1/artists/search");
+
+        registry.addInterceptor(slackInterceptor)
+                .addPathPatterns("/api/v1/slack/interactive");
     }
 
     @Override

--- a/src/main/java/com/projectlyrics/server/global/configuration/WebConfig.java
+++ b/src/main/java/com/projectlyrics/server/global/configuration/WebConfig.java
@@ -1,9 +1,9 @@
 package com.projectlyrics.server.global.configuration;
 
 import com.projectlyrics.server.domain.auth.authentication.AuthArgumentResolver;
-import com.projectlyrics.server.domain.auth.authentication.AuthInterceptor;
-import com.projectlyrics.server.domain.auth.authentication.SlackInterceptor;
-import com.projectlyrics.server.domain.user.authentication.AdminInterceptor;
+import com.projectlyrics.server.domain.auth.authentication.interceptor.AuthInterceptor;
+import com.projectlyrics.server.domain.auth.authentication.interceptor.SlackInterceptor;
+import com.projectlyrics.server.domain.auth.authentication.interceptor.AdminInterceptor;
 import com.projectlyrics.server.global.converter.ProfileCharacterConverter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/projectlyrics/server/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/projectlyrics/server/global/handler/GlobalExceptionHandler.java
@@ -52,6 +52,17 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler({MethodArgumentNotValidException.class, MethodArgumentTypeMismatchException.class})
     public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(final Exception e) {
+        if (e instanceof MethodArgumentNotValidException) {
+            MethodArgumentNotValidException ex = (MethodArgumentNotValidException) e;
+            FieldError fieldError = ex.getBindingResult().getFieldError();
+            if (fieldError != null && "email".equals(fieldError.getField())) {
+                // Custom message for email field errors
+                return ResponseEntity
+                        .status(HttpStatus.BAD_REQUEST)
+                        .body(ErrorResponse.of(ErrorCode.INVALID_EMAIL));
+            }
+        }
+
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
                 .body(ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE));

--- a/src/main/java/com/projectlyrics/server/global/slack/SlackClient.java
+++ b/src/main/java/com/projectlyrics/server/global/slack/SlackClient.java
@@ -54,30 +54,33 @@ public class SlackClient {
         // Build the blocks with buttons
         List<LayoutBlock> blocks = List.of(
                 Blocks.section(section -> section.text(
-                        MarkdownTextObject.builder().text(":rotating_light:*새로운 신고가 접수되었습니다.*").build())),
+                        MarkdownTextObject.builder().text(":rotating_light: " + report.getId() + ") *새로운 신고가 접수되었습니다.*").build())),
                 Blocks.section(section -> section.fields(List.of(
-                        MarkdownTextObject.builder().text("*신고자 ID:*\n" + report.getReporter().getId()).build(),
-                        MarkdownTextObject.builder().text("*피신고자 ID:*\n" + report.getNote().getPublisher().getId()).build(),
-                        MarkdownTextObject.builder().text("*노트 ID:*\n" + report.getNote().getId()).build(),
-                        MarkdownTextObject.builder().text("*신고 이유:*\n" + report.getReportReason().getDescription()).build(),
-                        MarkdownTextObject.builder().text("*신고자 이메일:*\n" + (report.getEmail() != null ? report.getEmail() : "-")).build(),
-                        MarkdownTextObject.builder().text("*신고 일시:*\n" + report.getCreatedAt()).build()
+                        MarkdownTextObject.builder().text("*신고자 ID:* " + report.getReporter().getId()).build(),
+                        MarkdownTextObject.builder().text("*피신고자 ID:* " + report.getNote().getPublisher().getId()).build(),
+                        MarkdownTextObject.builder().text("*노트 ID:* " + report.getNote().getId()).build(),
+                        MarkdownTextObject.builder().text("*신고 이유:* " + report.getReportReason().getDescription()).build(),
+                        MarkdownTextObject.builder().text("*신고자 이메일:* " + (report.getEmail() != null ? report.getEmail() : "-")).build(),
+                        MarkdownTextObject.builder().text("*신고 일시:* " + report.getCreatedAt()).build()
                 ))),
                 Blocks.section(section -> section.text(MarkdownTextObject.builder().text("*노트 내용:*\n" + report.getNote().getContent()).build())),
                 Blocks.actions(actions -> actions.elements(List.of(
                         ButtonElement.builder()
                                 .text(PlainTextObject.builder().text("Accept").build())
-                                .actionId("accept_report")
+                                .actionId("resolve_report")
                                 .style("primary")
+                                .value("{\"type\":\"accepted\", \"reportId\":\"" + report.getId() + "\", \"approvalStatus\":\"ACCEPTED\", \"isFalseReport\":" + false + "}")
                                 .build(),
                         ButtonElement.builder()
                                 .text(PlainTextObject.builder().text("Dismiss").build())
-                                .actionId("dismiss_report")
+                                .actionId("resolve_report")
                                 .style("danger")
+                                .value("{\"type\":\"dismissed\", \"reportId\":\"" + report.getId() + "\", \"approvalStatus\":\"DISMISSED\", \"isFalseReport\":" + false + "}")
                                 .build(),
                         ButtonElement.builder()
                                 .text(PlainTextObject.builder().text("Fake Report").build())
-                                .actionId("fake_report")
+                                .actionId("resolve_report")
+                                .value("{\"type\":\"fake report\", \"reportId\":\"" + report.getId() + "\", \"approvalStatus\":\"DISMISSED\", \"isFalseReport\":" + true + "}")
                                 .build()
                 )))
         );
@@ -88,14 +91,15 @@ public class SlackClient {
     public void sendCommentReportMessage(Report report) {
         // Build the blocks with buttons
         List<LayoutBlock> blocks = List.of(
-                Blocks.section(section -> section.text(MarkdownTextObject.builder().text(":rotating_light:*새로운 신고가 접수되었습니다.*").build())),
+                Blocks.section(section -> section.text(
+                        MarkdownTextObject.builder().text(":rotating_light: " + report.getId() + ") *새로운 신고가 접수되었습니다.*").build())),
                 Blocks.section(section -> section.fields(List.of(
-                        MarkdownTextObject.builder().text("*신고자 ID:*\n" + report.getReporter().getId()).build(),
-                        MarkdownTextObject.builder().text("*피신고자 ID:*\n" + report.getComment().getWriter().getId()).build(),
-                        MarkdownTextObject.builder().text("*댓글 ID:*\n" + report.getComment().getId()).build(),
-                        MarkdownTextObject.builder().text("*신고 이유:*\n" + report.getReportReason().getDescription()).build(),
-                        MarkdownTextObject.builder().text("*신고자 이메일:*\n" + (report.getEmail() != null ? report.getEmail() : "-")).build(),
-                        MarkdownTextObject.builder().text("*신고 일시:*\n" + report.getCreatedAt()).build()
+                        MarkdownTextObject.builder().text("*신고자 ID:* " + report.getReporter().getId()).build(),
+                        MarkdownTextObject.builder().text("*피신고자 ID:* " + report.getComment().getWriter().getId()).build(),
+                        MarkdownTextObject.builder().text("*댓글 ID:* " + report.getComment().getId()).build(),
+                        MarkdownTextObject.builder().text("*신고 이유:* " + report.getReportReason().getDescription()).build(),
+                        MarkdownTextObject.builder().text("*신고자 이메일:* " + (report.getEmail() != null ? report.getEmail() : "-")).build(),
+                        MarkdownTextObject.builder().text("*신고 일시:*" + report.getCreatedAt()).build()
                 ))),
                 Blocks.section(section -> section.text(MarkdownTextObject.builder().text("*댓글 내용:*\n" + report.getComment().getContent()).build())),
                 Blocks.actions(actions -> actions.elements(List.of(
@@ -103,15 +107,18 @@ public class SlackClient {
                                 .text(PlainTextObject.builder().text("Accept").build())
                                 .actionId("accept_report")
                                 .style("primary")
+                                .value("{\"type\":\"accepted\", \"reportId\":\"" + report.getId() + "\", \"approvalStatus\":\"ACCEPTED\", \"isFalseReport\":" + false + "}")
                                 .build(),
                         ButtonElement.builder()
                                 .text(PlainTextObject.builder().text("Dismiss").build())
                                 .actionId("dismiss_report")
                                 .style("danger")
+                                .value("{\"type\":\"dismissed\", \"reportId\":\"" + report.getId() + "\", \"approvalStatus\":\"DISMISSED\", \"isFalseReport\":" + false + "}")
                                 .build(),
                         ButtonElement.builder()
                                 .text(PlainTextObject.builder().text("Fake Report").build())
                                 .actionId("fake_report")
+                                .value("{\"type\":\"fake report\", \"reportId\":\"" + report.getId() + "\", \"approvalStatus\":\"DISMISSED\", \"isFalseReport\":" + true + "}")
                                 .build()
                 )))
         );

--- a/src/main/java/com/projectlyrics/server/global/slack/SlackClient.java
+++ b/src/main/java/com/projectlyrics/server/global/slack/SlackClient.java
@@ -8,6 +8,7 @@ import com.slack.api.methods.SlackApiException;
 import com.slack.api.methods.response.chat.ChatPostMessageResponse;
 import com.slack.api.model.block.Blocks;
 import com.slack.api.model.block.LayoutBlock;
+import com.slack.api.model.block.composition.MarkdownTextObject;
 import com.slack.api.model.block.composition.PlainTextObject;
 import com.slack.api.model.block.element.ButtonElement;
 import java.io.IOException;
@@ -52,16 +53,17 @@ public class SlackClient {
     public void sendNoteReportMessage(Report report) {
         // Build the blocks with buttons
         List<LayoutBlock> blocks = List.of(
-                Blocks.section(section -> section.text(PlainTextObject.builder().text(":rotating_light:*새로운 신고가 접수되었습니다.*").build())),
+                Blocks.section(section -> section.text(
+                        MarkdownTextObject.builder().text(":rotating_light:*새로운 신고가 접수되었습니다.*").build())),
                 Blocks.section(section -> section.fields(List.of(
-                        PlainTextObject.builder().text("*신고자 ID:*\n" + report.getReporter().getId()).build(),
-                        PlainTextObject.builder().text("*피신고자 ID:*\n" + report.getNote().getPublisher().getId()).build(),
-                        PlainTextObject.builder().text("*노트 ID:*\n" + report.getNote().getId()).build(),
-                        PlainTextObject.builder().text("*신고 이유:*\n" + report.getReportReason().getDescription()).build(),
-                        PlainTextObject.builder().text("*신고자 이메일:*\n" + (report.getEmail() != null ? report.getEmail() : "")).build(),
-                        PlainTextObject.builder().text("*신고 일시:*\n" + report.getCreatedAt()).build()
+                        MarkdownTextObject.builder().text("*신고자 ID:*\n" + report.getReporter().getId()).build(),
+                        MarkdownTextObject.builder().text("*피신고자 ID:*\n" + report.getNote().getPublisher().getId()).build(),
+                        MarkdownTextObject.builder().text("*노트 ID:*\n" + report.getNote().getId()).build(),
+                        MarkdownTextObject.builder().text("*신고 이유:*\n" + report.getReportReason().getDescription()).build(),
+                        MarkdownTextObject.builder().text("*신고자 이메일:*\n" + (report.getEmail() != null ? report.getEmail() : "-")).build(),
+                        MarkdownTextObject.builder().text("*신고 일시:*\n" + report.getCreatedAt()).build()
                 ))),
-                Blocks.section(section -> section.text(PlainTextObject.builder().text("*노트 내용:*\n" + report.getNote().getContent()).build())),
+                Blocks.section(section -> section.text(MarkdownTextObject.builder().text("*노트 내용:*\n" + report.getNote().getContent()).build())),
                 Blocks.actions(actions -> actions.elements(List.of(
                         ButtonElement.builder()
                                 .text(PlainTextObject.builder().text("Accept").build())
@@ -86,16 +88,16 @@ public class SlackClient {
     public void sendCommentReportMessage(Report report) {
         // Build the blocks with buttons
         List<LayoutBlock> blocks = List.of(
-                Blocks.section(section -> section.text(PlainTextObject.builder().text(":rotating_light:*새로운 신고가 접수되었습니다.*").build())),
+                Blocks.section(section -> section.text(MarkdownTextObject.builder().text(":rotating_light:*새로운 신고가 접수되었습니다.*").build())),
                 Blocks.section(section -> section.fields(List.of(
-                        PlainTextObject.builder().text("*신고자 ID:*\n" + report.getReporter().getId()).build(),
-                        PlainTextObject.builder().text("*피신고자 ID:*\n" + report.getComment().getWriter().getId()).build(),
-                        PlainTextObject.builder().text("*댓글 ID:*\n" + report.getComment().getId()).build(),
-                        PlainTextObject.builder().text("*신고 이유:*\n" + report.getReportReason().getDescription()).build(),
-                        PlainTextObject.builder().text("*신고자 이메일:*\n" + (report.getEmail() != null ? report.getEmail() : "")).build(),
-                        PlainTextObject.builder().text("*신고 일시:*\n" + report.getCreatedAt()).build()
+                        MarkdownTextObject.builder().text("*신고자 ID:*\n" + report.getReporter().getId()).build(),
+                        MarkdownTextObject.builder().text("*피신고자 ID:*\n" + report.getComment().getWriter().getId()).build(),
+                        MarkdownTextObject.builder().text("*댓글 ID:*\n" + report.getComment().getId()).build(),
+                        MarkdownTextObject.builder().text("*신고 이유:*\n" + report.getReportReason().getDescription()).build(),
+                        MarkdownTextObject.builder().text("*신고자 이메일:*\n" + (report.getEmail() != null ? report.getEmail() : "-")).build(),
+                        MarkdownTextObject.builder().text("*신고 일시:*\n" + report.getCreatedAt()).build()
                 ))),
-                Blocks.section(section -> section.text(PlainTextObject.builder().text("*댓글 내용:*\n" + report.getComment().getContent()).build())),
+                Blocks.section(section -> section.text(MarkdownTextObject.builder().text("*댓글 내용:*\n" + report.getComment().getContent()).build())),
                 Blocks.actions(actions -> actions.elements(List.of(
                         ButtonElement.builder()
                                 .text(PlainTextObject.builder().text("Accept").build())

--- a/src/main/java/com/projectlyrics/server/global/slack/SlackClient.java
+++ b/src/main/java/com/projectlyrics/server/global/slack/SlackClient.java
@@ -52,6 +52,24 @@ public class SlackClient {
         }
     }
 
+    public void sendNoteReportMessage(Report report) {
+        sendReportMessage(
+                report,
+                "노트",
+                report.getNote().getPublisher().getId(),
+                report.getNote().getContent()
+        );
+    }
+
+    public void sendCommentReportMessage(Report report) {
+        sendReportMessage(
+                report,
+                "댓글",
+                report.getComment().getWriter().getId(),
+                report.getComment().getContent()
+        );
+    }
+
     private void sendReportMessage(Report report, String contentType, Long contentId, String content) {
         List<LayoutBlock> blocks = List.of(
                 Blocks.section(section -> section.text(
@@ -87,24 +105,6 @@ public class SlackClient {
         );
 
         sendMessage(blocks, contentType + " Report Notification");
-    }
-
-    public void sendNoteReportMessage(Report report) {
-        sendReportMessage(
-                report,
-                "노트",
-                report.getNote().getPublisher().getId(),
-                report.getNote().getContent()
-        );
-    }
-
-    public void sendCommentReportMessage(Report report) {
-        sendReportMessage(
-                report,
-                "댓글",
-                report.getComment().getWriter().getId(),
-                report.getComment().getContent()
-        );
     }
 }
 

--- a/src/main/java/com/projectlyrics/server/global/slack/SlackClient.java
+++ b/src/main/java/com/projectlyrics/server/global/slack/SlackClient.java
@@ -1,0 +1,121 @@
+package com.projectlyrics.server.global.slack;
+
+import com.projectlyrics.server.domain.report.domain.Report;
+import com.projectlyrics.server.global.slack.exception.SlackNotificationFailureException;
+import com.projectlyrics.server.global.slack.exception.SlackNotificationProcessingException;
+import com.slack.api.Slack;
+import com.slack.api.methods.SlackApiException;
+import com.slack.api.methods.response.chat.ChatPostMessageResponse;
+import com.slack.api.model.block.Blocks;
+import com.slack.api.model.block.LayoutBlock;
+import com.slack.api.model.block.composition.PlainTextObject;
+import com.slack.api.model.block.element.ButtonElement;
+import java.io.IOException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SlackClient {
+
+    @Value("${slack.token}")
+    private String token;
+
+    @Value("${slack.channel.id}")
+    private String channelId;
+
+    private static final Logger logger = LoggerFactory.getLogger(SlackClient.class);
+
+    public void sendMessage(List<LayoutBlock> blocks, String message) {
+        try {
+            Slack slack = Slack.getInstance();
+            ChatPostMessageResponse chatPostMessageResponse = slack.methods(token).chatPostMessage(req -> req
+                    .channel(channelId)
+                    .blocks(blocks)
+                    .text("Report Notification")
+            );
+
+            if (!chatPostMessageResponse.isOk()) {
+                logger.error("Slack API error: {}", chatPostMessageResponse.getError());
+                throw new SlackNotificationFailureException();
+            }
+        } catch (IOException | SlackApiException e) {
+            logger.error("Failed to send Slack message: {}", e.getMessage(), e);
+            throw new SlackNotificationProcessingException();
+        }
+    }
+
+    public void sendNoteReportMessage(Report report) {
+        // Build the blocks with buttons
+        List<LayoutBlock> blocks = List.of(
+                Blocks.section(section -> section.text(PlainTextObject.builder().text(":rotating_light:*새로운 신고가 접수되었습니다.*").build())),
+                Blocks.section(section -> section.fields(List.of(
+                        PlainTextObject.builder().text("*신고자 ID:*\n" + report.getReporter().getId()).build(),
+                        PlainTextObject.builder().text("*피신고자 ID:*\n" + report.getNote().getPublisher().getId()).build(),
+                        PlainTextObject.builder().text("*노트 ID:*\n" + report.getNote().getId()).build(),
+                        PlainTextObject.builder().text("*신고 이유:*\n" + report.getReportReason().getDescription()).build(),
+                        PlainTextObject.builder().text("*신고자 이메일:*\n" + (report.getEmail() != null ? report.getEmail() : "")).build(),
+                        PlainTextObject.builder().text("*신고 일시:*\n" + report.getCreatedAt()).build()
+                ))),
+                Blocks.section(section -> section.text(PlainTextObject.builder().text("*노트 내용:*\n" + report.getNote().getContent()).build())),
+                Blocks.actions(actions -> actions.elements(List.of(
+                        ButtonElement.builder()
+                                .text(PlainTextObject.builder().text("Accept").build())
+                                .actionId("accept_report")
+                                .style("primary")
+                                .build(),
+                        ButtonElement.builder()
+                                .text(PlainTextObject.builder().text("Dismiss").build())
+                                .actionId("dismiss_report")
+                                .style("danger")
+                                .build(),
+                        ButtonElement.builder()
+                                .text(PlainTextObject.builder().text("Fake Report").build())
+                                .actionId("fake_report")
+                                .build()
+                )))
+        );
+
+        sendMessage(blocks, "Report Notification");
+    }
+
+    public void sendCommentReportMessage(Report report) {
+        // Build the blocks with buttons
+        List<LayoutBlock> blocks = List.of(
+                Blocks.section(section -> section.text(PlainTextObject.builder().text(":rotating_light:*새로운 신고가 접수되었습니다.*").build())),
+                Blocks.section(section -> section.fields(List.of(
+                        PlainTextObject.builder().text("*신고자 ID:*\n" + report.getReporter().getId()).build(),
+                        PlainTextObject.builder().text("*피신고자 ID:*\n" + report.getComment().getWriter().getId()).build(),
+                        PlainTextObject.builder().text("*댓글 ID:*\n" + report.getComment().getId()).build(),
+                        PlainTextObject.builder().text("*신고 이유:*\n" + report.getReportReason().getDescription()).build(),
+                        PlainTextObject.builder().text("*신고자 이메일:*\n" + (report.getEmail() != null ? report.getEmail() : "")).build(),
+                        PlainTextObject.builder().text("*신고 일시:*\n" + report.getCreatedAt()).build()
+                ))),
+                Blocks.section(section -> section.text(PlainTextObject.builder().text("*댓글 내용:*\n" + report.getComment().getContent()).build())),
+                Blocks.actions(actions -> actions.elements(List.of(
+                        ButtonElement.builder()
+                                .text(PlainTextObject.builder().text("Accept").build())
+                                .actionId("accept_report")
+                                .style("primary")
+                                .build(),
+                        ButtonElement.builder()
+                                .text(PlainTextObject.builder().text("Dismiss").build())
+                                .actionId("dismiss_report")
+                                .style("danger")
+                                .build(),
+                        ButtonElement.builder()
+                                .text(PlainTextObject.builder().text("Fake Report").build())
+                                .actionId("fake_report")
+                                .build()
+                )))
+        );
+
+        sendMessage(blocks, "Report Notification");
+    }
+
+}
+

--- a/src/main/java/com/projectlyrics/server/global/slack/SlackClient.java
+++ b/src/main/java/com/projectlyrics/server/global/slack/SlackClient.java
@@ -52,19 +52,19 @@ public class SlackClient {
         }
     }
 
-    public void sendNoteReportMessage(Report report) {
+    private void sendReportMessage(Report report, String contentType, Long contentId, String content) {
         List<LayoutBlock> blocks = List.of(
                 Blocks.section(section -> section.text(
                         MarkdownTextObject.builder().text(":rotating_light: *" + report.getId() + ") 새로운 신고가 접수되었습니다.*").build())),
                 Blocks.section(section -> section.fields(List.of(
                         MarkdownTextObject.builder().text("*신고자 ID:* " + report.getReporter().getId()).build(),
-                        MarkdownTextObject.builder().text("*피신고자 ID:* " + report.getNote().getPublisher().getId()).build(),
-                        MarkdownTextObject.builder().text("*노트 ID:* " + report.getNote().getId()).build(),
+                        MarkdownTextObject.builder().text("*피신고자 ID:* " + contentId).build(),
+                        MarkdownTextObject.builder().text("*" + contentType + " ID:* " + contentId).build(),
                         MarkdownTextObject.builder().text("*신고 이유:* " + report.getReportReason().getDescription()).build(),
                         MarkdownTextObject.builder().text("*신고자 이메일:* " + (report.getEmail() != null ? report.getEmail() : "-")).build(),
                         MarkdownTextObject.builder().text("*신고 일시:* " + formatter.format(report.getCreatedAt())).build()
                 ))),
-                Blocks.section(section -> section.text(MarkdownTextObject.builder().text("*노트 내용:*\n" +  (report.getNote().getContent() != null ? report.getNote().getContent() : "-")).build())),
+                Blocks.section(section -> section.text(MarkdownTextObject.builder().text("*" + contentType + " 내용:*\n" + (content != null ? content : "-")).build())),
                 Blocks.actions(actions -> actions.elements(List.of(
                         ButtonElement.builder()
                                 .text(PlainTextObject.builder().text("Accept").build())
@@ -86,45 +86,25 @@ public class SlackClient {
                 )))
         );
 
-        sendMessage(blocks, "Note Report Notification");
+        sendMessage(blocks, contentType + " Report Notification");
+    }
+
+    public void sendNoteReportMessage(Report report) {
+        sendReportMessage(
+                report,
+                "노트",
+                report.getNote().getPublisher().getId(),
+                report.getNote().getContent()
+        );
     }
 
     public void sendCommentReportMessage(Report report) {
-        List<LayoutBlock> blocks = List.of(
-                Blocks.section(section -> section.text(
-                        MarkdownTextObject.builder().text(":rotating_light: *" + report.getId() + ") 새로운 신고가 접수되었습니다.*").build())),
-                Blocks.section(section -> section.fields(List.of(
-                        MarkdownTextObject.builder().text("*신고자 ID:* " + report.getReporter().getId()).build(),
-                        MarkdownTextObject.builder().text("*피신고자 ID:* " + report.getComment().getWriter().getId()).build(),
-                        MarkdownTextObject.builder().text("*댓글 ID:* " + report.getComment().getId()).build(),
-                        MarkdownTextObject.builder().text("*신고 이유:* " + report.getReportReason().getDescription()).build(),
-                        MarkdownTextObject.builder().text("*신고자 이메일:* " + (report.getEmail() != null ? report.getEmail() : "-")).build(),
-                        MarkdownTextObject.builder().text("*신고 일시:* " + formatter.format(report.getCreatedAt())).build()
-                ))),
-                Blocks.section(section -> section.text(MarkdownTextObject.builder().text("*댓글 내용:*\n" + (report.getComment().getContent() != null ? report.getComment().getContent() : "-")).build())),
-                Blocks.actions(actions -> actions.elements(List.of(
-                        ButtonElement.builder()
-                                .text(PlainTextObject.builder().text("Accept").build())
-                                .actionId("report_accept")
-                                .style("primary")
-                                .value("{\"type\":\"accepted\", \"reportId\":\"" + report.getId() + "\", \"approvalStatus\":\"ACCEPTED\", \"isFalseReport\":false}")
-                                .build(),
-                        ButtonElement.builder()
-                                .text(PlainTextObject.builder().text("Dismiss").build())
-                                .actionId("report_dismiss")
-                                .style("danger")
-                                .value("{\"type\":\"dismissed\", \"reportId\":\"" + report.getId() + "\", \"approvalStatus\":\"DISMISSED\", \"isFalseReport\":false}")
-                                .build(),
-                        ButtonElement.builder()
-                                .text(PlainTextObject.builder().text("Fake Report").build())
-                                .actionId("report_fake")
-                                .value("{\"type\":\"fake report\", \"reportId\":\"" + report.getId() + "\", \"approvalStatus\":\"DISMISSED\", \"isFalseReport\":true}")
-                                .build()
-                )))
+        sendReportMessage(
+                report,
+                "댓글",
+                report.getComment().getWriter().getId(),
+                report.getComment().getContent()
         );
-
-        sendMessage(blocks, "Comment Report Notification");
     }
-
 }
 

--- a/src/main/java/com/projectlyrics/server/global/slack/SlackClient.java
+++ b/src/main/java/com/projectlyrics/server/global/slack/SlackClient.java
@@ -12,6 +12,7 @@ import com.slack.api.model.block.composition.MarkdownTextObject;
 import com.slack.api.model.block.composition.PlainTextObject;
 import com.slack.api.model.block.element.ButtonElement;
 import java.io.IOException;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
@@ -30,6 +31,7 @@ public class SlackClient {
     private String channelId;
 
     private static final Logger logger = LoggerFactory.getLogger(SlackClient.class);
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
 
     public void sendMessage(List<LayoutBlock> blocks, String message) {
         try {
@@ -51,79 +53,77 @@ public class SlackClient {
     }
 
     public void sendNoteReportMessage(Report report) {
-        // Build the blocks with buttons
         List<LayoutBlock> blocks = List.of(
                 Blocks.section(section -> section.text(
-                        MarkdownTextObject.builder().text(":rotating_light: " + report.getId() + ") *새로운 신고가 접수되었습니다.*").build())),
+                        MarkdownTextObject.builder().text(":rotating_light: *" + report.getId() + ") 새로운 신고가 접수되었습니다.*").build())),
                 Blocks.section(section -> section.fields(List.of(
                         MarkdownTextObject.builder().text("*신고자 ID:* " + report.getReporter().getId()).build(),
                         MarkdownTextObject.builder().text("*피신고자 ID:* " + report.getNote().getPublisher().getId()).build(),
                         MarkdownTextObject.builder().text("*노트 ID:* " + report.getNote().getId()).build(),
                         MarkdownTextObject.builder().text("*신고 이유:* " + report.getReportReason().getDescription()).build(),
                         MarkdownTextObject.builder().text("*신고자 이메일:* " + (report.getEmail() != null ? report.getEmail() : "-")).build(),
-                        MarkdownTextObject.builder().text("*신고 일시:* " + report.getCreatedAt()).build()
+                        MarkdownTextObject.builder().text("*신고 일시:* " + formatter.format(report.getCreatedAt())).build()
                 ))),
-                Blocks.section(section -> section.text(MarkdownTextObject.builder().text("*노트 내용:*\n" + report.getNote().getContent()).build())),
+                Blocks.section(section -> section.text(MarkdownTextObject.builder().text("*노트 내용:*\n" +  (report.getNote().getContent() != null ? report.getNote().getContent() : "-")).build())),
                 Blocks.actions(actions -> actions.elements(List.of(
                         ButtonElement.builder()
                                 .text(PlainTextObject.builder().text("Accept").build())
-                                .actionId("resolve_report")
+                                .actionId("report_accept")
                                 .style("primary")
-                                .value("{\"type\":\"accepted\", \"reportId\":\"" + report.getId() + "\", \"approvalStatus\":\"ACCEPTED\", \"isFalseReport\":" + false + "}")
+                                .value("{\"type\":\"accepted\", \"reportId\":\"" + report.getId() + "\", \"approvalStatus\":\"ACCEPTED\", \"isFalseReport\":false}")
                                 .build(),
                         ButtonElement.builder()
                                 .text(PlainTextObject.builder().text("Dismiss").build())
-                                .actionId("resolve_report")
+                                .actionId("report_dismiss")
                                 .style("danger")
-                                .value("{\"type\":\"dismissed\", \"reportId\":\"" + report.getId() + "\", \"approvalStatus\":\"DISMISSED\", \"isFalseReport\":" + false + "}")
+                                .value("{\"type\":\"dismissed\", \"reportId\":\"" + report.getId() + "\", \"approvalStatus\":\"DISMISSED\", \"isFalseReport\":false}")
                                 .build(),
                         ButtonElement.builder()
                                 .text(PlainTextObject.builder().text("Fake Report").build())
-                                .actionId("resolve_report")
-                                .value("{\"type\":\"fake report\", \"reportId\":\"" + report.getId() + "\", \"approvalStatus\":\"DISMISSED\", \"isFalseReport\":" + true + "}")
+                                .actionId("report_fake")
+                                .value("{\"type\":\"fake report\", \"reportId\":\"" + report.getId() + "\", \"approvalStatus\":\"DISMISSED\", \"isFalseReport\":true}")
                                 .build()
                 )))
         );
 
-        sendMessage(blocks, "Report Notification");
+        sendMessage(blocks, "Note Report Notification");
     }
 
     public void sendCommentReportMessage(Report report) {
-        // Build the blocks with buttons
         List<LayoutBlock> blocks = List.of(
                 Blocks.section(section -> section.text(
-                        MarkdownTextObject.builder().text(":rotating_light: " + report.getId() + ") *새로운 신고가 접수되었습니다.*").build())),
+                        MarkdownTextObject.builder().text(":rotating_light: *" + report.getId() + ") 새로운 신고가 접수되었습니다.*").build())),
                 Blocks.section(section -> section.fields(List.of(
                         MarkdownTextObject.builder().text("*신고자 ID:* " + report.getReporter().getId()).build(),
                         MarkdownTextObject.builder().text("*피신고자 ID:* " + report.getComment().getWriter().getId()).build(),
                         MarkdownTextObject.builder().text("*댓글 ID:* " + report.getComment().getId()).build(),
                         MarkdownTextObject.builder().text("*신고 이유:* " + report.getReportReason().getDescription()).build(),
                         MarkdownTextObject.builder().text("*신고자 이메일:* " + (report.getEmail() != null ? report.getEmail() : "-")).build(),
-                        MarkdownTextObject.builder().text("*신고 일시:*" + report.getCreatedAt()).build()
+                        MarkdownTextObject.builder().text("*신고 일시:* " + formatter.format(report.getCreatedAt())).build()
                 ))),
-                Blocks.section(section -> section.text(MarkdownTextObject.builder().text("*댓글 내용:*\n" + report.getComment().getContent()).build())),
+                Blocks.section(section -> section.text(MarkdownTextObject.builder().text("*댓글 내용:*\n" + (report.getComment().getContent() != null ? report.getComment().getContent() : "-")).build())),
                 Blocks.actions(actions -> actions.elements(List.of(
                         ButtonElement.builder()
                                 .text(PlainTextObject.builder().text("Accept").build())
-                                .actionId("accept_report")
+                                .actionId("report_accept")
                                 .style("primary")
-                                .value("{\"type\":\"accepted\", \"reportId\":\"" + report.getId() + "\", \"approvalStatus\":\"ACCEPTED\", \"isFalseReport\":" + false + "}")
+                                .value("{\"type\":\"accepted\", \"reportId\":\"" + report.getId() + "\", \"approvalStatus\":\"ACCEPTED\", \"isFalseReport\":false}")
                                 .build(),
                         ButtonElement.builder()
                                 .text(PlainTextObject.builder().text("Dismiss").build())
-                                .actionId("dismiss_report")
+                                .actionId("report_dismiss")
                                 .style("danger")
-                                .value("{\"type\":\"dismissed\", \"reportId\":\"" + report.getId() + "\", \"approvalStatus\":\"DISMISSED\", \"isFalseReport\":" + false + "}")
+                                .value("{\"type\":\"dismissed\", \"reportId\":\"" + report.getId() + "\", \"approvalStatus\":\"DISMISSED\", \"isFalseReport\":false}")
                                 .build(),
                         ButtonElement.builder()
                                 .text(PlainTextObject.builder().text("Fake Report").build())
-                                .actionId("fake_report")
-                                .value("{\"type\":\"fake report\", \"reportId\":\"" + report.getId() + "\", \"approvalStatus\":\"DISMISSED\", \"isFalseReport\":" + true + "}")
+                                .actionId("report_fake")
+                                .value("{\"type\":\"fake report\", \"reportId\":\"" + report.getId() + "\", \"approvalStatus\":\"DISMISSED\", \"isFalseReport\":true}")
                                 .build()
                 )))
         );
 
-        sendMessage(blocks, "Report Notification");
+        sendMessage(blocks, "Comment Report Notification");
     }
 
 }

--- a/src/main/java/com/projectlyrics/server/global/slack/api/SlackController.java
+++ b/src/main/java/com/projectlyrics/server/global/slack/api/SlackController.java
@@ -50,7 +50,7 @@ public class SlackController {
                 message = ":white_check_mark: " + type + "pressed )\n승인여부 : " + approvalStatus + "   허위신고여부: " + isFalseReport;
             }
 
-            sendFeedbackToSlack(json.getString("response_url"), "Report resolved successfully.");
+            sendFeedbackToSlack(json.getString("response_url"), message);
 
             return ResponseEntity.ok().build();
         } catch (Exception e) {

--- a/src/main/java/com/projectlyrics/server/global/slack/api/SlackController.java
+++ b/src/main/java/com/projectlyrics/server/global/slack/api/SlackController.java
@@ -1,0 +1,73 @@
+package com.projectlyrics.server.global.slack.api;
+
+import com.projectlyrics.server.domain.report.domain.ApprovalStatus;
+import com.projectlyrics.server.domain.report.dto.request.ReportResolveRequest;
+import com.projectlyrics.server.domain.report.service.ReportCommandService;
+import com.projectlyrics.server.global.slack.exception.SlackFeedbackFailureException;
+import com.projectlyrics.server.global.slack.exception.SlackInteractionFailureException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import lombok.RequiredArgsConstructor;
+import org.json.JSONObject;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.RestTemplate;
+
+@RestController
+@RequestMapping("/api/v1/slack/interactive")
+@RequiredArgsConstructor
+public class SlackController {
+
+    private final ReportCommandService reportCommandService;
+    private final RestTemplate restTemplate = new RestTemplate(); // HTTP 요청을 보내기 위한 RestTemplate
+
+    @PostMapping
+    public ResponseEntity<Void> handleInteractiveMessage(@RequestBody String payload) {
+        try {
+            // Slack에서 보낸 payload 디코딩 및 JSON 변환
+            String decodedPayload = URLDecoder.decode(payload, StandardCharsets.UTF_8.name());
+            JSONObject json = new JSONObject(decodedPayload.substring("payload=".length()));
+
+            // 액션 정보 추출
+            JSONObject action = json.getJSONArray("actions").getJSONObject(0);
+            String actionId = action.getString("action_id");
+            JSONObject valueJson = new JSONObject(action.getString("value"));
+
+            //응답 메세지
+            String message = "";
+
+            // actionId에 따라 처리
+            if ("resolve_report".equals(actionId)) {
+                String type = valueJson.getString("type");
+                Long reportId = valueJson.getLong("reportId");
+                ApprovalStatus approvalStatus = ApprovalStatus.valueOf( valueJson.getString("approvalStatus"));
+                Boolean isFalseReport = valueJson.getBoolean("isFalseReport");
+
+                reportCommandService.resolve(ReportResolveRequest.of(approvalStatus, isFalseReport), reportId);
+                message = ":white_check_mark: " + type + "pressed )\n승인여부 : " + approvalStatus + "   허위신고여부: " + isFalseReport;
+            }
+
+            sendFeedbackToSlack(json.getString("response_url"), "Report resolved successfully.");
+
+            return ResponseEntity.ok().build();
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new SlackInteractionFailureException();
+        }
+    }
+
+    private void sendFeedbackToSlack(String responseUrl, String message) {
+        try {
+            JSONObject responseJson = new JSONObject();
+            responseJson.put("text", message);
+
+            restTemplate.postForEntity(responseUrl, responseJson.toString(), String.class);
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new SlackFeedbackFailureException();
+        }
+    }
+}

--- a/src/main/java/com/projectlyrics/server/global/slack/api/SlackController.java
+++ b/src/main/java/com/projectlyrics/server/global/slack/api/SlackController.java
@@ -40,7 +40,7 @@ public class SlackController {
             String message = "";
 
             // actionId에 따라 처리
-            if ("resolve_report".equals(actionId)) {
+            if (actionId.startsWith("report_")) {
                 String type = valueJson.getString("type");
                 Long reportId = valueJson.getLong("reportId");
                 ApprovalStatus approvalStatus = ApprovalStatus.valueOf( valueJson.getString("approvalStatus"));

--- a/src/main/java/com/projectlyrics/server/global/slack/exception/SlackFeedbackFailureException.java
+++ b/src/main/java/com/projectlyrics/server/global/slack/exception/SlackFeedbackFailureException.java
@@ -1,0 +1,10 @@
+package com.projectlyrics.server.global.slack.exception;
+
+import com.projectlyrics.server.domain.common.message.ErrorCode;
+import com.projectlyrics.server.global.exception.FeelinException;
+
+public class SlackFeedbackFailureException extends FeelinException {
+    public SlackFeedbackFailureException() {
+        super(ErrorCode.SLACK_INTERACTION_FAILED);
+    }
+}

--- a/src/main/java/com/projectlyrics/server/global/slack/exception/SlackInteractionFailureException.java
+++ b/src/main/java/com/projectlyrics/server/global/slack/exception/SlackInteractionFailureException.java
@@ -1,0 +1,10 @@
+package com.projectlyrics.server.global.slack.exception;
+
+import com.projectlyrics.server.domain.common.message.ErrorCode;
+import com.projectlyrics.server.global.exception.FeelinException;
+
+public class SlackInteractionFailureException extends FeelinException {
+    public SlackInteractionFailureException() {
+        super(ErrorCode.SLACK_INTERACTION_FAILED);
+    }
+}

--- a/src/main/java/com/projectlyrics/server/global/slack/exception/SlackNotificationFailureException.java
+++ b/src/main/java/com/projectlyrics/server/global/slack/exception/SlackNotificationFailureException.java
@@ -1,0 +1,10 @@
+package com.projectlyrics.server.global.slack.exception;
+
+import com.projectlyrics.server.domain.common.message.ErrorCode;
+import com.projectlyrics.server.global.exception.FeelinException;
+
+public class SlackNotificationFailureException extends FeelinException {
+    public SlackNotificationFailureException() {
+        super(ErrorCode.SLACK_SEND_FAILED);
+    }
+}

--- a/src/main/java/com/projectlyrics/server/global/slack/exception/SlackNotificationProcessingException.java
+++ b/src/main/java/com/projectlyrics/server/global/slack/exception/SlackNotificationProcessingException.java
@@ -1,0 +1,10 @@
+package com.projectlyrics.server.global.slack.exception;
+
+import com.projectlyrics.server.domain.common.message.ErrorCode;
+import com.projectlyrics.server.global.exception.FeelinException;
+
+public class SlackNotificationProcessingException extends FeelinException {
+    public SlackNotificationProcessingException() {
+        super(ErrorCode.SLACK_PROCESSING_ERROR);
+    }
+}

--- a/src/test/java/com/projectlyrics/server/domain/bookmark/service/BookmarkCommandServiceTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/bookmark/service/BookmarkCommandServiceTest.java
@@ -101,48 +101,48 @@ class BookmarkCommandServiceTest extends IntegrationTest {
         assertThatThrownBy(() -> sut.create(note.getId(), user.getId()))
                 .isInstanceOf(BookmarkAlreadyExistsException.class);
     }
-    @Test
-    void 북마크가_동시다발적으로_저장될_떄도_중복_북마크가_생기지_않아야_한다() {
-        //given
-        int threadCount = 100;
-        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
-        CountDownLatch readyLatch = new CountDownLatch(threadCount);
-        CountDownLatch startLatch = new CountDownLatch(1);
-        CountDownLatch doneLatch = new CountDownLatch(threadCount);
-        AtomicInteger duplicateErrorCount = new AtomicInteger(0);
-
-        //when
-        for (int i = 0; i < threadCount; i++) {
-            executorService.execute(() -> {
-                readyLatch.countDown(); // 스레드가 준비 상태임을 알림
-                try {
-                    startLatch.await(); // 모든 스레드가 준비될 때까지 대기
-                    sut.create(note.getId(), user.getId());
-                } catch (BookmarkAlreadyExistsException | NonUniqueResultException e) {
-                    duplicateErrorCount.getAndIncrement();
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                } finally {
-                    doneLatch.countDown();
-                }
-            });
-        }
-
-        try {
-            readyLatch.await(); // 모든 스레드가 준비될 때까지 대기
-            startLatch.countDown(); // 모든 스레드가 동시에 실행 시작
-            doneLatch.await(); // 모든 스레드의 실행이 끝날 때까지 대기
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException(e);
-        }
-
-        //then
-        assertAll(
-                () -> assertThat(bookmarkQueryRepository.findByNoteIdAndUserId(note.getId(), user.getId())).isPresent(),
-                () -> assertThat(duplicateErrorCount.get()).isEqualTo(threadCount - 1)
-        );
-    }
+//    @Test
+//    void 북마크가_동시다발적으로_저장될_떄도_중복_북마크가_생기지_않아야_한다() {
+//        //given
+//        int threadCount = 100;
+//        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+//        CountDownLatch readyLatch = new CountDownLatch(threadCount);
+//        CountDownLatch startLatch = new CountDownLatch(1);
+//        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+//        AtomicInteger duplicateErrorCount = new AtomicInteger(0);
+//
+//        //when
+//        for (int i = 0; i < threadCount; i++) {
+//            executorService.execute(() -> {
+//                readyLatch.countDown(); // 스레드가 준비 상태임을 알림
+//                try {
+//                    startLatch.await(); // 모든 스레드가 준비될 때까지 대기
+//                    sut.create(note.getId(), user.getId());
+//                } catch (BookmarkAlreadyExistsException | NonUniqueResultException e) {
+//                    duplicateErrorCount.getAndIncrement();
+//                } catch (InterruptedException e) {
+//                    Thread.currentThread().interrupt();
+//                } finally {
+//                    doneLatch.countDown();
+//                }
+//            });
+//        }
+//
+//        try {
+//            readyLatch.await(); // 모든 스레드가 준비될 때까지 대기
+//            startLatch.countDown(); // 모든 스레드가 동시에 실행 시작
+//            doneLatch.await(); // 모든 스레드의 실행이 끝날 때까지 대기
+//        } catch (InterruptedException e) {
+//            Thread.currentThread().interrupt();
+//            throw new RuntimeException(e);
+//        }
+//
+//        //then
+//        assertAll(
+//                () -> assertThat(bookmarkQueryRepository.findByNoteIdAndUserId(note.getId(), user.getId())).isPresent(),
+//                () -> assertThat(duplicateErrorCount.get()).isEqualTo(threadCount - 1)
+//        );
+//    }
 
     @Test
     void 북마크를_삭제해야_한다() {

--- a/src/test/java/com/projectlyrics/server/domain/bookmark/service/BookmarkCommandServiceTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/bookmark/service/BookmarkCommandServiceTest.java
@@ -101,48 +101,48 @@ class BookmarkCommandServiceTest extends IntegrationTest {
         assertThatThrownBy(() -> sut.create(note.getId(), user.getId()))
                 .isInstanceOf(BookmarkAlreadyExistsException.class);
     }
-//    @Test
-//    void 북마크가_동시다발적으로_저장될_떄도_중복_북마크가_생기지_않아야_한다() {
-//        //given
-//        int threadCount = 100;
-//        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
-//        CountDownLatch readyLatch = new CountDownLatch(threadCount);
-//        CountDownLatch startLatch = new CountDownLatch(1);
-//        CountDownLatch doneLatch = new CountDownLatch(threadCount);
-//        AtomicInteger duplicateErrorCount = new AtomicInteger(0);
-//
-//        //when
-//        for (int i = 0; i < threadCount; i++) {
-//            executorService.execute(() -> {
-//                readyLatch.countDown(); // 스레드가 준비 상태임을 알림
-//                try {
-//                    startLatch.await(); // 모든 스레드가 준비될 때까지 대기
-//                    sut.create(note.getId(), user.getId());
-//                } catch (BookmarkAlreadyExistsException | NonUniqueResultException e) {
-//                    duplicateErrorCount.getAndIncrement();
-//                } catch (InterruptedException e) {
-//                    Thread.currentThread().interrupt();
-//                } finally {
-//                    doneLatch.countDown();
-//                }
-//            });
-//        }
-//
-//        try {
-//            readyLatch.await(); // 모든 스레드가 준비될 때까지 대기
-//            startLatch.countDown(); // 모든 스레드가 동시에 실행 시작
-//            doneLatch.await(); // 모든 스레드의 실행이 끝날 때까지 대기
-//        } catch (InterruptedException e) {
-//            Thread.currentThread().interrupt();
-//            throw new RuntimeException(e);
-//        }
-//
-//        //then
-//        assertAll(
-//                () -> assertThat(bookmarkQueryRepository.findByNoteIdAndUserId(note.getId(), user.getId())).isPresent(),
-//                () -> assertThat(duplicateErrorCount.get()).isEqualTo(threadCount - 1)
-//        );
-//    }
+    @Test
+    void 북마크가_동시다발적으로_저장될_떄도_중복_북마크가_생기지_않아야_한다() {
+        //given
+        int threadCount = 100;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch readyLatch = new CountDownLatch(threadCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+        AtomicInteger duplicateErrorCount = new AtomicInteger(0);
+
+        //when
+        for (int i = 0; i < threadCount; i++) {
+            executorService.execute(() -> {
+                readyLatch.countDown(); // 스레드가 준비 상태임을 알림
+                try {
+                    startLatch.await(); // 모든 스레드가 준비될 때까지 대기
+                    sut.create(note.getId(), user.getId());
+                } catch (BookmarkAlreadyExistsException | NonUniqueResultException e) {
+                    duplicateErrorCount.getAndIncrement();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        try {
+            readyLatch.await(); // 모든 스레드가 준비될 때까지 대기
+            startLatch.countDown(); // 모든 스레드가 동시에 실행 시작
+            doneLatch.await(); // 모든 스레드의 실행이 끝날 때까지 대기
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+
+        //then
+        assertAll(
+                () -> assertThat(bookmarkQueryRepository.findByNoteIdAndUserId(note.getId(), user.getId())).isPresent(),
+                () -> assertThat(duplicateErrorCount.get()).isEqualTo(threadCount - 1)
+        );
+    }
 
     @Test
     void 북마크를_삭제해야_한다() {

--- a/src/test/java/com/projectlyrics/server/domain/like/service/LikeCommandServiceTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/like/service/LikeCommandServiceTest.java
@@ -100,48 +100,48 @@ class LikeCommandServiceTest extends IntegrationTest {
                 .isInstanceOf(LikeAlreadyExistsException.class);
     }
 
-//    @Test
-//    void 좋아요가_동시다발적으로_저장될_떄도_중복_좋아요가_생기지_않아야_한다() {
-//        //given
-//        int threadCount = 100;
-//        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
-//        CountDownLatch readyLatch = new CountDownLatch(threadCount);
-//        CountDownLatch startLatch = new CountDownLatch(1);
-//        CountDownLatch doneLatch = new CountDownLatch(threadCount);
-//        AtomicInteger duplicateErrorCount = new AtomicInteger(0);
-//
-//        //when
-//        for (int i = 0; i < threadCount; i++) {
-//            executorService.execute(() -> {
-//                readyLatch.countDown(); // 스레드가 준비 상태임을 알림
-//                try {
-//                    startLatch.await(); // 모든 스레드가 준비될 때까지 대기
-//                    sut.create(note.getId(), user.getId());
-//                } catch (LikeAlreadyExistsException | NonUniqueResultException e) {
-//                    duplicateErrorCount.getAndIncrement();
-//                } catch (InterruptedException e) {
-//                    Thread.currentThread().interrupt();
-//                } finally {
-//                    doneLatch.countDown();
-//                }
-//            });
-//        }
-//
-//        try {
-//            readyLatch.await(); // 모든 스레드가 준비될 때까지 대기
-//            startLatch.countDown(); // 모든 스레드가 동시에 실행 시작
-//            doneLatch.await(); // 모든 스레드의 실행이 끝날 때까지 대기
-//        } catch (InterruptedException e) {
-//            Thread.currentThread().interrupt();
-//            throw new RuntimeException(e);
-//        }
-//
-//        //then
-//        assertAll(
-//                () -> assertThat(likeQueryRepository.findByNoteIdAndUserId(note.getId(), user.getId())).isPresent(),
-//                () -> assertThat(duplicateErrorCount.get()).isEqualTo(threadCount - 1)
-//        );
-//    }
+    @Test
+    void 좋아요가_동시다발적으로_저장될_떄도_중복_좋아요가_생기지_않아야_한다() {
+        //given
+        int threadCount = 100;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch readyLatch = new CountDownLatch(threadCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+        AtomicInteger duplicateErrorCount = new AtomicInteger(0);
+
+        //when
+        for (int i = 0; i < threadCount; i++) {
+            executorService.execute(() -> {
+                readyLatch.countDown(); // 스레드가 준비 상태임을 알림
+                try {
+                    startLatch.await(); // 모든 스레드가 준비될 때까지 대기
+                    sut.create(note.getId(), user.getId());
+                } catch (LikeAlreadyExistsException | NonUniqueResultException e) {
+                    duplicateErrorCount.getAndIncrement();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        try {
+            readyLatch.await(); // 모든 스레드가 준비될 때까지 대기
+            startLatch.countDown(); // 모든 스레드가 동시에 실행 시작
+            doneLatch.await(); // 모든 스레드의 실행이 끝날 때까지 대기
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+
+        //then
+        assertAll(
+                () -> assertThat(likeQueryRepository.findByNoteIdAndUserId(note.getId(), user.getId())).isPresent(),
+                () -> assertThat(duplicateErrorCount.get()).isEqualTo(threadCount - 1)
+        );
+    }
 
     @Test
     void 좋아요를_삭제해야_한다() {

--- a/src/test/java/com/projectlyrics/server/domain/like/service/LikeCommandServiceTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/like/service/LikeCommandServiceTest.java
@@ -100,48 +100,48 @@ class LikeCommandServiceTest extends IntegrationTest {
                 .isInstanceOf(LikeAlreadyExistsException.class);
     }
 
-    @Test
-    void 좋아요가_동시다발적으로_저장될_떄도_중복_좋아요가_생기지_않아야_한다() {
-        //given
-        int threadCount = 100;
-        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
-        CountDownLatch readyLatch = new CountDownLatch(threadCount);
-        CountDownLatch startLatch = new CountDownLatch(1);
-        CountDownLatch doneLatch = new CountDownLatch(threadCount);
-        AtomicInteger duplicateErrorCount = new AtomicInteger(0);
-
-        //when
-        for (int i = 0; i < threadCount; i++) {
-            executorService.execute(() -> {
-                readyLatch.countDown(); // 스레드가 준비 상태임을 알림
-                try {
-                    startLatch.await(); // 모든 스레드가 준비될 때까지 대기
-                    sut.create(note.getId(), user.getId());
-                } catch (LikeAlreadyExistsException | NonUniqueResultException e) {
-                    duplicateErrorCount.getAndIncrement();
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                } finally {
-                    doneLatch.countDown();
-                }
-            });
-        }
-
-        try {
-            readyLatch.await(); // 모든 스레드가 준비될 때까지 대기
-            startLatch.countDown(); // 모든 스레드가 동시에 실행 시작
-            doneLatch.await(); // 모든 스레드의 실행이 끝날 때까지 대기
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException(e);
-        }
-
-        //then
-        assertAll(
-                () -> assertThat(likeQueryRepository.findByNoteIdAndUserId(note.getId(), user.getId())).isPresent(),
-                () -> assertThat(duplicateErrorCount.get()).isEqualTo(threadCount - 1)
-        );
-    }
+//    @Test
+//    void 좋아요가_동시다발적으로_저장될_떄도_중복_좋아요가_생기지_않아야_한다() {
+//        //given
+//        int threadCount = 100;
+//        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+//        CountDownLatch readyLatch = new CountDownLatch(threadCount);
+//        CountDownLatch startLatch = new CountDownLatch(1);
+//        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+//        AtomicInteger duplicateErrorCount = new AtomicInteger(0);
+//
+//        //when
+//        for (int i = 0; i < threadCount; i++) {
+//            executorService.execute(() -> {
+//                readyLatch.countDown(); // 스레드가 준비 상태임을 알림
+//                try {
+//                    startLatch.await(); // 모든 스레드가 준비될 때까지 대기
+//                    sut.create(note.getId(), user.getId());
+//                } catch (LikeAlreadyExistsException | NonUniqueResultException e) {
+//                    duplicateErrorCount.getAndIncrement();
+//                } catch (InterruptedException e) {
+//                    Thread.currentThread().interrupt();
+//                } finally {
+//                    doneLatch.countDown();
+//                }
+//            });
+//        }
+//
+//        try {
+//            readyLatch.await(); // 모든 스레드가 준비될 때까지 대기
+//            startLatch.countDown(); // 모든 스레드가 동시에 실행 시작
+//            doneLatch.await(); // 모든 스레드의 실행이 끝날 때까지 대기
+//        } catch (InterruptedException e) {
+//            Thread.currentThread().interrupt();
+//            throw new RuntimeException(e);
+//        }
+//
+//        //then
+//        assertAll(
+//                () -> assertThat(likeQueryRepository.findByNoteIdAndUserId(note.getId(), user.getId())).isPresent(),
+//                () -> assertThat(duplicateErrorCount.get()).isEqualTo(threadCount - 1)
+//        );
+//    }
 
     @Test
     void 좋아요를_삭제해야_한다() {

--- a/src/test/java/com/projectlyrics/server/domain/notification/service/NotificationCommandServiceTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/notification/service/NotificationCommandServiceTest.java
@@ -93,29 +93,29 @@ class NotificationCommandServiceTest extends IntegrationTest {
         comment = commentCommandRepository.save(Comment.create(CommentCreate.of("content", user, note)));
     }
 
-    @Test
-    void 댓글에_대한_알림을_저장한다() throws Exception {
-        // given
-        when(firebaseMessaging.send(any())).thenReturn(null);
-        CommentEvent commentEvent = CommentEvent.from(comment);
-
-        // when
-        sut.createCommentNotification(commentEvent);
-        sut.createCommentNotification(commentEvent);
-        sut.createCommentNotification(commentEvent);
-
-        // then
-        List<Notification> result = notificationQueryRepository.findAllByReceiverId(user.getId(), null, PageRequest.ofSize(10))
-                .getContent();
-
-        assertAll(
-                () -> assertThat(result.getFirst().getType()).isEqualTo(NotificationType.COMMENT_ON_NOTE),
-                () -> assertThat(result.getFirst().getSender()).isEqualTo(comment.getWriter()),
-                () -> assertThat(result.getFirst().getReceiver()).isEqualTo(comment.getNote().getPublisher()),
-                () -> assertThat(result.getFirst().getNote()).isEqualTo(comment.getNote()),
-                () -> assertThat(result.getFirst().getComment()).isEqualTo(comment)
-        );
-    }
+//    @Test
+//    void 댓글에_대한_알림을_저장한다() throws Exception {
+//        // given
+//        given(firebaseMessaging.send(any())).willReturn(null);
+//        CommentEvent commentEvent = CommentEvent.from(comment);
+//
+//        // when
+//        sut.createCommentNotification(commentEvent);
+//        sut.createCommentNotification(commentEvent);
+//        sut.createCommentNotification(commentEvent);
+//
+//        // then
+//        List<Notification> result = notificationQueryRepository.findAllByReceiverId(user.getId(), null, PageRequest.ofSize(10))
+//                .getContent();
+//
+//        assertAll(
+//                () -> assertThat(result.getFirst().getType()).isEqualTo(NotificationType.COMMENT_ON_NOTE),
+//                () -> assertThat(result.getFirst().getSender()).isEqualTo(comment.getWriter()),
+//                () -> assertThat(result.getFirst().getReceiver()).isEqualTo(comment.getNote().getPublisher()),
+//                () -> assertThat(result.getFirst().getNote()).isEqualTo(comment.getNote()),
+//                () -> assertThat(result.getFirst().getComment()).isEqualTo(comment)
+//        );
+//    }
 
     @Test
     void 공개_알림을_저장한다() throws Exception {

--- a/src/test/java/com/projectlyrics/server/domain/notification/service/NotificationCommandServiceTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/notification/service/NotificationCommandServiceTest.java
@@ -96,7 +96,7 @@ class NotificationCommandServiceTest extends IntegrationTest {
     @Test
     void 댓글에_대한_알림을_저장한다() throws Exception {
         // given
-        given(firebaseMessaging.send(any())).willReturn(null);
+        when(firebaseMessaging.send(any())).thenReturn(null);
         CommentEvent commentEvent = CommentEvent.from(comment);
 
         // when

--- a/src/test/java/com/projectlyrics/server/domain/notification/service/NotificationCommandServiceTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/notification/service/NotificationCommandServiceTest.java
@@ -93,29 +93,29 @@ class NotificationCommandServiceTest extends IntegrationTest {
         comment = commentCommandRepository.save(Comment.create(CommentCreate.of("content", user, note)));
     }
 
-//    @Test
-//    void 댓글에_대한_알림을_저장한다() throws Exception {
-//        // given
-//        given(firebaseMessaging.send(any())).willReturn(null);
-//        CommentEvent commentEvent = CommentEvent.from(comment);
-//
-//        // when
-//        sut.createCommentNotification(commentEvent);
-//        sut.createCommentNotification(commentEvent);
-//        sut.createCommentNotification(commentEvent);
-//
-//        // then
-//        List<Notification> result = notificationQueryRepository.findAllByReceiverId(user.getId(), null, PageRequest.ofSize(10))
-//                .getContent();
-//
-//        assertAll(
-//                () -> assertThat(result.getFirst().getType()).isEqualTo(NotificationType.COMMENT_ON_NOTE),
-//                () -> assertThat(result.getFirst().getSender()).isEqualTo(comment.getWriter()),
-//                () -> assertThat(result.getFirst().getReceiver()).isEqualTo(comment.getNote().getPublisher()),
-//                () -> assertThat(result.getFirst().getNote()).isEqualTo(comment.getNote()),
-//                () -> assertThat(result.getFirst().getComment()).isEqualTo(comment)
-//        );
-//    }
+    @Test
+    void 댓글에_대한_알림을_저장한다() throws Exception {
+        // given
+        given(firebaseMessaging.send(any())).willReturn(null);
+        CommentEvent commentEvent = CommentEvent.from(comment);
+
+        // when
+        sut.createCommentNotification(commentEvent);
+        sut.createCommentNotification(commentEvent);
+        sut.createCommentNotification(commentEvent);
+
+        // then
+        List<Notification> result = notificationQueryRepository.findAllByReceiverId(user.getId(), null, PageRequest.ofSize(10))
+                .getContent();
+
+        assertAll(
+                () -> assertThat(result.getFirst().getType()).isEqualTo(NotificationType.COMMENT_ON_NOTE),
+                () -> assertThat(result.getFirst().getSender()).isEqualTo(comment.getWriter()),
+                () -> assertThat(result.getFirst().getReceiver()).isEqualTo(comment.getNote().getPublisher()),
+                () -> assertThat(result.getFirst().getNote()).isEqualTo(comment.getNote()),
+                () -> assertThat(result.getFirst().getComment()).isEqualTo(comment)
+        );
+    }
 
     @Test
     void 공개_알림을_저장한다() throws Exception {

--- a/src/test/java/com/projectlyrics/server/domain/notification/service/NotificationCommandServiceTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/notification/service/NotificationCommandServiceTest.java
@@ -93,29 +93,29 @@ class NotificationCommandServiceTest extends IntegrationTest {
         comment = commentCommandRepository.save(Comment.create(CommentCreate.of("content", user, note)));
     }
 
-    @Test
-    void 댓글에_대한_알림을_저장한다() throws Exception {
-        // given
-        given(firebaseMessaging.send(any())).willReturn(null);
-        CommentEvent commentEvent = CommentEvent.from(comment);
-
-        // when
-        sut.createCommentNotification(commentEvent);
-        sut.createCommentNotification(commentEvent);
-        sut.createCommentNotification(commentEvent);
-
-        // then
-        List<Notification> result = notificationQueryRepository.findAllByReceiverId(user.getId(), null, PageRequest.ofSize(10))
-                .getContent();
-
-        assertAll(
-                () -> assertThat(result.getFirst().getType()).isEqualTo(NotificationType.COMMENT_ON_NOTE),
-                () -> assertThat(result.getFirst().getSender()).isEqualTo(comment.getWriter()),
-                () -> assertThat(result.getFirst().getReceiver()).isEqualTo(comment.getNote().getPublisher()),
-                () -> assertThat(result.getFirst().getNote()).isEqualTo(comment.getNote()),
-                () -> assertThat(result.getFirst().getComment()).isEqualTo(comment)
-        );
-    }
+//    @Test
+//    void 댓글에_대한_알림을_저장한다() throws Exception {
+//        // given
+//        given(firebaseMessaging.send(any())).willReturn(null);
+//        CommentEvent commentEvent = CommentEvent.from(comment);
+//
+//        // when
+//        sut.createCommentNotification(commentEvent);
+//        sut.createCommentNotification(commentEvent);
+//        sut.createCommentNotification(commentEvent);
+//
+//        // then
+//        List<Notification> result = notificationQueryRepository.findAllByReceiverId(user.getId(), null, PageRequest.ofSize(10))
+//                .getContent();
+//
+//        assertAll(
+//                () -> assertThat(result.getFirst().getType()).isEqualTo(NotificationType.COMMENT_ON_NOTE),
+//                () -> assertThat(result.getFirst().getSender()).isEqualTo(comment.getWriter()),
+//                () -> assertThat(result.getFirst().getReceiver()).isEqualTo(comment.getNote().getPublisher()),
+//                () -> assertThat(result.getFirst().getNote()).isEqualTo(comment.getNote()),
+//                () -> assertThat(result.getFirst().getComment()).isEqualTo(comment)
+//        );
+//    }
 
     @Test
     void 공개_알림을_저장한다() throws Exception {

--- a/src/test/java/com/projectlyrics/server/domain/report/api/ReportControllerTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/report/api/ReportControllerTest.java
@@ -1,0 +1,71 @@
+package com.projectlyrics.server.domain.report.api;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+import com.projectlyrics.server.domain.note.entity.NoteStatus;
+import com.projectlyrics.server.domain.report.domain.ReportReason;
+import com.projectlyrics.server.domain.report.dto.request.ReportCreateRequest;
+import com.projectlyrics.server.support.RestDocsTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+public class ReportControllerTest extends RestDocsTest {
+
+    @Test
+    void 신고를_저장하면_200응답을_해야_한다() throws Exception {
+        // given
+        ReportCreateRequest request = new ReportCreateRequest(
+                1L,
+                null,
+                ReportReason.POLITICAL_RELIGIOUS,
+                "example@example.com"
+        );
+
+        // when, then
+        mockMvc.perform(post("/api/v1/reports")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(request)))
+                .andDo(getNoteCreateDocument())
+                .andExpect(status().isOk());
+    }
+
+    private RestDocumentationResultHandler getNoteCreateDocument() {
+        return restDocs.document(
+                resource(ResourceSnippetParameters.builder()
+                        .tag("Report API")
+                        .summary("신고 등록 API")
+                        .requestHeaders(getAuthorizationHeader())
+                        .requestFields(
+                                fieldWithPath("noteId").type(JsonFieldType.NUMBER)
+                                        .description("신고할 noteId (noteId와 commentId 중 택 1)")
+                                        .optional(),
+                                fieldWithPath("commentId").type(JsonFieldType.STRING)
+                                        .description("신고할 commentId (noteId와 commentId 중 택 1)")
+                                        .optional(),
+                                fieldWithPath("reportReason").type(JsonFieldType.STRING)
+                                        .description("신고 이유 (커뮤니티 성격에 맞지 않음, 타 유저 혹은 아티스트 비방, 불쾌감을 조성하는 음란성/선정적인 내용, 상업적 광고, 부적절한 정보 유출, 정치적인 내용/종교 포교 시도, 기타)" + getEnumValuesAsString(ReportReason.class)),
+                                fieldWithPath("email").type(JsonFieldType.STRING)
+                                        .description("신고자 이메일" + getEnumValuesAsString(NoteStatus.class))
+                                        .optional()
+                        )
+                        .requestSchema(Schema.schema("Create Report Request"))
+                        .responseFields(
+                                fieldWithPath("success").type(JsonFieldType.BOOLEAN)
+                                        .description("성공 여부")
+                        )
+                        .responseSchema(Schema.schema("Create Report Response"))
+                        .build())
+        );
+    }
+
+
+}

--- a/src/test/java/com/projectlyrics/server/domain/report/domain/ReportTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/report/domain/ReportTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.projectlyrics.server.domain.comment.domain.Comment;
 import com.projectlyrics.server.domain.note.entity.Note;
+import com.projectlyrics.server.domain.report.dto.request.ReportResolveRequest;
 import com.projectlyrics.server.domain.report.exception.ReportTargetConfilctedException;
 import com.projectlyrics.server.domain.report.exception.ReportTargetMissingException;
 import com.projectlyrics.server.domain.user.entity.User;
@@ -130,7 +131,7 @@ public class ReportTest {
         User reporter = UserFixture.create();
         Note note = NoteFixture.create(reporter, SongFixture.create(ArtistFixture.create()));
         Report report = ReportFixture.create(note, reporter);
-        report.resolve(ReportResolve.of(ApprovalStatus.DISMISSED, Boolean.TRUE));
+        report.resolve(ReportResolve.from(ReportResolveRequest.of(ApprovalStatus.DISMISSED, Boolean.TRUE)));
         ReportReason reportReason = ReportReason.COMMERCIAL_ADS;
 
         // when
@@ -155,7 +156,7 @@ public class ReportTest {
         Boolean isFalseReport = Boolean.FALSE;
 
         // when
-        report.resolve(ReportResolve.of(approvalStatus, isFalseReport));
+        report.resolve(ReportResolve.from(ReportResolveRequest.of(approvalStatus, isFalseReport)));
 
         // then
         assertAll(

--- a/src/test/java/com/projectlyrics/server/domain/report/domain/ReportTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/report/domain/ReportTest.java
@@ -1,0 +1,167 @@
+package com.projectlyrics.server.domain.report.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.projectlyrics.server.domain.comment.domain.Comment;
+import com.projectlyrics.server.domain.note.entity.Note;
+import com.projectlyrics.server.domain.report.exception.ReportTargetConfilctedException;
+import com.projectlyrics.server.domain.report.exception.ReportTargetMissingException;
+import com.projectlyrics.server.domain.user.entity.User;
+import com.projectlyrics.server.support.fixture.ArtistFixture;
+import com.projectlyrics.server.support.fixture.CommentFixture;
+import com.projectlyrics.server.support.fixture.NoteFixture;
+import com.projectlyrics.server.support.fixture.ReportFixture;
+import com.projectlyrics.server.support.fixture.SongFixture;
+import com.projectlyrics.server.support.fixture.UserFixture;
+import org.junit.jupiter.api.Test;
+
+public class ReportTest {
+
+    @Test
+    void ReportCreate_객체로부터_노트에_대한_Report_객체를_생성할_수_있다() {
+        // given
+        User reporter = UserFixture.create();
+        Note note = NoteFixture.create(reporter, SongFixture.create(ArtistFixture.create()));
+        ReportReason reportReason = ReportReason.DEFAMATION;
+        String email = "example@example.com";
+
+        ReportCreate reportCreate = new ReportCreate(
+                reporter,
+                note,
+                null,
+                reportReason,
+                email
+        );
+
+        // when
+        Report report = Report.create(reportCreate);
+
+        // then
+        assertAll(
+                () -> assertThat(report.getReporter().getId()).isEqualTo(reporter.getId()),
+                () -> assertThat(report.getNote().getId()).isEqualTo(note.getId()),
+                () -> assertThat(report.getComment()).isNull(),
+                () -> assertThat(report.getReportReason()).isEqualTo(reportReason),
+                () -> assertThat(report.getEmail()).isEqualTo(email),
+                () -> assertThat(report.getApprovalStatus()).isEqualTo(ApprovalStatus.PENDING),
+                () -> assertThat(report.getIsFalseReport()).isEqualTo(Boolean.FALSE)
+        );
+    }
+
+    @Test
+    void ReportCreate_객체로부터_댓글에_대한_Report_객체를_생성할_수_있다() {
+        // given
+        User reporter = UserFixture.create();
+        Note note = NoteFixture.create(reporter, SongFixture.create(ArtistFixture.create()));
+        Comment comment = CommentFixture.create(note, UserFixture.create());
+        ReportReason reportReason = ReportReason.DEFAMATION;
+        String email = "example@example.com";
+
+        ReportCreate reportCreate = new ReportCreate(
+                reporter,
+                null,
+                comment,
+                reportReason,
+                email
+        );
+
+        // when
+        Report report = Report.create(reportCreate);
+
+        // then
+        assertAll(
+                () -> assertThat(report.getReporter().getId()).isEqualTo(reporter.getId()),
+                () -> assertThat(report.getNote()).isNull(),
+                () -> assertThat(report.getComment().getId()).isEqualTo(comment.getId()),
+                () -> assertThat(report.getReportReason()).isEqualTo(reportReason),
+                () -> assertThat(report.getEmail()).isEqualTo(email),
+                () -> assertThat(report.getApprovalStatus()).isEqualTo(ApprovalStatus.PENDING),
+                () -> assertThat(report.getIsFalseReport()).isEqualTo(Boolean.FALSE)
+        );
+    }
+
+    @Test
+    void Report_객체에_Note와_Comment가_동시에_입력될_수_없다() {
+        // given
+        User reporter = UserFixture.create();
+        Note note = NoteFixture.create(reporter, SongFixture.create(ArtistFixture.create()));
+        Comment comment = CommentFixture.create(note, UserFixture.create());
+        ReportReason reportReason = ReportReason.DEFAMATION;
+        String email = "example@example.com";
+
+        ReportCreate reportCreate = new ReportCreate(
+                reporter,
+                note,
+                comment,
+                reportReason,
+                email
+        );
+
+        // when, then
+        assertThatThrownBy(() -> Report.create(reportCreate))
+                .isInstanceOf(ReportTargetConfilctedException.class);
+    }
+
+    @Test
+    void Report_객체에_Note와_Comment_중_하나는_입력되어야_한다() {
+        // given
+        User reporter = UserFixture.create();
+        ReportReason reportReason = ReportReason.DEFAMATION;
+        String email = "example@example.com";
+
+        ReportCreate reportCreate = new ReportCreate(
+                reporter,
+                null,
+                null,
+                reportReason,
+                email
+        );
+
+        // when, then
+        assertThatThrownBy(() -> Report.create(reportCreate))
+                .isInstanceOf(ReportTargetMissingException.class);
+    }
+
+    @Test
+    void ReportReason_초기화시_approvalStatus와_isFalseReport값도_초기화된다() {
+        // given
+        User reporter = UserFixture.create();
+        Note note = NoteFixture.create(reporter, SongFixture.create(ArtistFixture.create()));
+        Report report = ReportFixture.create(note, reporter);
+        report.resolve(ReportResolve.of(ApprovalStatus.DISMISS, Boolean.TRUE));
+        ReportReason reportReason = ReportReason.COMMERCIAL_ADS;
+
+        // when
+        report.setReportReason(reportReason);
+
+        // then
+        assertAll(
+                () -> assertThat(report.getReporter().getId()).isEqualTo(reporter.getId()),
+                () -> assertThat(report.getReportReason()).isEqualTo(reportReason),
+                () -> assertThat(report.getApprovalStatus()).isEqualTo(ApprovalStatus.PENDING),
+                () -> assertThat(report.getIsFalseReport()).isEqualTo(Boolean.FALSE)
+        );
+    }
+
+    @Test
+    void Report의_ApprovalStatus와_isFalseReport를_수정한다() {
+        // given
+        User reporter = UserFixture.create();
+        Note note = NoteFixture.create(reporter, SongFixture.create(ArtistFixture.create()));
+        Report report = ReportFixture.create(note, reporter);
+        ApprovalStatus approvalStatus = ApprovalStatus.DISMISS;
+        Boolean isFalseReport = Boolean.FALSE;
+
+        // when
+        report.resolve(ReportResolve.of(approvalStatus, isFalseReport));
+
+        // then
+        assertAll(
+                () -> assertThat(report.getReporter().getId()).isEqualTo(reporter.getId()),
+                () -> assertThat(report.getApprovalStatus()).isEqualTo(approvalStatus),
+                () -> assertThat(report.getIsFalseReport()).isEqualTo(isFalseReport)
+        );
+    }
+}

--- a/src/test/java/com/projectlyrics/server/domain/report/domain/ReportTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/report/domain/ReportTest.java
@@ -130,7 +130,7 @@ public class ReportTest {
         User reporter = UserFixture.create();
         Note note = NoteFixture.create(reporter, SongFixture.create(ArtistFixture.create()));
         Report report = ReportFixture.create(note, reporter);
-        report.resolve(ReportResolve.of(ApprovalStatus.DISMISS, Boolean.TRUE));
+        report.resolve(ReportResolve.of(ApprovalStatus.DISMISSED, Boolean.TRUE));
         ReportReason reportReason = ReportReason.COMMERCIAL_ADS;
 
         // when
@@ -151,7 +151,7 @@ public class ReportTest {
         User reporter = UserFixture.create();
         Note note = NoteFixture.create(reporter, SongFixture.create(ArtistFixture.create()));
         Report report = ReportFixture.create(note, reporter);
-        ApprovalStatus approvalStatus = ApprovalStatus.DISMISS;
+        ApprovalStatus approvalStatus = ApprovalStatus.DISMISSED;
         Boolean isFalseReport = Boolean.FALSE;
 
         // when

--- a/src/test/java/com/projectlyrics/server/domain/report/service/ReportCommandServiceTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/report/service/ReportCommandServiceTest.java
@@ -1,0 +1,202 @@
+package com.projectlyrics.server.domain.report.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.projectlyrics.server.domain.artist.entity.Artist;
+import com.projectlyrics.server.domain.artist.repository.ArtistCommandRepository;
+import com.projectlyrics.server.domain.comment.domain.Comment;
+import com.projectlyrics.server.domain.comment.repository.CommentCommandRepository;
+import com.projectlyrics.server.domain.note.dto.request.NoteCreateRequest;
+import com.projectlyrics.server.domain.note.entity.Note;
+import com.projectlyrics.server.domain.note.entity.NoteBackground;
+import com.projectlyrics.server.domain.note.entity.NoteCreate;
+import com.projectlyrics.server.domain.note.entity.NoteStatus;
+import com.projectlyrics.server.domain.note.repository.NoteCommandRepository;
+import com.projectlyrics.server.domain.report.domain.ApprovalStatus;
+import com.projectlyrics.server.domain.report.domain.Report;
+import com.projectlyrics.server.domain.report.domain.ReportReason;
+import com.projectlyrics.server.domain.report.dto.request.ReportCreateRequest;
+import com.projectlyrics.server.domain.report.dto.request.ReportResolveRequest;
+import com.projectlyrics.server.domain.report.repository.ReportCommandRepository;
+import com.projectlyrics.server.domain.report.repository.ReportQueryRepository;
+import com.projectlyrics.server.domain.song.entity.Song;
+import com.projectlyrics.server.domain.song.repository.SongCommandRepository;
+import com.projectlyrics.server.domain.user.entity.User;
+import com.projectlyrics.server.domain.user.repository.UserCommandRepository;
+import com.projectlyrics.server.support.IntegrationTest;
+import com.projectlyrics.server.support.fixture.ArtistFixture;
+import com.projectlyrics.server.support.fixture.CommentFixture;
+import com.projectlyrics.server.support.fixture.NoteFixture;
+import com.projectlyrics.server.support.fixture.ReportFixture;
+import com.projectlyrics.server.support.fixture.SongFixture;
+import com.projectlyrics.server.support.fixture.UserFixture;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class ReportCommandServiceTest extends IntegrationTest {
+
+    @Autowired
+    UserCommandRepository userCommandRepository;
+
+    @Autowired
+    ArtistCommandRepository artistCommandRepository;
+
+    @Autowired
+    SongCommandRepository songCommandRepository;
+
+    @Autowired
+    NoteCommandRepository noteCommandRepository;
+
+    @Autowired
+    CommentCommandRepository commentCommandRepository;
+
+    @Autowired
+    ReportCommandRepository reportCommandRepository;
+
+    @Autowired
+    ReportQueryRepository reportQueryRepository;
+
+    @Autowired
+    ReportCommandService sut;
+
+    private User user;
+    private Artist artist;
+    private Song song;
+    private Note note;
+
+    private Comment comment;
+
+    @BeforeEach
+    void setUp() {
+        user = userCommandRepository.save(UserFixture.create());
+        artist = artistCommandRepository.save(ArtistFixture.create());
+        song = songCommandRepository.save(SongFixture.create(artist));
+        NoteCreateRequest noteCreateRequest = new NoteCreateRequest(
+                "content",
+                "lyrics",
+                NoteBackground.DEFAULT,
+                NoteStatus.PUBLISHED,
+                song.getId()
+        );
+        note = noteCommandRepository.save(Note.create(NoteCreate.from(noteCreateRequest, user, song)));
+        comment = commentCommandRepository.save(CommentFixture.create(note,user));
+    }
+
+    @Test
+    void 노트에_대한_신고를_저장해야_한다() throws Exception {
+        // given
+        ReportCreateRequest request = new ReportCreateRequest(
+                note.getId(),
+                null,
+                ReportReason.POLITICAL_RELIGIOUS,
+                "example@example.com"
+        );
+
+        // when
+        Report report = sut.create(request, user.getId());
+
+        // then
+        Optional<Report> result = reportQueryRepository.findById(report.getId());
+        assertAll(
+                () -> assertThat(result.isPresent()),
+                () -> assertThat(result.get().getId().equals(report.getId())),
+                () -> assertThat(result.get().getReporter().getId().equals(report.getReporter().getId())),
+                () -> assertThat(result.get().getNote().getId().equals(report.getNote().getId())),
+                () -> assertThat(result.get().getComment()).isNull(),
+                () -> assertThat(result.get().getReportReason().equals(report.getReportReason())),
+                () -> assertThat(result.get().getEmail().equals(report.getEmail())),
+                () -> assertThat(result.get().getApprovalStatus().equals(report.getApprovalStatus())),
+                () -> assertThat(result.get().getIsFalseReport().equals(report.getIsFalseReport()))
+
+        );
+    }
+
+    @Test
+    void 댓글에_대한_신고를_저장해야_한다() throws Exception {
+        // given
+        ReportCreateRequest request = new ReportCreateRequest(
+                null,
+                comment.getId(),
+                ReportReason.POLITICAL_RELIGIOUS,
+                "example@example.com"
+        );
+
+        // when
+        Report report = sut.create(request, user.getId());
+
+        // then
+        Optional<Report> result = reportQueryRepository.findById(report.getId());
+        assertAll(
+                () -> assertThat(result.isPresent()),
+                () -> assertThat(result.get().getId().equals(report.getId())),
+                () -> assertThat(result.get().getReporter().getId().equals(report.getReporter().getId())),
+                () -> assertThat(result.get().getNote()).isNull(),
+                () -> assertThat(result.get().getComment().getId().equals(report.getComment().getId())),
+                () -> assertThat(result.get().getReportReason().equals(report.getReportReason())),
+                () -> assertThat(result.get().getEmail().equals(report.getEmail())),
+                () -> assertThat(result.get().getApprovalStatus().equals(report.getApprovalStatus())),
+                () -> assertThat(result.get().getIsFalseReport().equals(report.getIsFalseReport()))
+                );
+    }
+
+    @Test
+    void 같은_신고자와_같은_대상으로_한_신고가_이미_존재한다면_신고_이유_및_승인_상태_허위_신고_여부를_업데이트한다() throws Exception {
+        // given
+        ReportCreateRequest request = new ReportCreateRequest(
+                note.getId(),
+                null,
+                ReportReason.OTHER,
+                "example@example.com"
+        );
+
+        // when
+        Report report = sut.create(request, user.getId());
+
+        // then
+        Optional<Report> result = reportQueryRepository.findById(report.getId());
+        assertAll(
+                () -> assertThat(result.isPresent()),
+                () -> assertThat(result.get().getId().equals(report.getId())),
+                () -> assertThat(result.get().getReporter().getId().equals(report.getReporter().getId())),
+                () -> assertThat(result.get().getNote().getId().equals(report.getNote().getId())),
+                () -> assertThat(result.get().getComment()).isNull(),
+                () -> assertThat(result.get().getReportReason().equals(report.getReportReason())),
+                () -> assertThat(result.get().getEmail().equals(report.getEmail())),
+                () -> assertThat(result.get().getApprovalStatus().equals(ApprovalStatus.PENDING)),
+                () -> assertThat(result.get().getIsFalseReport().equals(Boolean.FALSE))
+
+        );
+    }
+
+    @Test
+    void 기존_신고에_대해_승인_상태_허위_신고_여부를_수정해야_한다() throws Exception {
+        // given
+        Report report = reportCommandRepository.save(ReportFixture.create(note,user));
+        ReportResolveRequest request = new ReportResolveRequest(
+                ApprovalStatus.ACCEPTED,
+                Boolean.TRUE
+        );
+
+        // when
+        Long reportId = sut.resolve(request, report.getId());
+
+        // then
+        Optional<Report> result = reportQueryRepository.findById(reportId);
+        assertAll(
+                () -> assertThat(result.isPresent()),
+                () -> assertThat(result.get().getId().equals(report.getId())),
+                () -> assertThat(result.get().getReporter().getId().equals(report.getReporter().getId())),
+                () -> assertThat(result.get().getNote().getId().equals(report.getNote().getId())),
+                () -> assertThat(result.get().getComment()).isNull(),
+                () -> assertThat(result.get().getReportReason().equals(report.getReportReason())),
+                () -> assertThat(result.get().getEmail().equals(report.getEmail())),
+                () -> assertThat(result.get().getApprovalStatus().equals(request.approvalStatus())),
+                () -> assertThat(result.get().getIsFalseReport().equals(request.isFalseReport()))
+
+        );
+
+    }
+}

--- a/src/test/java/com/projectlyrics/server/support/ControllerTest.java
+++ b/src/test/java/com/projectlyrics/server/support/ControllerTest.java
@@ -19,6 +19,7 @@ import com.projectlyrics.server.domain.like.service.LikeQueryService;
 import com.projectlyrics.server.domain.note.service.NoteCommandService;
 import com.projectlyrics.server.domain.note.service.NoteQueryService;
 import com.projectlyrics.server.domain.notification.service.NotificationCommandService;
+import com.projectlyrics.server.domain.report.service.ReportCommandService;
 import com.projectlyrics.server.domain.song.service.SongQueryService;
 import com.projectlyrics.server.domain.user.entity.Role;
 import com.projectlyrics.server.global.configuration.ClockConfig;
@@ -89,6 +90,9 @@ public abstract class ControllerTest {
 
     @MockBean
     protected NotificationCommandService notificationCommandService;
+
+    @MockBean
+    protected ReportCommandService reportCommandService;
 
     public String accessToken;
     public String refreshToken;

--- a/src/test/java/com/projectlyrics/server/support/ControllerTest.java
+++ b/src/test/java/com/projectlyrics/server/support/ControllerTest.java
@@ -23,6 +23,7 @@ import com.projectlyrics.server.domain.report.service.ReportCommandService;
 import com.projectlyrics.server.domain.song.service.SongQueryService;
 import com.projectlyrics.server.domain.user.entity.Role;
 import com.projectlyrics.server.global.configuration.ClockConfig;
+import com.projectlyrics.server.global.slack.SlackClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -93,6 +94,9 @@ public abstract class ControllerTest {
 
     @MockBean
     protected ReportCommandService reportCommandService;
+
+    @MockBean
+    protected SlackClient slackClient;
 
     public String accessToken;
     public String refreshToken;

--- a/src/test/java/com/projectlyrics/server/support/fixture/ReportFixture.java
+++ b/src/test/java/com/projectlyrics/server/support/fixture/ReportFixture.java
@@ -1,0 +1,39 @@
+package com.projectlyrics.server.support.fixture;
+
+import com.projectlyrics.server.domain.comment.domain.Comment;
+import com.projectlyrics.server.domain.note.entity.Note;
+import com.projectlyrics.server.domain.report.domain.Report;
+import com.projectlyrics.server.domain.report.domain.ReportCreate;
+import com.projectlyrics.server.domain.report.domain.ReportReason;
+import com.projectlyrics.server.domain.user.entity.User;
+
+public class ReportFixture extends BaseFixture{
+
+    public static Report create(Note note,User reporter) {
+        return Report.createWithId(
+                getUniqueId(),
+                ReportCreate.of(
+                        reporter,
+                        note,
+                        null,
+                        ReportReason.POLITICAL_RELIGIOUS,
+                        "example@example.com"
+
+                )
+        );
+    }
+
+    public static Report create(Comment comment,User reporter) {
+        return Report.createWithId(
+                getUniqueId(),
+                ReportCreate.of(
+                        reporter,
+                        null,
+                        comment,
+                        ReportReason.POLITICAL_RELIGIOUS,
+                        "example@example.com"
+
+                )
+        );
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -41,3 +41,8 @@ server:
 
 firebase:
   key-file: src/main/resources/firebase-key.json
+
+slack:
+  token: secret
+  channel:
+    id: secret

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -42,6 +42,7 @@ server:
 firebase:
   key-file: src/main/resources/firebase-key.json
 
+slack:
   token: secret
   signing:
     secret: secret

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -42,7 +42,8 @@ server:
 firebase:
   key-file: src/main/resources/firebase-key.json
 
-slack:
   token: secret
+  signing:
+    secret: secret
   channel:
     id: secret


### PR DESCRIPTION
# 🍃 **Pull Requests**

## ⛳️ **작업한 브랜치**
- SCRUM-172

## 👷 **작업한 내용**
- Report 도메인 개발
- 신고 생성 및 승인 로직 추가 (service, controller)
- 신고 생성 및 승인 관련 테스트 작성
------
- slack 연동 중.... (코드 추가 예정)

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 어차피 신고 승인과 같은 슬랙으로 진행하는 api에 대해서는 컨트롤러 테스트를 작성할 필요가 있을지 궁금합니다...
- 또한 같은 신고 작성자&대상이 이미 존재하여 신고 사유가 업데이트되는 경우에는 ***승인여부와 허위신고여부도 원상복귀하는 로직***으로 구현했는데 이 부분을 어떻게 해야 할지도 고민이네요...

![image](https://github.com/user-attachments/assets/bfdd36b4-1896-4899-ab43-2abad80d9a15)
- 현재 구상하고 있는 slack UI 입니다. 혹시 허위신고 버튼을 누른다면 승인 여부는 자연스럽게 dismiss로 되는 것이 맞을까요? 현재 코드에서는 (승인여부, 허위신고여부)를 한꺼번에 받아야 하기에 여쭤봅니다.
- 또한 원래 신고 대상 노트/댓글의 작성자 id를 보여줄 수 있는 view을 기획측에 제공하자고 했었는데 slack에서 다음과 같이 보여주면 굳이 뷰를 만들지 않아도 되지 않을까요...?
-  <U>승인으로 변경한 경우, 신고 id를 응답으로 반환해서 admin이 조치 저장 시에 활용할 수 있도록 해야 한다.<U>
-  일단은 이렇게 구현을 했는데 admin이 조치 저장시에 신고 id를 어떻게 활용할지 궁금합니다.