### PR TITLE
조치 기능 개발

### DIFF
--- a/src/main/java/com/projectlyrics/server/domain/auth/exception/ForcedWithdrawalUserException.java
+++ b/src/main/java/com/projectlyrics/server/domain/auth/exception/ForcedWithdrawalUserException.java
@@ -1,0 +1,12 @@
+package com.projectlyrics.server.domain.auth.exception;
+
+import com.projectlyrics.server.domain.common.message.ErrorCode;
+import com.projectlyrics.server.global.exception.FeelinException;
+
+public class ForcedWithdrawalUserException extends FeelinException {
+
+    public ForcedWithdrawalUserException() {
+        super(ErrorCode.USER_FORCED_WITHDRAWAL);
+    }
+}
+

--- a/src/main/java/com/projectlyrics/server/domain/auth/service/AuthCommandService.java
+++ b/src/main/java/com/projectlyrics/server/domain/auth/service/AuthCommandService.java
@@ -1,12 +1,12 @@
 package com.projectlyrics.server.domain.auth.service;
 
+import com.projectlyrics.server.domain.auth.authentication.jwt.AuthToken;
 import com.projectlyrics.server.domain.auth.authentication.jwt.JwtProvider;
 import com.projectlyrics.server.domain.auth.domain.Auth;
 import com.projectlyrics.server.domain.auth.domain.AuthGetSocialInfo;
 import com.projectlyrics.server.domain.auth.dto.request.AuthSignInRequest;
 import com.projectlyrics.server.domain.auth.dto.request.AuthSignUpRequest;
 import com.projectlyrics.server.domain.auth.dto.response.AuthTokenResponse;
-import com.projectlyrics.server.domain.auth.authentication.jwt.AuthToken;
 import com.projectlyrics.server.domain.auth.exception.AlreadyExistsUserException;
 import com.projectlyrics.server.domain.auth.exception.AuthNotFoundException;
 import com.projectlyrics.server.domain.auth.repository.AuthRepository;

--- a/src/main/java/com/projectlyrics/server/domain/auth/service/AuthCommandService.java
+++ b/src/main/java/com/projectlyrics/server/domain/auth/service/AuthCommandService.java
@@ -22,6 +22,7 @@ import com.projectlyrics.server.domain.user.entity.UserCreate;
 import com.projectlyrics.server.domain.user.exception.UserNotFoundException;
 import com.projectlyrics.server.domain.user.repository.UserCommandRepository;
 import com.projectlyrics.server.domain.user.repository.UserQueryRepository;
+import java.time.Clock;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -110,5 +111,16 @@ public class AuthCommandService {
         likeCommandRepository.deleteAllByUserId(userId);
         noteCommandRepository.deleteAllByPublisherId(userId);
         userCommandRepository.deleteById(userId);
+    }
+
+    public void forcedWithdrawal(User user) {
+        authRepository.findById(user.getSocialInfo().getSocialId())
+                .ifPresent(authRepository::delete);
+        bookmarkCommandRepository.deleteAllByUserId(user.getId());
+        commentCommandRepository.deleteAllByWriterId(user.getId());
+        favoriteArtistCommandRepository.deleteAllByUserId(user.getId());
+        likeCommandRepository.deleteAllByUserId(user.getId());
+        noteCommandRepository.deleteAllByPublisherId(user.getId());
+        user.forcedWithdrawal(Clock.systemDefaultZone());
     }
 }

--- a/src/main/java/com/projectlyrics/server/domain/auth/service/AuthCommandService.java
+++ b/src/main/java/com/projectlyrics/server/domain/auth/service/AuthCommandService.java
@@ -9,6 +9,7 @@ import com.projectlyrics.server.domain.auth.dto.request.AuthSignUpRequest;
 import com.projectlyrics.server.domain.auth.dto.response.AuthTokenResponse;
 import com.projectlyrics.server.domain.auth.exception.AlreadyExistsUserException;
 import com.projectlyrics.server.domain.auth.exception.AuthNotFoundException;
+import com.projectlyrics.server.domain.auth.exception.ForcedWithdrawalUserException;
 import com.projectlyrics.server.domain.auth.repository.AuthRepository;
 import com.projectlyrics.server.domain.bookmark.repository.BookmarkCommandRepository;
 import com.projectlyrics.server.domain.comment.repository.CommentCommandRepository;
@@ -54,6 +55,9 @@ public class AuthCommandService {
     private void checkIfAlreadyExists(SocialInfo socialInfo) {
         if (userQueryRepository.existsBySocialInfo(socialInfo)) {
             throw new AlreadyExistsUserException();
+        }
+        else if (userQueryRepository.existsBySocialInfoAndForceDelete(socialInfo)) {
+            throw new ForcedWithdrawalUserException();
         }
     }
 

--- a/src/main/java/com/projectlyrics/server/domain/comment/service/CommentCommandService.java
+++ b/src/main/java/com/projectlyrics/server/domain/comment/service/CommentCommandService.java
@@ -9,7 +9,7 @@ import com.projectlyrics.server.domain.comment.exception.InvalidCommentDeletionE
 import com.projectlyrics.server.domain.comment.exception.InvalidCommentUpdateException;
 import com.projectlyrics.server.domain.comment.repository.CommentCommandRepository;
 import com.projectlyrics.server.domain.comment.repository.CommentQueryRepository;
-import com.projectlyrics.server.domain.discipline.exception.InvaildDisciplineActionException;
+import com.projectlyrics.server.domain.discipline.exception.InvalidDisciplineActionException;
 import com.projectlyrics.server.domain.discipline.repository.DisciplineQueryRepository;
 import com.projectlyrics.server.domain.note.entity.Note;
 import com.projectlyrics.server.domain.note.exception.NoteNotFoundException;
@@ -69,7 +69,7 @@ public class CommentCommandService {
 
     private void checkDiscipline(Long artistId, Long userId) {
         if (disciplineQueryRepository.existsByAll(userId) || disciplineQueryRepository.existsByArtist(artistId, userId)) {
-            throw new InvaildDisciplineActionException();
+            throw new InvalidDisciplineActionException();
         }
     }
 }

--- a/src/main/java/com/projectlyrics/server/domain/comment/service/CommentCommandService.java
+++ b/src/main/java/com/projectlyrics/server/domain/comment/service/CommentCommandService.java
@@ -68,7 +68,7 @@ public class CommentCommandService {
     }
 
     private void checkDiscipline(Long artistId, Long userId) {
-        if (disciplineQueryRepository.existsDisciplineOfAll(userId) || disciplineQueryRepository.existsDisciplineOfArtist(artistId, userId)) {
+        if (disciplineQueryRepository.existsByAll(userId) || disciplineQueryRepository.existsByArtist(artistId, userId)) {
             throw new InvaildDisciplineActionException();
         }
     }

--- a/src/main/java/com/projectlyrics/server/domain/comment/service/CommentCommandService.java
+++ b/src/main/java/com/projectlyrics/server/domain/comment/service/CommentCommandService.java
@@ -9,6 +9,8 @@ import com.projectlyrics.server.domain.comment.exception.InvalidCommentDeletionE
 import com.projectlyrics.server.domain.comment.exception.InvalidCommentUpdateException;
 import com.projectlyrics.server.domain.comment.repository.CommentCommandRepository;
 import com.projectlyrics.server.domain.comment.repository.CommentQueryRepository;
+import com.projectlyrics.server.domain.discipline.exception.InvaildDisciplineAction;
+import com.projectlyrics.server.domain.discipline.repository.DisciplineQueryRepository;
 import com.projectlyrics.server.domain.note.entity.Note;
 import com.projectlyrics.server.domain.note.exception.NoteNotFoundException;
 import com.projectlyrics.server.domain.note.repository.NoteQueryRepository;
@@ -33,12 +35,15 @@ public class CommentCommandService {
     private final UserQueryRepository userQueryRepository;
     private final NoteQueryRepository noteQueryRepository;
     private final ApplicationEventPublisher eventPublisher;
+    private final DisciplineQueryRepository disciplineQueryRepository;
 
     public Comment create(CommentCreateRequest request, Long writerId) {
         User writer = userQueryRepository.findById(writerId)
                 .orElseThrow(UserNotFoundException::new);
         Note note = noteQueryRepository.findById(request.noteId())
                 .orElseThrow(NoteNotFoundException::new);
+
+        checkDiscipline(note.getSong().getArtist().getId(), writerId);
 
         Comment comment = Comment.create(CommentCreate.of(request.content(), writer, note));
         eventPublisher.publishEvent(CommentEvent.from(comment));
@@ -60,5 +65,11 @@ public class CommentCommandService {
                         comment -> comment.delete(writerId, Clock.systemDefaultZone()),
                         () -> { throw new InvalidCommentDeletionException(); }
                 );
+    }
+
+    private void checkDiscipline(Long artistId, Long userId) {
+        if (disciplineQueryRepository.existsDisciplineOfAll(userId) || disciplineQueryRepository.existsDisciplineOfArtist(artistId, userId)) {
+            throw new InvaildDisciplineAction();
+        }
     }
 }

--- a/src/main/java/com/projectlyrics/server/domain/comment/service/CommentCommandService.java
+++ b/src/main/java/com/projectlyrics/server/domain/comment/service/CommentCommandService.java
@@ -9,7 +9,7 @@ import com.projectlyrics.server.domain.comment.exception.InvalidCommentDeletionE
 import com.projectlyrics.server.domain.comment.exception.InvalidCommentUpdateException;
 import com.projectlyrics.server.domain.comment.repository.CommentCommandRepository;
 import com.projectlyrics.server.domain.comment.repository.CommentQueryRepository;
-import com.projectlyrics.server.domain.discipline.exception.InvaildDisciplineAction;
+import com.projectlyrics.server.domain.discipline.exception.InvaildDisciplineActionException;
 import com.projectlyrics.server.domain.discipline.repository.DisciplineQueryRepository;
 import com.projectlyrics.server.domain.note.entity.Note;
 import com.projectlyrics.server.domain.note.exception.NoteNotFoundException;
@@ -69,7 +69,7 @@ public class CommentCommandService {
 
     private void checkDiscipline(Long artistId, Long userId) {
         if (disciplineQueryRepository.existsDisciplineOfAll(userId) || disciplineQueryRepository.existsDisciplineOfArtist(artistId, userId)) {
-            throw new InvaildDisciplineAction();
+            throw new InvaildDisciplineActionException();
         }
     }
 }

--- a/src/main/java/com/projectlyrics/server/domain/common/entity/BaseEntity.java
+++ b/src/main/java/com/projectlyrics/server/domain/common/entity/BaseEntity.java
@@ -5,12 +5,11 @@ import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-
+import jakarta.persistence.MappedSuperclass;
 import java.time.Clock;
 import java.time.LocalDateTime;
-
-import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedBy;
@@ -47,9 +46,11 @@ public abstract class BaseEntity {
     @Column(nullable = true)
     private Long deletedBy;
 
-    protected BaseEntity() {
-        this.status = EntityStatusEnum.IN_USE;
-    }
+    @Value("${admin}")
+    private Long adminUserId;
+
+    protected BaseEntity() {this.status = EntityStatusEnum.IN_USE;}
+
 
     public boolean isInUse() {
         return EntityStatusEnum.IN_USE.equals(this.status);
@@ -70,6 +71,6 @@ public abstract class BaseEntity {
     public void forcedWithdrawal(Clock clock) {
         this.status = EntityStatusEnum.FORCED_WITHDRAWAL;
         this.deletedAt = LocalDateTime.now(clock);
-        this.deletedBy = 1L; //admin
+        this.deletedBy = adminUserId; //admin
     }
 }

--- a/src/main/java/com/projectlyrics/server/domain/common/entity/BaseEntity.java
+++ b/src/main/java/com/projectlyrics/server/domain/common/entity/BaseEntity.java
@@ -67,8 +67,8 @@ public abstract class BaseEntity {
         this.deletedBy = null;
     }
 
-    public void forceDelete(Clock clock) {
-        this.status = EntityStatusEnum.FORCE_DELETED;
+    public void forcedWithdrawal(Clock clock) {
+        this.status = EntityStatusEnum.FORCED_WITHDRAWAL;
         this.deletedAt = LocalDateTime.now(clock);
         this.deletedBy = 0L;
     }

--- a/src/main/java/com/projectlyrics/server/domain/common/entity/BaseEntity.java
+++ b/src/main/java/com/projectlyrics/server/domain/common/entity/BaseEntity.java
@@ -66,4 +66,10 @@ public abstract class BaseEntity {
         this.deletedAt = null;
         this.deletedBy = null;
     }
+
+    public void forceDelete(Clock clock) {
+        this.status = EntityStatusEnum.FORCE_DELETED;
+        this.deletedAt = LocalDateTime.now(clock);
+        this.deletedBy = 0L;
+    }
 }

--- a/src/main/java/com/projectlyrics/server/domain/common/entity/BaseEntity.java
+++ b/src/main/java/com/projectlyrics/server/domain/common/entity/BaseEntity.java
@@ -70,6 +70,6 @@ public abstract class BaseEntity {
     public void forcedWithdrawal(Clock clock) {
         this.status = EntityStatusEnum.FORCED_WITHDRAWAL;
         this.deletedAt = LocalDateTime.now(clock);
-        this.deletedBy = 0L;
+        this.deletedBy = 1L; //admin
     }
 }

--- a/src/main/java/com/projectlyrics/server/domain/common/entity/enumerate/EntityStatusEnum.java
+++ b/src/main/java/com/projectlyrics/server/domain/common/entity/enumerate/EntityStatusEnum.java
@@ -2,5 +2,5 @@ package com.projectlyrics.server.domain.common.entity.enumerate;
 
 public enum EntityStatusEnum {
 
-    YET, IN_USE, DELETED
+    YET, IN_USE, DELETED, FORCE_DELETED
 }

--- a/src/main/java/com/projectlyrics/server/domain/common/entity/enumerate/EntityStatusEnum.java
+++ b/src/main/java/com/projectlyrics/server/domain/common/entity/enumerate/EntityStatusEnum.java
@@ -2,5 +2,5 @@ package com.projectlyrics.server.domain.common.entity.enumerate;
 
 public enum EntityStatusEnum {
 
-    YET, IN_USE, DELETED, FORCE_DELETED
+    YET, IN_USE, DELETED, FORCED_WITHDRAWAL
 }

--- a/src/main/java/com/projectlyrics/server/domain/common/message/ErrorCode.java
+++ b/src/main/java/com/projectlyrics/server/domain/common/message/ErrorCode.java
@@ -83,11 +83,15 @@ public enum ErrorCode {
     REPORT_TARGET_MISSING(HttpStatus.BAD_REQUEST, "12002", "신고 대상(Note 또는 Comment)가 필요합니다."),
     DUPLICATE_REPORT(HttpStatus.CONFLICT, "12003", "이미 신고가 완료된 대상입니다"),
 
+    // Discipline
+    DISCIPLINE_NOT_FOUND(HttpStatus.NOT_FOUND, "14000", "해당 조치를 조회할 수 없습니다"),
+    INVALID_DISCIPLINE_CREATE(HttpStatus.BAD_REQUEST, "14001", "조치 생성에 실패했습니다"),
+
     // Slack
-    SLACK_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "13000", "슬랙 메세지 전송에 실패했습니다."),
-    SLACK_PROCESSING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "13001", "슬랙 메세지 전송 중 에러가 발생했습니다."),
-    SLACK_INTERACTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "13002", "슬랙 상호작용 인터렉션에 문제가 발생했습니다"),
-    SLACK_FEEDBACK_FAILED(HttpStatus.INTERNAL_SERVER_ERROR,"13003", "슬랙에 피드백 메세지 제공에 실패했습니다."),
+    SLACK_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "14000", "슬랙 메세지 전송에 실패했습니다."),
+    SLACK_PROCESSING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "14001", "슬랙 메세지 전송 중 에러가 발생했습니다."),
+    SLACK_INTERACTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "14002", "슬랙 상호작용 인터렉션에 문제가 발생했습니다"),
+    SLACK_FEEDBACK_FAILED(HttpStatus.INTERNAL_SERVER_ERROR,"14003", "슬랙에 피드백 메세지 제공에 실패했습니다."),
     ;
 
     private final HttpStatus responseStatus;

--- a/src/main/java/com/projectlyrics/server/domain/common/message/ErrorCode.java
+++ b/src/main/java/com/projectlyrics/server/domain/common/message/ErrorCode.java
@@ -86,6 +86,7 @@ public enum ErrorCode {
     // Discipline
     DISCIPLINE_NOT_FOUND(HttpStatus.NOT_FOUND, "14000", "해당 조치를 조회할 수 없습니다"),
     INVALID_DISCIPLINE_CREATE(HttpStatus.BAD_REQUEST, "14001", "조치 생성에 실패했습니다"),
+    INVAILD_DISCIPLINE_ACTION(HttpStatus.FORBIDDEN, "14002", "징계로 인해 해당 작업을 수행할 수 없습니다"),
 
     // Slack
     SLACK_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "14000", "슬랙 메세지 전송에 실패했습니다."),

--- a/src/main/java/com/projectlyrics/server/domain/common/message/ErrorCode.java
+++ b/src/main/java/com/projectlyrics/server/domain/common/message/ErrorCode.java
@@ -31,6 +31,7 @@ public enum ErrorCode {
     INVALID_TOKEN_PREFIX(HttpStatus.BAD_REQUEST, "01009", "Bearer 인증 형식이 아닙니다."),
     INVALID_SOCIAL_TOKEN(HttpStatus.UNAUTHORIZED, "01010", "유효하지 않은 소셜 인증 토큰입니다."),
     AUTH_NOT_FOUND(HttpStatus.NOT_FOUND, "01011", "해당 인증 정보를 찾을 수 없습니다."),
+    USER_FORCED_WITHDRAWAL(HttpStatus.FORBIDDEN, "01012", "강제 탈퇴 이력이 있는 유저입니다"),
 
     // User
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "02000", "해당 유저가 존재하지 않습니다."),

--- a/src/main/java/com/projectlyrics/server/domain/common/message/ErrorCode.java
+++ b/src/main/java/com/projectlyrics/server/domain/common/message/ErrorCode.java
@@ -87,7 +87,7 @@ public enum ErrorCode {
     // Discipline
     DISCIPLINE_NOT_FOUND(HttpStatus.NOT_FOUND, "14000", "해당 조치를 조회할 수 없습니다"),
     INVALID_DISCIPLINE_CREATE(HttpStatus.BAD_REQUEST, "14001", "조치 생성에 실패했습니다"),
-    INVAILD_DISCIPLINE_ACTION(HttpStatus.FORBIDDEN, "14002", "징계로 인해 해당 작업을 수행할 수 없습니다"),
+    INVALID_DISCIPLINE_ACTION(HttpStatus.FORBIDDEN, "14002", "징계로 인해 해당 작업을 수행할 수 없습니다"),
 
     // Slack
     SLACK_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "14000", "슬랙 메세지 전송에 실패했습니다."),

--- a/src/main/java/com/projectlyrics/server/domain/discipline/domain/Discipline.java
+++ b/src/main/java/com/projectlyrics/server/domain/discipline/domain/Discipline.java
@@ -48,13 +48,13 @@ public class Discipline extends BaseEntity {
     @Enumerated(value = EnumType.STRING)
     private DisciplineType type;
 
-    private Discipline(Long id, User user, Artist artist, DisciplineReason reason, DisciplineType type) {
+    private Discipline(Long id, User user, Artist artist, DisciplineReason reason, DisciplineType type, LocalDateTime startTime) {
         this.id = id;
         this.user = user;
         this.artist = artist;
         this.reason = reason;
         this.type = type;
-        this.startTime = LocalDateTime.now()
+        this.startTime = startTime
                 .withMinute(0)
                 .withSecond(0)
                 .withNano(0); ;
@@ -67,7 +67,8 @@ public class Discipline extends BaseEntity {
                 disciplineCreate.user(),
                 disciplineCreate.artist(),
                 disciplineCreate.reason(),
-                disciplineCreate.type()
+                disciplineCreate.type(),
+                LocalDateTime.now()
         );
     }
 
@@ -77,7 +78,8 @@ public class Discipline extends BaseEntity {
                 disciplineCreate.user(),
                 disciplineCreate.artist(),
                 disciplineCreate.reason(),
-                disciplineCreate.type()
+                disciplineCreate.type(),
+                LocalDateTime.now()
         );
     }
 }

--- a/src/main/java/com/projectlyrics/server/domain/discipline/domain/Discipline.java
+++ b/src/main/java/com/projectlyrics/server/domain/discipline/domain/Discipline.java
@@ -1,7 +1,7 @@
 package com.projectlyrics.server.domain.discipline.domain;
 
 import com.projectlyrics.server.domain.artist.entity.Artist;
-import com.projectlyrics.server.domain.note.entity.Note;
+import com.projectlyrics.server.domain.common.entity.BaseEntity;
 import com.projectlyrics.server.domain.report.domain.ReportReason;
 import com.projectlyrics.server.domain.user.entity.User;
 import jakarta.persistence.Column;
@@ -25,7 +25,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "disciplines")
 @EqualsAndHashCode(of = "id", callSuper = false)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Discipline {
+public class Discipline extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/projectlyrics/server/domain/discipline/domain/Discipline.java
+++ b/src/main/java/com/projectlyrics/server/domain/discipline/domain/Discipline.java
@@ -57,8 +57,8 @@ public class Discipline extends BaseEntity {
         this.startTime = startTime
                 .withMinute(0)
                 .withSecond(0)
-                .withNano(0); ;
-        this.endTime = startTime.plus(type.getPeriod());
+                .withNano(0);
+        this.endTime = this.startTime.plus(type.getPeriod());
     }
 
     public static Discipline create(DisciplineCreate disciplineCreate) {
@@ -68,7 +68,7 @@ public class Discipline extends BaseEntity {
                 disciplineCreate.artist(),
                 disciplineCreate.reason(),
                 disciplineCreate.type(),
-                LocalDateTime.now()
+                disciplineCreate.startTime()
         );
     }
 
@@ -79,7 +79,7 @@ public class Discipline extends BaseEntity {
                 disciplineCreate.artist(),
                 disciplineCreate.reason(),
                 disciplineCreate.type(),
-                LocalDateTime.now()
+                disciplineCreate.startTime()
         );
     }
 }

--- a/src/main/java/com/projectlyrics/server/domain/discipline/domain/Discipline.java
+++ b/src/main/java/com/projectlyrics/server/domain/discipline/domain/Discipline.java
@@ -34,6 +34,9 @@ public class Discipline {
     @ManyToOne(fetch = FetchType.LAZY)
     private User user;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Artist artist;
+
     @Column(name = "start_time", nullable = false)
     private LocalDateTime startTime;
 
@@ -46,7 +49,36 @@ public class Discipline {
     @Enumerated(value = EnumType.STRING)
     private DisciplineType type;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    private Artist artist;
+    private Discipline(Long id, User user, Artist artist, ReportReason reason, DisciplineType type) {
+        this.id = id;
+        this.user = user;
+        this.artist = artist;
+        this.reason = reason;
+        this.type = type;
+        this.startTime = LocalDateTime.now()
+                .withMinute(0)
+                .withSecond(0)
+                .withNano(0); ;
+        this.endTime = startTime.plus(type.getPeriod());
+    }
 
+    public static Discipline create(DisciplineCreate disciplineCreate) {
+        return new Discipline(
+                null,
+                disciplineCreate.user(),
+                disciplineCreate.artist(),
+                disciplineCreate.reason(),
+                disciplineCreate.type()
+        );
+    }
+
+    public static Discipline createWithId(Long id, DisciplineCreate disciplineCreate) {
+        return new Discipline(
+                id,
+                disciplineCreate.user(),
+                disciplineCreate.artist(),
+                disciplineCreate.reason(),
+                disciplineCreate.type()
+        );
+    }
 }

--- a/src/main/java/com/projectlyrics/server/domain/discipline/domain/Discipline.java
+++ b/src/main/java/com/projectlyrics/server/domain/discipline/domain/Discipline.java
@@ -48,17 +48,23 @@ public class Discipline extends BaseEntity {
     @Enumerated(value = EnumType.STRING)
     private DisciplineType type;
 
-    private Discipline(Long id, User user, Artist artist, DisciplineReason reason, DisciplineType type, LocalDateTime startTime) {
+    private String notificationContent;
+
+    private Discipline(Long id, User user, Artist artist, DisciplineReason reason, DisciplineType type, LocalDateTime startTime, String notificationContent) {
         this.id = id;
         this.user = user;
         this.artist = artist;
         this.reason = reason;
         this.type = type;
         this.startTime = startTime
+                .withHour(0)
                 .withMinute(0)
                 .withSecond(0)
                 .withNano(0);
         this.endTime = this.startTime.plus(type.getPeriod());
+        this.notificationContent = notificationContent
+                .replace("{시작시간}", startTime.getYear() + "년 " + startTime.getMonthValue() + "월 " + startTime.getDayOfMonth() + "일 " + startTime.getHour()+ "시")
+                .replace("{종료시간}", endTime.getYear() + "년 " + endTime.getMonthValue() + "월 " + endTime.getDayOfMonth() + "일 " + endTime.getHour()+ "시");
     }
 
     public static Discipline create(DisciplineCreate disciplineCreate) {
@@ -68,7 +74,8 @@ public class Discipline extends BaseEntity {
                 disciplineCreate.artist(),
                 disciplineCreate.reason(),
                 disciplineCreate.type(),
-                disciplineCreate.startTime()
+                disciplineCreate.startTime(),
+                disciplineCreate.notificationContent()
         );
     }
 
@@ -79,7 +86,8 @@ public class Discipline extends BaseEntity {
                 disciplineCreate.artist(),
                 disciplineCreate.reason(),
                 disciplineCreate.type(),
-                disciplineCreate.startTime()
+                disciplineCreate.startTime(),
+                disciplineCreate.notificationContent()
         );
     }
 }

--- a/src/main/java/com/projectlyrics/server/domain/discipline/domain/Discipline.java
+++ b/src/main/java/com/projectlyrics/server/domain/discipline/domain/Discipline.java
@@ -2,7 +2,6 @@ package com.projectlyrics.server.domain.discipline.domain;
 
 import com.projectlyrics.server.domain.artist.entity.Artist;
 import com.projectlyrics.server.domain.common.entity.BaseEntity;
-import com.projectlyrics.server.domain.report.domain.ReportReason;
 import com.projectlyrics.server.domain.user.entity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -44,12 +43,12 @@ public class Discipline extends BaseEntity {
     private LocalDateTime endTime;
 
     @Enumerated(value = EnumType.STRING)
-    private ReportReason reason;
+    private DisciplineReason reason;
 
     @Enumerated(value = EnumType.STRING)
     private DisciplineType type;
 
-    private Discipline(Long id, User user, Artist artist, ReportReason reason, DisciplineType type) {
+    private Discipline(Long id, User user, Artist artist, DisciplineReason reason, DisciplineType type) {
         this.id = id;
         this.user = user;
         this.artist = artist;

--- a/src/main/java/com/projectlyrics/server/domain/discipline/domain/Discipline.java
+++ b/src/main/java/com/projectlyrics/server/domain/discipline/domain/Discipline.java
@@ -1,0 +1,52 @@
+package com.projectlyrics.server.domain.discipline.domain;
+
+import com.projectlyrics.server.domain.artist.entity.Artist;
+import com.projectlyrics.server.domain.note.entity.Note;
+import com.projectlyrics.server.domain.report.domain.ReportReason;
+import com.projectlyrics.server.domain.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "disciplines")
+@EqualsAndHashCode(of = "id", callSuper = false)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Discipline {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    @Column(name = "start_time", nullable = false)
+    private LocalDateTime startTime;
+
+    @Column(name = "end_time", nullable = false)
+    private LocalDateTime endTime;
+
+    @Enumerated(value = EnumType.STRING)
+    private ReportReason reason;
+
+    @Enumerated(value = EnumType.STRING)
+    private DisciplineType type;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Artist artist;
+
+}

--- a/src/main/java/com/projectlyrics/server/domain/discipline/domain/DisciplineCreate.java
+++ b/src/main/java/com/projectlyrics/server/domain/discipline/domain/DisciplineCreate.java
@@ -2,15 +2,18 @@ package com.projectlyrics.server.domain.discipline.domain;
 
 import com.projectlyrics.server.domain.artist.entity.Artist;
 import com.projectlyrics.server.domain.user.entity.User;
+import java.time.LocalDateTime;
 
 public record DisciplineCreate (
         User user,
         Artist artist,
         DisciplineReason reason,
-        DisciplineType type
+        DisciplineType type,
+
+        LocalDateTime startTime
 
 ){
-    public static DisciplineCreate of(User user, Artist artist, DisciplineReason reason, DisciplineType type) {
-        return new DisciplineCreate(user, artist, reason, type);
+    public static DisciplineCreate of(User user, Artist artist, DisciplineReason reason, DisciplineType type, LocalDateTime startTime) {
+        return new DisciplineCreate(user, artist, reason, type, startTime);
     }
 }

--- a/src/main/java/com/projectlyrics/server/domain/discipline/domain/DisciplineCreate.java
+++ b/src/main/java/com/projectlyrics/server/domain/discipline/domain/DisciplineCreate.java
@@ -1,0 +1,17 @@
+package com.projectlyrics.server.domain.discipline.domain;
+
+import com.projectlyrics.server.domain.artist.entity.Artist;
+import com.projectlyrics.server.domain.report.domain.ReportReason;
+import com.projectlyrics.server.domain.user.entity.User;
+
+public record DisciplineCreate (
+        User user,
+        Artist artist,
+        ReportReason reason,
+        DisciplineType type
+
+){
+    public static DisciplineCreate of(User user, Artist artist, ReportReason reason, DisciplineType type) {
+        return new DisciplineCreate(user, artist, reason, type);
+    }
+}

--- a/src/main/java/com/projectlyrics/server/domain/discipline/domain/DisciplineCreate.java
+++ b/src/main/java/com/projectlyrics/server/domain/discipline/domain/DisciplineCreate.java
@@ -9,7 +9,6 @@ public record DisciplineCreate (
         Artist artist,
         DisciplineReason reason,
         DisciplineType type,
-
         LocalDateTime startTime
 
 ){

--- a/src/main/java/com/projectlyrics/server/domain/discipline/domain/DisciplineCreate.java
+++ b/src/main/java/com/projectlyrics/server/domain/discipline/domain/DisciplineCreate.java
@@ -1,17 +1,16 @@
 package com.projectlyrics.server.domain.discipline.domain;
 
 import com.projectlyrics.server.domain.artist.entity.Artist;
-import com.projectlyrics.server.domain.report.domain.ReportReason;
 import com.projectlyrics.server.domain.user.entity.User;
 
 public record DisciplineCreate (
         User user,
         Artist artist,
-        ReportReason reason,
+        DisciplineReason reason,
         DisciplineType type
 
 ){
-    public static DisciplineCreate of(User user, Artist artist, ReportReason reason, DisciplineType type) {
+    public static DisciplineCreate of(User user, Artist artist, DisciplineReason reason, DisciplineType type) {
         return new DisciplineCreate(user, artist, reason, type);
     }
 }

--- a/src/main/java/com/projectlyrics/server/domain/discipline/domain/DisciplineCreate.java
+++ b/src/main/java/com/projectlyrics/server/domain/discipline/domain/DisciplineCreate.java
@@ -9,10 +9,11 @@ public record DisciplineCreate (
         Artist artist,
         DisciplineReason reason,
         DisciplineType type,
-        LocalDateTime startTime
+        LocalDateTime startTime,
+        String notificationContent
 
 ){
-    public static DisciplineCreate of(User user, Artist artist, DisciplineReason reason, DisciplineType type, LocalDateTime startTime) {
-        return new DisciplineCreate(user, artist, reason, type, startTime);
+    public static DisciplineCreate of(User user, Artist artist, DisciplineReason reason, DisciplineType type, LocalDateTime startTime, String notificationContent) {
+        return new DisciplineCreate(user, artist, reason, type, startTime, notificationContent);
     }
 }

--- a/src/main/java/com/projectlyrics/server/domain/discipline/domain/DisciplineReason.java
+++ b/src/main/java/com/projectlyrics/server/domain/discipline/domain/DisciplineReason.java
@@ -1,0 +1,23 @@
+package com.projectlyrics.server.domain.discipline.domain;
+
+public enum DisciplineReason {
+    INAPPROPRIATE_CONTENT("커뮤니티 성격에 맞지 않음"),
+    DEFAMATION("타 유저 혹은 아티스트 비방"),
+    EXPLICIT_CONTENT("불쾌감을 조성하는 음란성/선정적인 내용"),
+    COMMERCIAL_ADS("상업적 광고"),
+    INFO_DISCLOSURE("부적절한 정보 유출"),
+    POLITICAL_RELIGIOUS("정치적인 내용/종교 포교 시도"),
+    OTHER("기타"),
+    FAKE_REPORT("허위 신고")
+    ;
+
+    private final String description;
+
+    DisciplineReason(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/com/projectlyrics/server/domain/discipline/domain/DisciplineType.java
+++ b/src/main/java/com/projectlyrics/server/domain/discipline/domain/DisciplineType.java
@@ -1,0 +1,32 @@
+package com.projectlyrics.server.domain.discipline.domain;
+
+import java.time.Period;
+
+public enum DisciplineType {
+    WARNING("경고", Period.ZERO),
+    ALL_3DAYS("3일간 모든 아티스트 레코드 노트/댓글 작성 제한", Period.ofDays(3)),
+    ALL_14DAYS("14일간 모든 아티스트 레코드 노트/댓글 작성 제한", Period.ofDays(14)),
+    ALL_30DAYS("30일간 모든 아티스트 레코드 노트/댓글 작성 제한", Period.ofDays(30)),
+    ALL_3MONTHS("3개월간 모든 아티스트 레코드 노트/댓글 작성 제한", Period.ofMonths(3)),
+    ARTIST_3DAYS("3일간 해당 아티스트 레코드 글 작성 제한", Period.ofDays(3)),
+    ARTIST_14DAYS("14일간 해당 아티스트 레코드 노트/댓글 작성 제한", Period.ofDays(14)),
+    ARTIST_30DAYS("30일간 해당 아티스트 레코드 노트/댓글 작성 제한", Period.ofDays(30)),
+    ARTIST_3MONTHS("3개월간 해당 아티스트 레코드 노트/댓글 작성 제한", Period.ofMonths(3)),
+    FORCED_WITHDRAWAL("강제 탈퇴(영구)", Period.ofYears(1000));
+
+    private final String description;
+    private final Period period;
+
+    DisciplineType(String description, Period period) {
+        this.description = description;
+        this.period = period;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public Period getPeriod() {
+        return period;
+    }
+}

--- a/src/main/java/com/projectlyrics/server/domain/discipline/dto/request/DisciplineCreateRequest.java
+++ b/src/main/java/com/projectlyrics/server/domain/discipline/dto/request/DisciplineCreateRequest.java
@@ -15,9 +15,10 @@ public record DisciplineCreateRequest (
         DisciplineType disciplineType,
 
         @NotNull
-        LocalDateTime startTime
+        LocalDateTime startTime,
+        String notificationContent
 ){
-        public static DisciplineCreateRequest of(Long userId, Long artistId, DisciplineReason disciplineReason, DisciplineType disciplineType, LocalDateTime startTime) {
-                return new DisciplineCreateRequest(userId, artistId, disciplineReason, disciplineType, startTime);
+        public static DisciplineCreateRequest of(Long userId, Long artistId, DisciplineReason disciplineReason, DisciplineType disciplineType, LocalDateTime startTime, String notificationContent) {
+                return new DisciplineCreateRequest(userId, artistId, disciplineReason, disciplineType, startTime, notificationContent);
         }
 }

--- a/src/main/java/com/projectlyrics/server/domain/discipline/dto/request/DisciplineCreateRequest.java
+++ b/src/main/java/com/projectlyrics/server/domain/discipline/dto/request/DisciplineCreateRequest.java
@@ -1,0 +1,16 @@
+package com.projectlyrics.server.domain.discipline.dto.request;
+
+import com.projectlyrics.server.domain.discipline.domain.DisciplineType;
+import com.projectlyrics.server.domain.report.domain.ReportReason;
+import jakarta.validation.constraints.NotNull;
+
+public record DisciplineCreateRequest (
+        @NotNull
+        Long userId,
+        Long artistId,
+        @NotNull
+        ReportReason reportReason,
+        @NotNull
+        DisciplineType disciplineType
+){
+}

--- a/src/main/java/com/projectlyrics/server/domain/discipline/dto/request/DisciplineCreateRequest.java
+++ b/src/main/java/com/projectlyrics/server/domain/discipline/dto/request/DisciplineCreateRequest.java
@@ -3,6 +3,7 @@ package com.projectlyrics.server.domain.discipline.dto.request;
 import com.projectlyrics.server.domain.discipline.domain.DisciplineReason;
 import com.projectlyrics.server.domain.discipline.domain.DisciplineType;
 import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
 
 public record DisciplineCreateRequest (
         @NotNull
@@ -11,9 +12,12 @@ public record DisciplineCreateRequest (
         @NotNull
         DisciplineReason disciplineReason,
         @NotNull
-        DisciplineType disciplineType
+        DisciplineType disciplineType,
+
+        @NotNull
+        LocalDateTime startTime
 ){
-        public static DisciplineCreateRequest of(Long userId, Long artistId, DisciplineReason disciplineReason, DisciplineType disciplineType) {
-                return new DisciplineCreateRequest(userId, artistId, disciplineReason, disciplineType);
+        public static DisciplineCreateRequest of(Long userId, Long artistId, DisciplineReason disciplineReason, DisciplineType disciplineType, LocalDateTime startTime) {
+                return new DisciplineCreateRequest(userId, artistId, disciplineReason, disciplineType, startTime);
         }
 }

--- a/src/main/java/com/projectlyrics/server/domain/discipline/dto/request/DisciplineCreateRequest.java
+++ b/src/main/java/com/projectlyrics/server/domain/discipline/dto/request/DisciplineCreateRequest.java
@@ -1,7 +1,7 @@
 package com.projectlyrics.server.domain.discipline.dto.request;
 
+import com.projectlyrics.server.domain.discipline.domain.DisciplineReason;
 import com.projectlyrics.server.domain.discipline.domain.DisciplineType;
-import com.projectlyrics.server.domain.report.domain.ReportReason;
 import jakarta.validation.constraints.NotNull;
 
 public record DisciplineCreateRequest (
@@ -9,8 +9,11 @@ public record DisciplineCreateRequest (
         Long userId,
         Long artistId,
         @NotNull
-        ReportReason reportReason,
+        DisciplineReason disciplineReason,
         @NotNull
         DisciplineType disciplineType
 ){
+        public static DisciplineCreateRequest of(Long userId, Long artistId, DisciplineReason disciplineReason, DisciplineType disciplineType) {
+                return new DisciplineCreateRequest(userId, artistId, disciplineReason, disciplineType);
+        }
 }

--- a/src/main/java/com/projectlyrics/server/domain/discipline/exception/InvaildDisciplineAction.java
+++ b/src/main/java/com/projectlyrics/server/domain/discipline/exception/InvaildDisciplineAction.java
@@ -1,0 +1,11 @@
+package com.projectlyrics.server.domain.discipline.exception;
+
+import com.projectlyrics.server.domain.common.message.ErrorCode;
+import com.projectlyrics.server.global.exception.FeelinException;
+
+public class InvaildDisciplineAction extends FeelinException {
+
+    public InvaildDisciplineAction() {
+        super(ErrorCode.INVAILD_DISCIPLINE_ACTION);
+    }
+}

--- a/src/main/java/com/projectlyrics/server/domain/discipline/exception/InvaildDisciplineActionException.java
+++ b/src/main/java/com/projectlyrics/server/domain/discipline/exception/InvaildDisciplineActionException.java
@@ -3,9 +3,9 @@ package com.projectlyrics.server.domain.discipline.exception;
 import com.projectlyrics.server.domain.common.message.ErrorCode;
 import com.projectlyrics.server.global.exception.FeelinException;
 
-public class InvaildDisciplineAction extends FeelinException {
+public class InvaildDisciplineActionException extends FeelinException {
 
-    public InvaildDisciplineAction() {
+    public InvaildDisciplineActionException() {
         super(ErrorCode.INVAILD_DISCIPLINE_ACTION);
     }
 }

--- a/src/main/java/com/projectlyrics/server/domain/discipline/exception/InvalidDisciplineActionException.java
+++ b/src/main/java/com/projectlyrics/server/domain/discipline/exception/InvalidDisciplineActionException.java
@@ -3,9 +3,9 @@ package com.projectlyrics.server.domain.discipline.exception;
 import com.projectlyrics.server.domain.common.message.ErrorCode;
 import com.projectlyrics.server.global.exception.FeelinException;
 
-public class InvaildDisciplineActionException extends FeelinException {
+public class InvalidDisciplineActionException extends FeelinException {
 
-    public InvaildDisciplineActionException() {
-        super(ErrorCode.INVAILD_DISCIPLINE_ACTION);
+    public InvalidDisciplineActionException() {
+        super(ErrorCode.INVALID_DISCIPLINE_ACTION);
     }
 }

--- a/src/main/java/com/projectlyrics/server/domain/discipline/exception/InvalidDisciplineCreate.java
+++ b/src/main/java/com/projectlyrics/server/domain/discipline/exception/InvalidDisciplineCreate.java
@@ -1,0 +1,12 @@
+package com.projectlyrics.server.domain.discipline.exception;
+
+import com.projectlyrics.server.domain.common.message.ErrorCode;
+import com.projectlyrics.server.global.exception.FeelinException;
+
+public class InvalidDisciplineCreate extends FeelinException {
+
+    public InvalidDisciplineCreate() {
+        super(ErrorCode.INVALID_DISCIPLINE_CREATE);
+    }
+}
+

--- a/src/main/java/com/projectlyrics/server/domain/discipline/exception/InvalidDisciplineCreateException.java
+++ b/src/main/java/com/projectlyrics/server/domain/discipline/exception/InvalidDisciplineCreateException.java
@@ -3,9 +3,9 @@ package com.projectlyrics.server.domain.discipline.exception;
 import com.projectlyrics.server.domain.common.message.ErrorCode;
 import com.projectlyrics.server.global.exception.FeelinException;
 
-public class InvalidDisciplineCreate extends FeelinException {
+public class InvalidDisciplineCreateException extends FeelinException {
 
-    public InvalidDisciplineCreate() {
+    public InvalidDisciplineCreateException() {
         super(ErrorCode.INVALID_DISCIPLINE_CREATE);
     }
 }

--- a/src/main/java/com/projectlyrics/server/domain/discipline/repository/DisciplineCommandRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/discipline/repository/DisciplineCommandRepository.java
@@ -1,0 +1,9 @@
+package com.projectlyrics.server.domain.discipline.repository;
+
+import com.projectlyrics.server.domain.discipline.domain.Discipline;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DisciplineCommandRepository extends JpaRepository<Discipline, Long> {
+}

--- a/src/main/java/com/projectlyrics/server/domain/discipline/repository/DisciplineQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/discipline/repository/DisciplineQueryRepository.java
@@ -1,4 +1,8 @@
 package com.projectlyrics.server.domain.discipline.repository;
 
+import com.projectlyrics.server.domain.discipline.domain.Discipline;
+import java.util.Optional;
+
 public interface DisciplineQueryRepository {
+    Optional<Discipline> findById(Long disciplineId);
 }

--- a/src/main/java/com/projectlyrics/server/domain/discipline/repository/DisciplineQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/discipline/repository/DisciplineQueryRepository.java
@@ -5,4 +5,6 @@ import java.util.Optional;
 
 public interface DisciplineQueryRepository {
     Optional<Discipline> findById(Long disciplineId);
+    Boolean existsDisciplineOfAll(Long userId);
+    Boolean existsDisciplineOfArtist(Long artistId, Long userId);
 }

--- a/src/main/java/com/projectlyrics/server/domain/discipline/repository/DisciplineQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/discipline/repository/DisciplineQueryRepository.java
@@ -5,6 +5,6 @@ import java.util.Optional;
 
 public interface DisciplineQueryRepository {
     Optional<Discipline> findById(Long disciplineId);
-    Boolean existsDisciplineOfAll(Long userId);
-    Boolean existsDisciplineOfArtist(Long artistId, Long userId);
+    Boolean existsByAll(Long userId);
+    Boolean existsByArtist(Long artistId, Long userId);
 }

--- a/src/main/java/com/projectlyrics/server/domain/discipline/repository/DisciplineQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/discipline/repository/DisciplineQueryRepository.java
@@ -1,0 +1,4 @@
+package com.projectlyrics.server.domain.discipline.repository;
+
+public interface DisciplineQueryRepository {
+}

--- a/src/main/java/com/projectlyrics/server/domain/discipline/repository/impl/QueryDslDisciplineQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/discipline/repository/impl/QueryDslDisciplineQueryRepository.java
@@ -31,7 +31,7 @@ public class QueryDslDisciplineQueryRepository implements DisciplineQueryReposit
     }
 
     @Override
-    public Boolean existsDisciplineOfAll(Long userId) {
+    public Boolean existsByAll(Long userId) {
         return jpaQueryFactory
                 .selectOne()
                 .from(discipline)
@@ -46,7 +46,7 @@ public class QueryDslDisciplineQueryRepository implements DisciplineQueryReposit
     }
 
     @Override
-    public Boolean existsDisciplineOfArtist(Long artistId, Long userId) {
+    public Boolean existsByArtist(Long artistId, Long userId) {
         return jpaQueryFactory
                 .selectOne()
                 .from(discipline)

--- a/src/main/java/com/projectlyrics/server/domain/discipline/repository/impl/QueryDslDisciplineQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/discipline/repository/impl/QueryDslDisciplineQueryRepository.java
@@ -1,0 +1,12 @@
+package com.projectlyrics.server.domain.discipline.repository.impl;
+
+import com.projectlyrics.server.domain.discipline.repository.DisciplineQueryRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class QueryDslDisciplineQueryRepository implements DisciplineQueryRepository {
+    private final JPAQueryFactory jpaQueryFactory;
+}

--- a/src/main/java/com/projectlyrics/server/domain/discipline/repository/impl/QueryDslDisciplineQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/discipline/repository/impl/QueryDslDisciplineQueryRepository.java
@@ -3,8 +3,10 @@ package com.projectlyrics.server.domain.discipline.repository.impl;
 import static com.projectlyrics.server.domain.discipline.domain.QDiscipline.discipline;
 
 import com.projectlyrics.server.domain.discipline.domain.Discipline;
+import com.projectlyrics.server.domain.discipline.domain.DisciplineType;
 import com.projectlyrics.server.domain.discipline.repository.DisciplineQueryRepository;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -26,5 +28,36 @@ public class QueryDslDisciplineQueryRepository implements DisciplineQueryReposit
                                 discipline.deletedAt.isNull()
                         )
                         .fetchOne());
+    }
+
+    @Override
+    public Boolean existsDisciplineOfAll(Long userId) {
+        return jpaQueryFactory
+                .selectOne()
+                .from(discipline)
+                .where(
+                        discipline.user.id.eq(userId),
+                        discipline.type.in(DisciplineType.ALL_3DAYS, DisciplineType.ALL_14DAYS, DisciplineType.ALL_30DAYS, DisciplineType.ALL_3MONTHS),
+                        discipline.startTime.before(LocalDateTime.now()),
+                        discipline.endTime.after(LocalDateTime.now()),
+                        discipline.deletedAt.isNull()
+                )
+                .fetchFirst() != null;
+    }
+
+    @Override
+    public Boolean existsDisciplineOfArtist(Long artistId, Long userId) {
+        return jpaQueryFactory
+                .selectOne()
+                .from(discipline)
+                .where(
+                        discipline.user.id.eq(userId),
+                        discipline.artist.id.eq(artistId),
+                        discipline.type.in(DisciplineType.ARTIST_3DAYS, DisciplineType.ARTIST_14DAYS, DisciplineType.ARTIST_30DAYS, DisciplineType.ARTIST_3MONTHS),
+                        discipline.startTime.before(LocalDateTime.now()),
+                        discipline.endTime.after(LocalDateTime.now()),
+                        discipline.deletedAt.isNull()
+                )
+                .fetchFirst() != null;
     }
 }

--- a/src/main/java/com/projectlyrics/server/domain/discipline/repository/impl/QueryDslDisciplineQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/discipline/repository/impl/QueryDslDisciplineQueryRepository.java
@@ -1,7 +1,11 @@
 package com.projectlyrics.server.domain.discipline.repository.impl;
 
+import static com.projectlyrics.server.domain.discipline.domain.QDiscipline.discipline;
+
+import com.projectlyrics.server.domain.discipline.domain.Discipline;
 import com.projectlyrics.server.domain.discipline.repository.DisciplineQueryRepository;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -9,4 +13,18 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class QueryDslDisciplineQueryRepository implements DisciplineQueryRepository {
     private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Optional<Discipline> findById(Long disciplineId) {
+        return Optional.ofNullable(
+                jpaQueryFactory
+                        .selectFrom(discipline)
+                        .leftJoin(discipline.user).fetchJoin()
+                        .leftJoin(discipline.artist).fetchJoin()
+                        .where(
+                                discipline.id.eq(disciplineId),
+                                discipline.deletedAt.isNull()
+                        )
+                        .fetchOne());
+    }
 }

--- a/src/main/java/com/projectlyrics/server/domain/discipline/service/DisciplineCommandService.java
+++ b/src/main/java/com/projectlyrics/server/domain/discipline/service/DisciplineCommandService.java
@@ -47,7 +47,7 @@ public class DisciplineCommandService {
         Artist artist = artistQueryRepository.findById(request.artistId())
                 .orElseThrow(ArtistNotFoundException::new);
 
-        Discipline discipline = disciplineCommandRepository.save(Discipline.create(DisciplineCreate.of(user, artist, request.disciplineReason(), request.disciplineType(), request.startTime())));
+        Discipline discipline = disciplineCommandRepository.save(Discipline.create(DisciplineCreate.of(user, artist, request.disciplineReason(), request.disciplineType(), request.startTime(), request.notificationContent())));
 
         User admin = userQueryRepository.findById(1L).orElseThrow(UserNotFoundException::new);
         eventPublisher.publishEvent(DisciplineEvent.from(admin, discipline));

--- a/src/main/java/com/projectlyrics/server/domain/discipline/service/DisciplineCommandService.java
+++ b/src/main/java/com/projectlyrics/server/domain/discipline/service/DisciplineCommandService.java
@@ -3,22 +3,16 @@ package com.projectlyrics.server.domain.discipline.service;
 import com.projectlyrics.server.domain.artist.entity.Artist;
 import com.projectlyrics.server.domain.artist.exception.ArtistNotFoundException;
 import com.projectlyrics.server.domain.artist.repository.ArtistQueryRepository;
-import com.projectlyrics.server.domain.auth.repository.AuthRepository;
-import com.projectlyrics.server.domain.bookmark.repository.BookmarkCommandRepository;
-import com.projectlyrics.server.domain.comment.repository.CommentCommandRepository;
+import com.projectlyrics.server.domain.auth.service.AuthCommandService;
 import com.projectlyrics.server.domain.discipline.domain.Discipline;
 import com.projectlyrics.server.domain.discipline.domain.DisciplineCreate;
 import com.projectlyrics.server.domain.discipline.domain.DisciplineType;
 import com.projectlyrics.server.domain.discipline.dto.request.DisciplineCreateRequest;
 import com.projectlyrics.server.domain.discipline.repository.DisciplineCommandRepository;
-import com.projectlyrics.server.domain.favoriteartist.repository.FavoriteArtistCommandRepository;
-import com.projectlyrics.server.domain.like.repository.LikeCommandRepository;
-import com.projectlyrics.server.domain.note.repository.NoteCommandRepository;
 import com.projectlyrics.server.domain.notification.domain.event.DisciplineEvent;
 import com.projectlyrics.server.domain.user.entity.User;
 import com.projectlyrics.server.domain.user.exception.UserNotFoundException;
 import com.projectlyrics.server.domain.user.repository.UserQueryRepository;
-import java.time.Clock;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -32,12 +26,7 @@ public class DisciplineCommandService {
     private final DisciplineCommandRepository disciplineCommandRepository;
     private final UserQueryRepository userQueryRepository;
     private final ArtistQueryRepository artistQueryRepository;
-    private final AuthRepository authRepository;
-    private final BookmarkCommandRepository bookmarkCommandRepository;
-    private final CommentCommandRepository commentCommandRepository;
-    private final FavoriteArtistCommandRepository favoriteArtistCommandRepository;
-    private final LikeCommandRepository likeCommandRepository;
-    private final NoteCommandRepository noteCommandRepository;
+    private final AuthCommandService authCommandService;
     private final ApplicationEventPublisher eventPublisher;
 
     public Discipline create(DisciplineCreateRequest request) {
@@ -53,14 +42,7 @@ public class DisciplineCommandService {
         eventPublisher.publishEvent(DisciplineEvent.from(admin, discipline));
 
         if (discipline.getType() == DisciplineType.FORCED_WITHDRAWAL) {
-            authRepository.findById(user.getSocialInfo().getSocialId())
-                    .ifPresent(authRepository::delete);
-            bookmarkCommandRepository.deleteAllByUserId(user.getId());
-            commentCommandRepository.deleteAllByWriterId(user.getId());
-            favoriteArtistCommandRepository.deleteAllByUserId(user.getId());
-            likeCommandRepository.deleteAllByUserId(user.getId());
-            noteCommandRepository.deleteAllByPublisherId(user.getId());
-            user.forcedWithdrawal(Clock.systemDefaultZone());
+            authCommandService.forcedWithdrawal(user);
         }
 
         return discipline;

--- a/src/main/java/com/projectlyrics/server/domain/discipline/service/DisciplineCommandService.java
+++ b/src/main/java/com/projectlyrics/server/domain/discipline/service/DisciplineCommandService.java
@@ -57,7 +57,7 @@ public class DisciplineCommandService {
             favoriteArtistCommandRepository.deleteAllByUserId(user.getId());
             likeCommandRepository.deleteAllByUserId(user.getId());
             noteCommandRepository.deleteAllByPublisherId(user.getId());
-            user.forceDelete(Clock.systemDefaultZone());
+            user.forcedWithdrawal(Clock.systemDefaultZone());
         }
 
         return discipline;

--- a/src/main/java/com/projectlyrics/server/domain/discipline/service/DisciplineCommandService.java
+++ b/src/main/java/com/projectlyrics/server/domain/discipline/service/DisciplineCommandService.java
@@ -3,13 +3,21 @@ package com.projectlyrics.server.domain.discipline.service;
 import com.projectlyrics.server.domain.artist.entity.Artist;
 import com.projectlyrics.server.domain.artist.exception.ArtistNotFoundException;
 import com.projectlyrics.server.domain.artist.repository.ArtistQueryRepository;
+import com.projectlyrics.server.domain.auth.repository.AuthRepository;
+import com.projectlyrics.server.domain.bookmark.repository.BookmarkCommandRepository;
+import com.projectlyrics.server.domain.comment.repository.CommentCommandRepository;
 import com.projectlyrics.server.domain.discipline.domain.Discipline;
 import com.projectlyrics.server.domain.discipline.domain.DisciplineCreate;
+import com.projectlyrics.server.domain.discipline.domain.DisciplineType;
 import com.projectlyrics.server.domain.discipline.dto.request.DisciplineCreateRequest;
 import com.projectlyrics.server.domain.discipline.repository.DisciplineCommandRepository;
+import com.projectlyrics.server.domain.favoriteartist.repository.FavoriteArtistCommandRepository;
+import com.projectlyrics.server.domain.like.repository.LikeCommandRepository;
+import com.projectlyrics.server.domain.note.repository.NoteCommandRepository;
 import com.projectlyrics.server.domain.user.entity.User;
 import com.projectlyrics.server.domain.user.exception.UserNotFoundException;
 import com.projectlyrics.server.domain.user.repository.UserQueryRepository;
+import java.time.Clock;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -23,6 +31,12 @@ public class DisciplineCommandService {
     private final DisciplineCommandRepository disciplineCommandRepository;
     private final UserQueryRepository userQueryRepository;
     private final ArtistQueryRepository artistQueryRepository;
+    private final AuthRepository authRepository;
+    private final BookmarkCommandRepository bookmarkCommandRepository;
+    private final CommentCommandRepository commentCommandRepository;
+    private final FavoriteArtistCommandRepository favoriteArtistCommandRepository;
+    private final LikeCommandRepository likeCommandRepository;
+    private final NoteCommandRepository noteCommandRepository;
 
     public Discipline create(DisciplineCreateRequest request) {
 
@@ -33,7 +47,18 @@ public class DisciplineCommandService {
                         .orElseThrow(ArtistNotFoundException::new))
                 .orElse(null);
 
-        Discipline discipline = disciplineCommandRepository.save(Discipline.create(DisciplineCreate.of(user, artist, request.disciplineReason(), request.disciplineType())));
+        Discipline discipline = disciplineCommandRepository.save(Discipline.create(DisciplineCreate.of(user, artist, request.disciplineReason(), request.disciplineType(), request.startTime())));
+
+        if (discipline.getType() == DisciplineType.FORCED_WITHDRAWAL) {
+            authRepository.findById(user.getSocialInfo().getSocialId())
+                    .ifPresent(authRepository::delete);
+            bookmarkCommandRepository.deleteAllByUserId(user.getId());
+            commentCommandRepository.deleteAllByWriterId(user.getId());
+            favoriteArtistCommandRepository.deleteAllByUserId(user.getId());
+            likeCommandRepository.deleteAllByUserId(user.getId());
+            noteCommandRepository.deleteAllByPublisherId(user.getId());
+            user.forceDelete(Clock.systemDefaultZone());
+        }
 
         return discipline;
     }

--- a/src/main/java/com/projectlyrics/server/domain/discipline/service/DisciplineCommandService.java
+++ b/src/main/java/com/projectlyrics/server/domain/discipline/service/DisciplineCommandService.java
@@ -19,7 +19,6 @@ import com.projectlyrics.server.domain.user.entity.User;
 import com.projectlyrics.server.domain.user.exception.UserNotFoundException;
 import com.projectlyrics.server.domain.user.repository.UserQueryRepository;
 import java.time.Clock;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -45,10 +44,8 @@ public class DisciplineCommandService {
 
         User user = userQueryRepository.findById(request.userId())
                 .orElseThrow(UserNotFoundException::new);
-        Artist artist = Optional.ofNullable(request.artistId())
-                .map(artistId -> artistQueryRepository.findById(artistId)
-                        .orElseThrow(ArtistNotFoundException::new))
-                .orElse(null);
+        Artist artist = artistQueryRepository.findById(request.artistId())
+                .orElseThrow(ArtistNotFoundException::new);
 
         Discipline discipline = disciplineCommandRepository.save(Discipline.create(DisciplineCreate.of(user, artist, request.disciplineReason(), request.disciplineType(), request.startTime())));
 

--- a/src/main/java/com/projectlyrics/server/domain/discipline/service/DisciplineCommandService.java
+++ b/src/main/java/com/projectlyrics/server/domain/discipline/service/DisciplineCommandService.java
@@ -51,7 +51,9 @@ public class DisciplineCommandService {
                 .orElse(null);
 
         Discipline discipline = disciplineCommandRepository.save(Discipline.create(DisciplineCreate.of(user, artist, request.disciplineReason(), request.disciplineType(), request.startTime())));
-        eventPublisher.publishEvent(DisciplineEvent.from(discipline));
+
+        User admin = userQueryRepository.findById(1L).orElseThrow(UserNotFoundException::new);
+        eventPublisher.publishEvent(DisciplineEvent.from(admin, discipline));
 
         if (discipline.getType() == DisciplineType.FORCED_WITHDRAWAL) {
             authRepository.findById(user.getSocialInfo().getSocialId())

--- a/src/main/java/com/projectlyrics/server/domain/discipline/service/DisciplineCommandService.java
+++ b/src/main/java/com/projectlyrics/server/domain/discipline/service/DisciplineCommandService.java
@@ -1,0 +1,40 @@
+package com.projectlyrics.server.domain.discipline.service;
+
+import com.projectlyrics.server.domain.artist.entity.Artist;
+import com.projectlyrics.server.domain.artist.exception.ArtistNotFoundException;
+import com.projectlyrics.server.domain.artist.repository.ArtistQueryRepository;
+import com.projectlyrics.server.domain.discipline.domain.Discipline;
+import com.projectlyrics.server.domain.discipline.domain.DisciplineCreate;
+import com.projectlyrics.server.domain.discipline.dto.request.DisciplineCreateRequest;
+import com.projectlyrics.server.domain.discipline.repository.DisciplineCommandRepository;
+import com.projectlyrics.server.domain.user.entity.User;
+import com.projectlyrics.server.domain.user.exception.UserNotFoundException;
+import com.projectlyrics.server.domain.user.repository.UserQueryRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class DisciplineCommandService {
+
+    private final DisciplineCommandRepository disciplineCommandRepository;
+    private final UserQueryRepository userQueryRepository;
+    private final ArtistQueryRepository artistQueryRepository;
+
+    public Discipline create(DisciplineCreateRequest request) {
+
+        User user = userQueryRepository.findById(request.userId())
+                .orElseThrow(UserNotFoundException::new);
+        Artist artist = Optional.ofNullable(request.artistId())
+                .map(artistId -> artistQueryRepository.findById(artistId)
+                        .orElseThrow(ArtistNotFoundException::new))
+                .orElse(null);
+
+        Discipline discipline = disciplineCommandRepository.save(Discipline.create(DisciplineCreate.of(user, artist, request.reportReason(), request.disciplineType())));
+
+        return discipline;
+    }
+}

--- a/src/main/java/com/projectlyrics/server/domain/discipline/service/DisciplineCommandService.java
+++ b/src/main/java/com/projectlyrics/server/domain/discipline/service/DisciplineCommandService.java
@@ -33,7 +33,7 @@ public class DisciplineCommandService {
                         .orElseThrow(ArtistNotFoundException::new))
                 .orElse(null);
 
-        Discipline discipline = disciplineCommandRepository.save(Discipline.create(DisciplineCreate.of(user, artist, request.reportReason(), request.disciplineType())));
+        Discipline discipline = disciplineCommandRepository.save(Discipline.create(DisciplineCreate.of(user, artist, request.disciplineReason(), request.disciplineType())));
 
         return discipline;
     }

--- a/src/main/java/com/projectlyrics/server/domain/discipline/service/DisciplineCommandService.java
+++ b/src/main/java/com/projectlyrics/server/domain/discipline/service/DisciplineCommandService.java
@@ -14,6 +14,7 @@ import com.projectlyrics.server.domain.user.entity.User;
 import com.projectlyrics.server.domain.user.exception.UserNotFoundException;
 import com.projectlyrics.server.domain.user.repository.UserQueryRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,6 +23,9 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @RequiredArgsConstructor
 public class DisciplineCommandService {
+
+    @Value("${admin}")
+    private Long adminUserId;
 
     private final DisciplineCommandRepository disciplineCommandRepository;
     private final UserQueryRepository userQueryRepository;
@@ -38,7 +42,7 @@ public class DisciplineCommandService {
 
         Discipline discipline = disciplineCommandRepository.save(Discipline.create(DisciplineCreate.of(user, artist, request.disciplineReason(), request.disciplineType(), request.startTime(), request.notificationContent())));
 
-        User admin = userQueryRepository.findById(1L).orElseThrow(UserNotFoundException::new);
+        User admin = userQueryRepository.findById(adminUserId).orElseThrow(UserNotFoundException::new);
         eventPublisher.publishEvent(DisciplineEvent.from(admin, discipline));
 
         if (discipline.getType() == DisciplineType.FORCED_WITHDRAWAL) {

--- a/src/main/java/com/projectlyrics/server/domain/discipline/service/DisciplineCommandService.java
+++ b/src/main/java/com/projectlyrics/server/domain/discipline/service/DisciplineCommandService.java
@@ -14,12 +14,14 @@ import com.projectlyrics.server.domain.discipline.repository.DisciplineCommandRe
 import com.projectlyrics.server.domain.favoriteartist.repository.FavoriteArtistCommandRepository;
 import com.projectlyrics.server.domain.like.repository.LikeCommandRepository;
 import com.projectlyrics.server.domain.note.repository.NoteCommandRepository;
+import com.projectlyrics.server.domain.notification.domain.event.DisciplineEvent;
 import com.projectlyrics.server.domain.user.entity.User;
 import com.projectlyrics.server.domain.user.exception.UserNotFoundException;
 import com.projectlyrics.server.domain.user.repository.UserQueryRepository;
 import java.time.Clock;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -37,6 +39,7 @@ public class DisciplineCommandService {
     private final FavoriteArtistCommandRepository favoriteArtistCommandRepository;
     private final LikeCommandRepository likeCommandRepository;
     private final NoteCommandRepository noteCommandRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     public Discipline create(DisciplineCreateRequest request) {
 
@@ -48,6 +51,7 @@ public class DisciplineCommandService {
                 .orElse(null);
 
         Discipline discipline = disciplineCommandRepository.save(Discipline.create(DisciplineCreate.of(user, artist, request.disciplineReason(), request.disciplineType(), request.startTime())));
+        eventPublisher.publishEvent(DisciplineEvent.from(discipline));
 
         if (discipline.getType() == DisciplineType.FORCED_WITHDRAWAL) {
             authRepository.findById(user.getSocialInfo().getSocialId())

--- a/src/main/java/com/projectlyrics/server/domain/like/repository/LikeQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/like/repository/LikeQueryRepository.java
@@ -1,11 +1,13 @@
 package com.projectlyrics.server.domain.like.repository;
 
 import com.projectlyrics.server.domain.like.domain.Like;
-
+import jakarta.persistence.LockModeType;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.Lock;
 
 public interface LikeQueryRepository {
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     Optional<Like> findByNoteIdAndUserId(Long noteId, Long userId);
 
     long countByNoteId(Long noteId);

--- a/src/main/java/com/projectlyrics/server/domain/like/repository/LikeQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/like/repository/LikeQueryRepository.java
@@ -1,13 +1,10 @@
 package com.projectlyrics.server.domain.like.repository;
 
 import com.projectlyrics.server.domain.like.domain.Like;
-import jakarta.persistence.LockModeType;
 import java.util.Optional;
-import org.springframework.data.jpa.repository.Lock;
 
 public interface LikeQueryRepository {
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
     Optional<Like> findByNoteIdAndUserId(Long noteId, Long userId);
 
     long countByNoteId(Long noteId);

--- a/src/main/java/com/projectlyrics/server/domain/like/repository/impl/QueryDslLikeQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/like/repository/impl/QueryDslLikeQueryRepository.java
@@ -1,14 +1,13 @@
 package com.projectlyrics.server.domain.like.repository.impl;
 
+import static com.projectlyrics.server.domain.like.domain.QLike.like;
+
 import com.projectlyrics.server.domain.like.domain.Like;
 import com.projectlyrics.server.domain.like.repository.LikeQueryRepository;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
-
-import java.util.Optional;
-
-import static com.projectlyrics.server.domain.like.domain.QLike.like;
 
 @Repository
 @RequiredArgsConstructor

--- a/src/main/java/com/projectlyrics/server/domain/note/service/NoteCommandService.java
+++ b/src/main/java/com/projectlyrics/server/domain/note/service/NoteCommandService.java
@@ -1,6 +1,6 @@
 package com.projectlyrics.server.domain.note.service;
 
-import com.projectlyrics.server.domain.discipline.exception.InvaildDisciplineAction;
+import com.projectlyrics.server.domain.discipline.exception.InvaildDisciplineActionException;
 import com.projectlyrics.server.domain.discipline.repository.DisciplineQueryRepository;
 import com.projectlyrics.server.domain.note.dto.request.NoteCreateRequest;
 import com.projectlyrics.server.domain.note.dto.request.NoteUpdateRequest;
@@ -51,7 +51,7 @@ public class NoteCommandService {
 
     private void checkDiscipline(Long artistId, Long userId) {
        if (disciplineQueryRepository.existsDisciplineOfAll(userId) || disciplineQueryRepository.existsDisciplineOfArtist(artistId, userId)) {
-           throw new InvaildDisciplineAction();
+           throw new InvaildDisciplineActionException();
        }
     }
 

--- a/src/main/java/com/projectlyrics/server/domain/note/service/NoteCommandService.java
+++ b/src/main/java/com/projectlyrics/server/domain/note/service/NoteCommandService.java
@@ -50,7 +50,7 @@ public class NoteCommandService {
     }
 
     private void checkDiscipline(Long artistId, Long userId) {
-       if (disciplineQueryRepository.existsDisciplineOfAll(userId) || disciplineQueryRepository.existsDisciplineOfArtist(artistId, userId)) {
+       if (disciplineQueryRepository.existsByAll(userId) || disciplineQueryRepository.existsByArtist(artistId, userId)) {
            throw new InvaildDisciplineActionException();
        }
     }

--- a/src/main/java/com/projectlyrics/server/domain/note/service/NoteCommandService.java
+++ b/src/main/java/com/projectlyrics/server/domain/note/service/NoteCommandService.java
@@ -1,6 +1,6 @@
 package com.projectlyrics.server.domain.note.service;
 
-import com.projectlyrics.server.domain.discipline.exception.InvaildDisciplineActionException;
+import com.projectlyrics.server.domain.discipline.exception.InvalidDisciplineActionException;
 import com.projectlyrics.server.domain.discipline.repository.DisciplineQueryRepository;
 import com.projectlyrics.server.domain.note.dto.request.NoteCreateRequest;
 import com.projectlyrics.server.domain.note.dto.request.NoteUpdateRequest;
@@ -51,7 +51,7 @@ public class NoteCommandService {
 
     private void checkDiscipline(Long artistId, Long userId) {
        if (disciplineQueryRepository.existsByAll(userId) || disciplineQueryRepository.existsByArtist(artistId, userId)) {
-           throw new InvaildDisciplineActionException();
+           throw new InvalidDisciplineActionException();
        }
     }
 

--- a/src/main/java/com/projectlyrics/server/domain/notification/domain/Notification.java
+++ b/src/main/java/com/projectlyrics/server/domain/notification/domain/Notification.java
@@ -105,6 +105,11 @@ public class Notification extends BaseEntity {
                         .putData("noteId", note.getId().toString())
                         .putData("noteTitle", note.getContent())
                         .build();
+            case DISCIPLINE:
+                return builder
+                        .putData("type", type.name())
+                        .putData("content", content)
+                        .build();
             default:
                 throw new IllegalArgumentException("Invalid notification type");
         }

--- a/src/main/java/com/projectlyrics/server/domain/notification/domain/Notification.java
+++ b/src/main/java/com/projectlyrics/server/domain/notification/domain/Notification.java
@@ -5,6 +5,7 @@ import com.projectlyrics.server.domain.comment.domain.Comment;
 import com.projectlyrics.server.domain.common.entity.BaseEntity;
 import com.projectlyrics.server.domain.note.entity.Note;
 import com.projectlyrics.server.domain.notification.domain.event.CommentEvent;
+import com.projectlyrics.server.domain.notification.domain.event.DisciplineEvent;
 import com.projectlyrics.server.domain.notification.domain.event.PublicEvent;
 import com.projectlyrics.server.domain.user.entity.User;
 import jakarta.persistence.*;
@@ -64,6 +65,18 @@ public class Notification extends BaseEntity {
                 event.receiver(),
                 event.note(),
                 event.comment()
+        );
+    }
+
+    public static Notification create(DisciplineEvent event) {
+        return new Notification(
+                null,
+                NotificationType.DISCIPLINE,
+                "작성하신 게시글/댓글이 " +event.discipline().getReason()+ " 이유로 삭제 조치 되었습니다.",
+                event.sender(),
+                event.receiver(),
+                null,
+                null
         );
     }
 

--- a/src/main/java/com/projectlyrics/server/domain/notification/domain/Notification.java
+++ b/src/main/java/com/projectlyrics/server/domain/notification/domain/Notification.java
@@ -1,6 +1,5 @@
 package com.projectlyrics.server.domain.notification.domain;
 
-import com.google.firebase.messaging.Message;
 import com.projectlyrics.server.domain.comment.domain.Comment;
 import com.projectlyrics.server.domain.common.entity.BaseEntity;
 import com.projectlyrics.server.domain.note.entity.Note;
@@ -9,7 +8,13 @@ import com.projectlyrics.server.domain.notification.domain.event.DisciplineEvent
 import com.projectlyrics.server.domain.notification.domain.event.PublicEvent;
 import com.projectlyrics.server.domain.notification.exception.NotificationReceiverUnmatchException;
 import com.projectlyrics.server.domain.user.entity.User;
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -93,30 +98,6 @@ public class Notification extends BaseEntity {
                 null,
                 null
         );
-    }
-
-
-    public Message getMessage() {
-        Message.Builder builder = Message.builder()
-                .setToken(receiver.getFcmToken());
-
-        switch (type) {
-            case COMMENT_ON_NOTE:
-                return builder
-                        .putData("type", type.name())
-                        .putData("senderId", sender.getId().toString())
-                        .putData("senderNickname", sender.getNickname().getValue())
-                        .putData("noteId", note.getId().toString())
-                        .putData("noteTitle", note.getContent())
-                        .build();
-            case DISCIPLINE:
-                return builder
-                        .putData("type", type.name())
-                        .putData("content", content)
-                        .build();
-            default:
-                throw new IllegalArgumentException("Invalid notification type");
-        }
     }
   
     public void check(Long userId) {

--- a/src/main/java/com/projectlyrics/server/domain/notification/domain/NotificationType.java
+++ b/src/main/java/com/projectlyrics/server/domain/notification/domain/NotificationType.java
@@ -2,7 +2,7 @@ package com.projectlyrics.server.domain.notification.domain;
 
 public enum NotificationType {
     COMMENT_ON_NOTE,
-    REPORT,
+    DISCIPLINE,
     PUBLIC,
     ;
 }

--- a/src/main/java/com/projectlyrics/server/domain/notification/domain/event/DisciplineEvent.java
+++ b/src/main/java/com/projectlyrics/server/domain/notification/domain/event/DisciplineEvent.java
@@ -9,9 +9,9 @@ public record DisciplineEvent (
         Discipline discipline
 ) {
 
-    public static DisciplineEvent from(Discipline discipline) {
+    public static DisciplineEvent from(User sender, Discipline discipline) {
         return new DisciplineEvent(
-                discipline.getUser(),
+                sender,
                 discipline.getUser(),
                 discipline
         );

--- a/src/main/java/com/projectlyrics/server/domain/notification/domain/event/DisciplineEvent.java
+++ b/src/main/java/com/projectlyrics/server/domain/notification/domain/event/DisciplineEvent.java
@@ -1,0 +1,19 @@
+package com.projectlyrics.server.domain.notification.domain.event;
+
+import com.projectlyrics.server.domain.discipline.domain.Discipline;
+import com.projectlyrics.server.domain.user.entity.User;
+
+public record DisciplineEvent (
+        User sender,
+        User receiver,
+        Discipline discipline
+) {
+
+    public static DisciplineEvent from(Discipline discipline) {
+        return new DisciplineEvent(
+                discipline.getUser(),
+                discipline.getUser(),
+                discipline
+        );
+    }
+}

--- a/src/main/java/com/projectlyrics/server/domain/notification/service/NotificationCommandService.java
+++ b/src/main/java/com/projectlyrics/server/domain/notification/service/NotificationCommandService.java
@@ -1,13 +1,10 @@
 package com.projectlyrics.server.domain.notification.service;
 
 import com.google.firebase.messaging.FirebaseMessaging;
-import com.google.firebase.messaging.FirebaseMessagingException;
-import com.google.firebase.messaging.MulticastMessage;
 import com.projectlyrics.server.domain.notification.domain.Notification;
 import com.projectlyrics.server.domain.notification.domain.event.CommentEvent;
 import com.projectlyrics.server.domain.notification.domain.event.DisciplineEvent;
 import com.projectlyrics.server.domain.notification.domain.event.PublicEvent;
-import com.projectlyrics.server.domain.notification.exception.FailedToSendNotificationException;
 import com.projectlyrics.server.domain.notification.repository.NotificationCommandRepository;
 import com.projectlyrics.server.domain.notification.repository.NotificationQueryRepository;
 import com.projectlyrics.server.domain.user.entity.User;
@@ -36,26 +33,15 @@ public class NotificationCommandService {
     @Async
     @EventListener
     public CompletableFuture<Void> createCommentNotification(CommentEvent event) {
-        Notification notification = notificationCommandRepository.save(Notification.create(event));
-        send(notification);
+        notificationCommandRepository.save(Notification.create(event));
         return CompletableFuture.completedFuture(null);
     }
 
     @Async
     @EventListener
     public CompletableFuture<Void> createDisciplineNotification(DisciplineEvent event) {
-        Notification notification = notificationCommandRepository.save(Notification.create(event));
-        send(notification);
+        notificationCommandRepository.save(Notification.create(event));
         return CompletableFuture.completedFuture(null);
-    }
-
-    private void send(Notification notification) {
-        try {
-            firebaseMessaging.send(notification.getMessage());
-        } catch (FirebaseMessagingException e) {
-            log.info(e.getMessage());
-            throw new FailedToSendNotificationException();
-        }
     }
 
     public void createPublicNotification(Long adminId, String content) {

--- a/src/main/java/com/projectlyrics/server/domain/notification/service/NotificationCommandService.java
+++ b/src/main/java/com/projectlyrics/server/domain/notification/service/NotificationCommandService.java
@@ -5,6 +5,7 @@ import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.MulticastMessage;
 import com.projectlyrics.server.domain.notification.domain.Notification;
 import com.projectlyrics.server.domain.notification.domain.event.CommentEvent;
+import com.projectlyrics.server.domain.notification.domain.event.DisciplineEvent;
 import com.projectlyrics.server.domain.notification.domain.event.PublicEvent;
 import com.projectlyrics.server.domain.notification.exception.FailedToSendNotificationException;
 import com.projectlyrics.server.domain.notification.repository.NotificationCommandRepository;
@@ -33,6 +34,13 @@ public class NotificationCommandService {
     @Async
     @EventListener
     public void createCommentNotification(CommentEvent event) {
+        Notification notification = notificationCommandRepository.save(Notification.create(event));
+        send(notification);
+    }
+
+    @Async
+    @EventListener
+    public void createDisciplineNotification(DisciplineEvent event) {
         Notification notification = notificationCommandRepository.save(Notification.create(event));
         send(notification);
     }

--- a/src/main/java/com/projectlyrics/server/domain/notification/service/NotificationCommandService.java
+++ b/src/main/java/com/projectlyrics/server/domain/notification/service/NotificationCommandService.java
@@ -12,14 +12,14 @@ import com.projectlyrics.server.domain.notification.repository.NotificationComma
 import com.projectlyrics.server.domain.user.entity.User;
 import com.projectlyrics.server.domain.user.exception.UserNotFoundException;
 import com.projectlyrics.server.domain.user.repository.UserQueryRepository;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Slf4j
 @Service
@@ -33,16 +33,18 @@ public class NotificationCommandService {
 
     @Async
     @EventListener
-    public void createCommentNotification(CommentEvent event) {
+    public CompletableFuture<Void> createCommentNotification(CommentEvent event) {
         Notification notification = notificationCommandRepository.save(Notification.create(event));
         send(notification);
+        return CompletableFuture.completedFuture(null);
     }
 
     @Async
     @EventListener
-    public void createDisciplineNotification(DisciplineEvent event) {
+    public CompletableFuture<Void> createDisciplineNotification(DisciplineEvent event) {
         Notification notification = notificationCommandRepository.save(Notification.create(event));
         send(notification);
+        return CompletableFuture.completedFuture(null);
     }
 
     private void send(Notification notification) {

--- a/src/main/java/com/projectlyrics/server/domain/report/dto/request/ReportCreateRequest.java
+++ b/src/main/java/com/projectlyrics/server/domain/report/dto/request/ReportCreateRequest.java
@@ -1,10 +1,6 @@
 package com.projectlyrics.server.domain.report.dto.request;
 
-import com.projectlyrics.server.domain.comment.domain.Comment;
-import com.projectlyrics.server.domain.note.entity.Note;
 import com.projectlyrics.server.domain.report.domain.ReportReason;
-import com.projectlyrics.server.domain.user.entity.User;
-import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
 

--- a/src/main/java/com/projectlyrics/server/domain/user/entity/User.java
+++ b/src/main/java/com/projectlyrics/server/domain/user/entity/User.java
@@ -1,5 +1,8 @@
 package com.projectlyrics.server.domain.user.entity;
 
+import static com.projectlyrics.server.domain.common.util.DomainUtils.checkEnum;
+import static com.projectlyrics.server.domain.common.util.DomainUtils.checkNull;
+
 import com.projectlyrics.server.domain.common.entity.BaseEntity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Embedded;
@@ -11,15 +14,11 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.List;
-
-import static com.projectlyrics.server.domain.common.util.DomainUtils.checkEnum;
-import static com.projectlyrics.server.domain.common.util.DomainUtils.checkNull;
 
 @Getter
 @EqualsAndHashCode(of = "id", callSuper = false)

--- a/src/main/java/com/projectlyrics/server/domain/user/repository/UserQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/user/repository/UserQueryRepository.java
@@ -16,4 +16,6 @@ public interface UserQueryRepository {
     List<User> findAll();
 
     boolean existsBySocialInfo(SocialInfo socialInfo);
+
+    boolean existsBySocialInfoAndForceDelete(SocialInfo socialInfo);
 }

--- a/src/main/java/com/projectlyrics/server/domain/user/repository/impl/QueryDslUserQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/user/repository/impl/QueryDslUserQueryRepository.java
@@ -1,19 +1,17 @@
 package com.projectlyrics.server.domain.user.repository.impl;
 
+import static com.projectlyrics.server.domain.user.entity.QUser.user;
+
+import com.projectlyrics.server.domain.common.entity.enumerate.EntityStatusEnum;
 import com.projectlyrics.server.domain.user.entity.AuthProvider;
-import com.projectlyrics.server.domain.user.entity.QUser;
 import com.projectlyrics.server.domain.user.entity.SocialInfo;
 import com.projectlyrics.server.domain.user.entity.User;
 import com.projectlyrics.server.domain.user.repository.UserQueryRepository;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-
 import java.util.List;
 import java.util.Optional;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
-
-import static com.projectlyrics.server.domain.user.entity.QUser.user;
 
 @Repository
 @RequiredArgsConstructor
@@ -63,7 +61,23 @@ public class QueryDslUserQueryRepository implements UserQueryRepository {
         return Optional.ofNullable(
                 jpaQueryFactory
                         .selectFrom(user)
-                        .where(user.socialInfo.eq(socialInfo))
+                        .where(
+                                user.socialInfo.eq(socialInfo),
+                                user.status.in(EntityStatusEnum.YET, EntityStatusEnum.IN_USE)
+                        )
+                        .fetchOne()
+        ).isPresent();
+    }
+
+    @Override
+    public boolean existsBySocialInfoAndForceDelete(SocialInfo socialInfo) {
+        return Optional.ofNullable(
+                jpaQueryFactory
+                        .selectFrom(user)
+                        .where(
+                                user.socialInfo.eq(socialInfo),
+                                user.status.eq(EntityStatusEnum.FORCED_WITHDRAWAL)
+                        )
                         .fetchOne()
         ).isPresent();
     }

--- a/src/main/java/com/projectlyrics/server/domain/user/repository/impl/QueryDslUserQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/user/repository/impl/QueryDslUserQueryRepository.java
@@ -58,27 +58,23 @@ public class QueryDslUserQueryRepository implements UserQueryRepository {
 
     @Override
     public boolean existsBySocialInfo(SocialInfo socialInfo) {
-        return Optional.ofNullable(
-                jpaQueryFactory
-                        .selectFrom(user)
-                        .where(
-                                user.socialInfo.eq(socialInfo),
-                                user.status.in(EntityStatusEnum.YET, EntityStatusEnum.IN_USE)
-                        )
-                        .fetchOne()
-        ).isPresent();
+        return jpaQueryFactory
+                .selectFrom(user)
+                .where(
+                        user.socialInfo.eq(socialInfo),
+                        user.status.in(EntityStatusEnum.YET, EntityStatusEnum.IN_USE)
+                )
+                .fetchFirst() != null;
     }
 
     @Override
     public boolean existsBySocialInfoAndForceDelete(SocialInfo socialInfo) {
-        return Optional.ofNullable(
-                jpaQueryFactory
-                        .selectFrom(user)
-                        .where(
-                                user.socialInfo.eq(socialInfo),
-                                user.status.eq(EntityStatusEnum.FORCED_WITHDRAWAL)
-                        )
-                        .fetchOne()
-        ).isPresent();
+        return jpaQueryFactory
+                .selectFrom(user)
+                .where(
+                        user.socialInfo.eq(socialInfo),
+                        user.status.eq(EntityStatusEnum.FORCED_WITHDRAWAL)
+                )
+                .fetchFirst() != null;
     }
 }

--- a/src/main/java/com/projectlyrics/server/global/slack/SlackClient.java
+++ b/src/main/java/com/projectlyrics/server/global/slack/SlackClient.java
@@ -58,6 +58,7 @@ public class SlackClient {
                 "노트",
                 report.getNote().getPublisher().getId(),
                 report.getNote().getId(),
+                report.getNote().getSong().getArtist().getId(),
                 report.getNote().getContent()
         );
     }
@@ -68,11 +69,12 @@ public class SlackClient {
                 "댓글",
                 report.getComment().getWriter().getId(),
                 report.getComment().getId(),
+                report.getComment().getNote().getSong().getArtist().getId(),
                 report.getComment().getContent()
         );
     }
 
-    private void sendReportMessage(Report report, String contentType, Long reportedUserId, Long contentId, String content) {
+    private void sendReportMessage(Report report, String contentType, Long reportedUserId, Long contentId, Long artistId, String content) {
         List<LayoutBlock> blocks = List.of(
                 Blocks.section(section -> section.text(
                         MarkdownTextObject.builder().text(":rotating_light: *" + report.getId() + ") 새로운 신고가 접수되었습니다.*").build())),
@@ -90,18 +92,18 @@ public class SlackClient {
                                 .text(PlainTextObject.builder().text("Accept").build())
                                 .actionId("report_accept")
                                 .style("primary")
-                                .value("{\"type\":\"accepted\", \"reportId\":\"" + report.getId() + "\", \"approvalStatus\":\"ACCEPTED\", \"isFalseReport\":false}")
+                                .value("{\"user\":\""+reportedUserId+", \"reportId\":\"" + report.getId() + ", \"artistId\":\"" + artistId + "\", \"approvalStatus\":\"ACCEPTED\", \"isFalseReport\":false}")
                                 .build(),
                         ButtonElement.builder()
                                 .text(PlainTextObject.builder().text("Dismiss").build())
                                 .actionId("report_dismiss")
                                 .style("danger")
-                                .value("{\"type\":\"dismissed\", \"reportId\":\"" + report.getId() + "\", \"approvalStatus\":\"DISMISSED\", \"isFalseReport\":false}")
+                                .value("{\"reportId\":\"" + report.getId() + "\", \"approvalStatus\":\"DISMISSED\", \"isFalseReport\":false}")
                                 .build(),
                         ButtonElement.builder()
                                 .text(PlainTextObject.builder().text("Fake Report").build())
                                 .actionId("report_fake")
-                                .value("{\"type\":\"fake report\", \"reportId\":\"" + report.getId() + "\", \"approvalStatus\":\"DISMISSED\", \"isFalseReport\":true}")
+                                .value("{\"user\":\""+report.getReporter().getId()+ ", \"reportId\":\"" + report.getId() + ", \"artistId\":\"" + artistId + "\", \"approvalStatus\":\"DISMISSED\", \"isFalseReport\":true}")
                                 .build()
                 )))
         );

--- a/src/main/java/com/projectlyrics/server/global/slack/SlackClient.java
+++ b/src/main/java/com/projectlyrics/server/global/slack/SlackClient.java
@@ -92,7 +92,7 @@ public class SlackClient {
                                 .text(PlainTextObject.builder().text("Accept").build())
                                 .actionId("report_accept")
                                 .style("primary")
-                                .value("{\"user\":\""+reportedUserId+", \"reportId\":\"" + report.getId() + ", \"artistId\":\"" + artistId + "\", \"approvalStatus\":\"ACCEPTED\", \"isFalseReport\":false}")
+                                .value("{\"userId\":\""+reportedUserId+", \"reportId\":\"" + report.getId() + ", \"artistId\":\"" + artistId + "\", \"approvalStatus\":\"ACCEPTED\", \"isFalseReport\":false}")
                                 .build(),
                         ButtonElement.builder()
                                 .text(PlainTextObject.builder().text("Dismiss").build())
@@ -103,7 +103,7 @@ public class SlackClient {
                         ButtonElement.builder()
                                 .text(PlainTextObject.builder().text("Fake Report").build())
                                 .actionId("report_fake")
-                                .value("{\"user\":\""+report.getReporter().getId()+ ", \"reportId\":\"" + report.getId() + ", \"artistId\":\"" + artistId + "\", \"approvalStatus\":\"DISMISSED\", \"isFalseReport\":true}")
+                                .value("{\"userId\":\""+report.getReporter().getId()+ ", \"reportId\":\"" + report.getId() + ", \"artistId\":\"" + artistId + "\", \"approvalStatus\":\"DISMISSED\", \"isFalseReport\":true}")
                                 .build()
                 )))
         );

--- a/src/main/java/com/projectlyrics/server/global/slack/SlackClient.java
+++ b/src/main/java/com/projectlyrics/server/global/slack/SlackClient.java
@@ -57,6 +57,7 @@ public class SlackClient {
                 report,
                 "노트",
                 report.getNote().getPublisher().getId(),
+                report.getNote().getId(),
                 report.getNote().getContent()
         );
     }
@@ -66,17 +67,18 @@ public class SlackClient {
                 report,
                 "댓글",
                 report.getComment().getWriter().getId(),
+                report.getComment().getId(),
                 report.getComment().getContent()
         );
     }
 
-    private void sendReportMessage(Report report, String contentType, Long contentId, String content) {
+    private void sendReportMessage(Report report, String contentType, Long reportedUserId, Long contentId, String content) {
         List<LayoutBlock> blocks = List.of(
                 Blocks.section(section -> section.text(
                         MarkdownTextObject.builder().text(":rotating_light: *" + report.getId() + ") 새로운 신고가 접수되었습니다.*").build())),
                 Blocks.section(section -> section.fields(List.of(
                         MarkdownTextObject.builder().text("*신고자 ID:* " + report.getReporter().getId()).build(),
-                        MarkdownTextObject.builder().text("*피신고자 ID:* " + contentId).build(),
+                        MarkdownTextObject.builder().text("*피신고자 ID:* " + reportedUserId).build(),
                         MarkdownTextObject.builder().text("*" + contentType + " ID:* " + contentId).build(),
                         MarkdownTextObject.builder().text("*신고 이유:* " + report.getReportReason().getDescription()).build(),
                         MarkdownTextObject.builder().text("*신고자 이메일:* " + (report.getEmail() != null ? report.getEmail() : "-")).build(),

--- a/src/main/java/com/projectlyrics/server/global/slack/api/SlackController.java
+++ b/src/main/java/com/projectlyrics/server/global/slack/api/SlackController.java
@@ -1,5 +1,6 @@
 package com.projectlyrics.server.global.slack.api;
 
+import com.projectlyrics.server.domain.auth.service.AuthCommandService;
 import com.projectlyrics.server.domain.discipline.domain.DisciplineReason;
 import com.projectlyrics.server.domain.discipline.domain.DisciplineType;
 import com.projectlyrics.server.domain.discipline.dto.request.DisciplineCreateRequest;
@@ -45,6 +46,7 @@ public class SlackController {
 
     private final ReportCommandService reportCommandService;
     private final DisciplineCommandService disciplineCommandService;
+    private final AuthCommandService authCommandService;
     private final RestTemplate restTemplate = new RestTemplate(); // HTTP 요청을 보내기 위한 RestTemplate
     private static final Logger logger = LoggerFactory.getLogger(SlackController.class);
 

--- a/src/main/java/com/projectlyrics/server/global/slack/api/SlackController.java
+++ b/src/main/java/com/projectlyrics/server/global/slack/api/SlackController.java
@@ -1,6 +1,7 @@
 package com.projectlyrics.server.global.slack.api;
 
 import com.projectlyrics.server.domain.auth.service.AuthCommandService;
+import com.projectlyrics.server.domain.discipline.domain.Discipline;
 import com.projectlyrics.server.domain.discipline.domain.DisciplineReason;
 import com.projectlyrics.server.domain.discipline.domain.DisciplineType;
 import com.projectlyrics.server.domain.discipline.dto.request.DisciplineCreateRequest;
@@ -133,7 +134,7 @@ public class SlackController {
                 if (userId == null || artistId == null || reportId == null || disciplineReason == null || disciplineType == null || startTime == null) {
                     throw new InvalidDisciplineCreate();
                 }
-                disciplineCommandService.create(DisciplineCreateRequest.of(userId, artistId, disciplineReason, disciplineType, startTime));
+                Discipline discipline = disciplineCommandService.create(DisciplineCreateRequest.of(userId, artistId, disciplineReason, disciplineType, startTime));
                 //조치가 들어오면 (허위 신고가 아닌 건에 한해) 해당 노트/댓글 삭제
                 if (disciplineReason != DisciplineReason.FAKE_REPORT) {
                     reportCommandService.deleteReportedTarget(reportId);
@@ -142,7 +143,7 @@ public class SlackController {
                         .put("type", "section")
                         .put("text", new JSONObject()
                                 .put("type", "mrkdwn")
-                                .put("text", ":mega: *사용자*: " + userId + "에 대한 조치가 완료되었습니다.*: \n*조치 사유:* " + disciplineReason.getDescription() + "\n*조치 내용:* " + disciplineType.getDescription())
+                                .put("text", ":mega: *사용자*: " + userId + "에 대한 조치가 완료되었습니다.*: \n*조치 사유:* " + disciplineReason.getDescription() + "\n*조치 내용:* " + disciplineType.getDescription()+"\n*조치 기간: *"+discipline.getStartTime()+" ~ "+discipline.getEndTime())
                         )
                 );
             }

--- a/src/main/java/com/projectlyrics/server/global/slack/api/SlackController.java
+++ b/src/main/java/com/projectlyrics/server/global/slack/api/SlackController.java
@@ -95,6 +95,7 @@ public class SlackController {
                 }
             }
             else if (actionId.startsWith("discipline")) {
+                blocks = new JSONArray();
                 JSONArray actions = json.getJSONArray("actions");
                 DisciplineType disciplineType = null;
                 DisciplineReason disciplineReason = null;
@@ -130,6 +131,13 @@ public class SlackController {
                     reportCommandService.deleteReportedTarget(reportId);
                 }
                 disciplineCommandService.create(DisciplineCreateRequest.of(userId, artistId, disciplineReason, disciplineType));
+                blocks.put(new JSONObject()
+                        .put("type", "section")
+                        .put("text", new JSONObject()
+                                .put("type", "mrkdwn")
+                                .put("text", ":mega: *사용자*: " + userId + "에 대한 조치가 완료되었습니다.*: \n*조치 사유:* " + disciplineReason.getDescription() + "\n*조치 내용:* " + disciplineType.getDescription())
+                        )
+                );
             }
 
             sendFeedbackToSlack(blocks, threadTs);

--- a/src/main/java/com/projectlyrics/server/global/slack/api/SlackController.java
+++ b/src/main/java/com/projectlyrics/server/global/slack/api/SlackController.java
@@ -1,6 +1,5 @@
 package com.projectlyrics.server.global.slack.api;
 
-import com.projectlyrics.server.domain.auth.service.AuthCommandService;
 import com.projectlyrics.server.domain.discipline.domain.Discipline;
 import com.projectlyrics.server.domain.discipline.domain.DisciplineReason;
 import com.projectlyrics.server.domain.discipline.domain.DisciplineType;
@@ -47,10 +46,8 @@ public class SlackController {
 
     private final ReportCommandService reportCommandService;
     private final DisciplineCommandService disciplineCommandService;
-    private final AuthCommandService authCommandService;
     private final RestTemplate restTemplate = new RestTemplate(); // HTTP 요청을 보내기 위한 RestTemplate
     private static final Logger logger = LoggerFactory.getLogger(SlackController.class);
-
 
     @PostMapping
     public ResponseEntity<Void> handleInteractiveMessage(HttpServletRequest request) {

--- a/src/main/java/com/projectlyrics/server/global/slack/api/SlackController.java
+++ b/src/main/java/com/projectlyrics/server/global/slack/api/SlackController.java
@@ -125,12 +125,11 @@ public class SlackController {
                 if (userId == null || artistId == null || reportId == null || disciplineReason == null || disciplineType == null) {
                     throw new InvalidDisciplineCreate();
                 }
-
+                disciplineCommandService.create(DisciplineCreateRequest.of(userId, artistId, disciplineReason, disciplineType));
                 //조치가 들어오면 (허위 신고가 아닌 건에 한해) 해당 노트/댓글 삭제
                 if (disciplineReason != DisciplineReason.FAKE_REPORT) {
                     reportCommandService.deleteReportedTarget(reportId);
                 }
-                disciplineCommandService.create(DisciplineCreateRequest.of(userId, artistId, disciplineReason, disciplineType));
                 blocks.put(new JSONObject()
                         .put("type", "section")
                         .put("text", new JSONObject()

--- a/src/main/java/com/projectlyrics/server/global/slack/api/SlackController.java
+++ b/src/main/java/com/projectlyrics/server/global/slack/api/SlackController.java
@@ -5,7 +5,7 @@ import com.projectlyrics.server.domain.discipline.domain.Discipline;
 import com.projectlyrics.server.domain.discipline.domain.DisciplineReason;
 import com.projectlyrics.server.domain.discipline.domain.DisciplineType;
 import com.projectlyrics.server.domain.discipline.dto.request.DisciplineCreateRequest;
-import com.projectlyrics.server.domain.discipline.exception.InvalidDisciplineCreate;
+import com.projectlyrics.server.domain.discipline.exception.InvalidDisciplineCreateException;
 import com.projectlyrics.server.domain.discipline.service.DisciplineCommandService;
 import com.projectlyrics.server.domain.report.domain.ApprovalStatus;
 import com.projectlyrics.server.domain.report.dto.request.ReportResolveRequest;
@@ -132,7 +132,7 @@ public class SlackController {
                 }
 
                 if (userId == null || artistId == null || reportId == null || disciplineReason == null || disciplineType == null || startTime == null) {
-                    throw new InvalidDisciplineCreate();
+                    throw new InvalidDisciplineCreateException();
                 }
                 Discipline discipline = disciplineCommandService.create(DisciplineCreateRequest.of(userId, artistId, disciplineReason, disciplineType, startTime));
                 //조치가 들어오면 (허위 신고가 아닌 건에 한해) 해당 노트/댓글 삭제

--- a/src/main/java/com/projectlyrics/server/global/slack/api/SlackController.java
+++ b/src/main/java/com/projectlyrics/server/global/slack/api/SlackController.java
@@ -1,6 +1,8 @@
 package com.projectlyrics.server.global.slack.api;
 
+import com.projectlyrics.server.domain.discipline.domain.DisciplineType;
 import com.projectlyrics.server.domain.report.domain.ApprovalStatus;
+import com.projectlyrics.server.domain.report.domain.ReportReason;
 import com.projectlyrics.server.domain.report.dto.request.ReportResolveRequest;
 import com.projectlyrics.server.domain.report.service.ReportCommandService;
 import com.projectlyrics.server.global.slack.exception.SlackFeedbackFailureException;
@@ -9,19 +11,21 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import lombok.RequiredArgsConstructor;
+import org.json.JSONArray;
 import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.ContentCachingRequestWrapper;
+
 
 @RestController
 @RequestMapping("/api/v1/slack/interactive")
@@ -36,6 +40,8 @@ public class SlackController {
 
     private final ReportCommandService reportCommandService;
     private final RestTemplate restTemplate = new RestTemplate(); // HTTP 요청을 보내기 위한 RestTemplate
+    private static final Logger logger = LoggerFactory.getLogger(SlackController.class);
+
 
     @PostMapping
     public ResponseEntity<Void> handleInteractiveMessage(HttpServletRequest request) {
@@ -51,52 +57,267 @@ public class SlackController {
             String actionId = action.getString("action_id");
             JSONObject valueJson = new JSONObject(action.getString("value"));
 
-            // 응답 메세지
-            String message = "";
-            String threadTs = json.getJSONObject("container").optString("message_ts"); ;  // Extract thread_ts if present
+            // 스레드 타임스탬프 추출
+            String threadTs = json.getJSONObject("container").optString("message_ts");  // Extract thread_ts if present
 
+            // 메시지 블록 생성
+            JSONArray blocks = new JSONArray();
             // actionId에 따라 처리
             if (actionId.startsWith("report_")) {
-                String type = valueJson.getString("type");
                 Long reportId = valueJson.getLong("reportId");
                 ApprovalStatus approvalStatus = ApprovalStatus.valueOf(valueJson.getString("approvalStatus"));
                 Boolean isFalseReport = valueJson.getBoolean("isFalseReport");
 
                 reportCommandService.resolve(ReportResolveRequest.of(approvalStatus, isFalseReport), reportId);
-                message = ":white_check_mark: *" + type + " pressed)*\n승인여부 : " + approvalStatus + "   허위신고여부: " + isFalseReport;
+                // 메시지 블록에 추가
+                blocks.put(new JSONObject()
+                        .put("type", "section")
+                        .put("text", new JSONObject()
+                                .put("type", "mrkdwn")
+                                .put("text", ":white_check_mark: *승인 여부*: " + approvalStatus + "\n*허위 신고 여부*: " + isFalseReport)
+                        )
+                );
+
+                if (actionId.contains("accept") || actionId.contains("fake")) {
+                    Long userId = valueJson.getLong("user");
+                    addBlockOfDiscipline(userId, blocks);
+                }
             }
 
-            sendFeedbackToSlack(message, threadTs);
+            sendFeedbackToSlack(blocks, threadTs);
 
             return ResponseEntity.ok().build();
         } catch (Exception e) {
-            e.printStackTrace();
+            logger.error("Failed to send message to Slack", e);
             throw new SlackInteractionFailureException();
         }
     }
 
-    private void sendFeedbackToSlack(String message, String threadTs) {
+    private void sendFeedbackToSlack(JSONArray blocks, String threadTs) {
         try {
+            // 최상위 JSONObject 생성
             JSONObject responseJson = new JSONObject();
-            responseJson.put("channel", channelId);  // 여기에 채널 ID를 넣으세요
-            responseJson.put("text", message);
+            responseJson.put("channel", channelId);  // 슬랙 채널 ID 설정
+            responseJson.put("blocks", blocks);  // blocks는 JSONArray로 전달
 
-            // 스레드에 답장할 경우
+            // 스레드에 답장할 경우 thread_ts 포함
             if (threadTs != null && !threadTs.isEmpty()) {
-                responseJson.put("thread_ts", threadTs);  // 스레드의 타임스탬프 포함
+                responseJson.put("thread_ts", threadTs);
             }
 
             HttpHeaders headers = new HttpHeaders();
-            headers.setContentType(MediaType.APPLICATION_JSON);  // UTF-8 인코딩
-            headers.set("Authorization", "Bearer "+ token);  // Slack 봇 토큰 설정
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            headers.set("Authorization", "Bearer " + token);  // 슬랙 봇 토큰
 
             HttpEntity<String> entity = new HttpEntity<>(responseJson.toString(), headers);
-            String slackApiUrl = "https://slack.com/api/chat.postMessage";  // Slack API URL
+            String slackApiUrl = "https://slack.com/api/chat.postMessage";
 
             restTemplate.postForEntity(slackApiUrl, entity, String.class);
         } catch (Exception e) {
-            e.printStackTrace();
+            logger.error("Failed to send message to Slack", e);
             throw new SlackFeedbackFailureException();
         }
     }
+
+    private void addBlockOfDiscipline(Long userId, JSONArray blocks) {
+        // 조치 선택 폼을 blocks에 추가
+        blocks.put(new JSONObject()
+                .put("type", "input")
+                .put("element", new JSONObject()
+                        .put("type", "multi_static_select")
+                        .put("placeholder", new JSONObject()
+                                .put("type", "plain_text")
+                                .put("text", "옵션을 선택하세요")
+                                .put("emoji", true)
+                        )
+                        .put("options", new JSONArray()
+                                .put(new JSONObject()
+                                        .put("text", new JSONObject()
+                                                .put("type", "plain_text")
+                                                .put("text", DisciplineType.WARNING.getDescription())
+                                                .put("emoji", true)
+                                        )
+                                        .put("value", DisciplineType.WARNING.name())
+                                )
+                                .put(new JSONObject()
+                                        .put("text", new JSONObject()
+                                                .put("type", "plain_text")
+                                                .put("text", DisciplineType.ARTIST_3DAYS.getDescription())
+                                                .put("emoji", true)
+                                        )
+                                        .put("value", DisciplineType.ARTIST_3DAYS.name())
+                                )
+                                .put(new JSONObject()
+                                        .put("text", new JSONObject()
+                                                .put("type", "plain_text")
+                                                .put("text", DisciplineType.ARTIST_14DAYS.getDescription())
+                                                .put("emoji", true)
+                                        )
+                                        .put("value", DisciplineType.ARTIST_14DAYS.name())
+                                )
+                                .put(new JSONObject()
+                                        .put("text", new JSONObject()
+                                                .put("type", "plain_text")
+                                                .put("text", DisciplineType.ARTIST_30DAYS.getDescription())
+                                                .put("emoji", true)
+                                        )
+                                        .put("value", DisciplineType.ARTIST_30DAYS.name())
+                                )
+                                .put(new JSONObject()
+                                        .put("text", new JSONObject()
+                                                .put("type", "plain_text")
+                                                .put("text", DisciplineType.ARTIST_3MONTHS.getDescription())
+                                                .put("emoji", true)
+                                        )
+                                        .put("value", DisciplineType.ARTIST_3MONTHS.name())
+                                )
+                                .put(new JSONObject()
+                                        .put("text", new JSONObject()
+                                                .put("type", "plain_text")
+                                                .put("text", DisciplineType.ALL_3DAYS.getDescription())
+                                                .put("emoji", true)
+                                        )
+                                        .put("value", DisciplineType.ALL_3DAYS.name())
+                                )
+                                .put(new JSONObject()
+                                        .put("text", new JSONObject()
+                                                .put("type", "plain_text")
+                                                .put("text", DisciplineType.ALL_14DAYS.getDescription())
+                                                .put("emoji", true)
+                                        )
+                                        .put("value", DisciplineType.ALL_14DAYS.name())
+                                )
+                                .put(new JSONObject()
+                                        .put("text", new JSONObject()
+                                                .put("type", "plain_text")
+                                                .put("text", DisciplineType.ALL_30DAYS.getDescription())
+                                                .put("emoji", true)
+                                        )
+                                        .put("value", DisciplineType.ALL_30DAYS.name())
+                                )
+                                .put(new JSONObject()
+                                        .put("text", new JSONObject()
+                                                .put("type", "plain_text")
+                                                .put("text", DisciplineType.ALL_3MONTHS.getDescription())
+                                                .put("emoji", true)
+                                        )
+                                        .put("value", DisciplineType.ALL_3MONTHS.name())
+                                )
+                                .put(new JSONObject()
+                                        .put("text", new JSONObject()
+                                                .put("type", "plain_text")
+                                                .put("text", DisciplineType.FORCED_WITHDRAWAL.getDescription())
+                                                .put("emoji", true)
+                                        )
+                                        .put("value", DisciplineType.FORCED_WITHDRAWAL.name())
+                                )
+                        )
+                        .put("action_id", "multi_static_select_action")
+                )
+                .put("label", new JSONObject()
+                        .put("type", "plain_text")
+                        .put("text", ":pencil2: 사용자 " + userId + "에 대한 조치")
+                        .put("emoji", true)
+                )
+        );
+
+
+        // 징계 이유 선택 폼 추가
+        blocks.put(new JSONObject()
+                .put("type", "input")
+                .put("element", new JSONObject()
+                        .put("type", "multi_static_select")
+                        .put("placeholder", new JSONObject()
+                                .put("type", "plain_text")
+                                .put("text", "이유를 선택하세요")
+                                .put("emoji", true)
+                        )
+                        .put("options", new JSONArray()
+                                // ReportReason enum을 기반으로 옵션 생성
+                                .put(new JSONObject()
+                                        .put("text", new JSONObject()
+                                                .put("type", "plain_text")
+                                                .put("text", ReportReason.INAPPROPRIATE_CONTENT.getDescription())
+                                                .put("emoji", true)
+                                        )
+                                        .put("value", ReportReason.INAPPROPRIATE_CONTENT.name())
+                                )
+                                .put(new JSONObject()
+                                        .put("text", new JSONObject()
+                                                .put("type", "plain_text")
+                                                .put("text", ReportReason.DEFAMATION.getDescription())
+                                                .put("emoji", true)
+                                        )
+                                        .put("value", ReportReason.DEFAMATION.name())
+                                )
+                                .put(new JSONObject()
+                                        .put("text", new JSONObject()
+                                                .put("type", "plain_text")
+                                                .put("text", ReportReason.EXPLICIT_CONTENT.getDescription())
+                                                .put("emoji", true)
+                                        )
+                                        .put("value", ReportReason.EXPLICIT_CONTENT.name())
+                                )
+                                .put(new JSONObject()
+                                        .put("text", new JSONObject()
+                                                .put("type", "plain_text")
+                                                .put("text", ReportReason.COMMERCIAL_ADS.getDescription())
+                                                .put("emoji", true)
+                                        )
+                                        .put("value", ReportReason.COMMERCIAL_ADS.name())
+                                )
+                                .put(new JSONObject()
+                                        .put("text", new JSONObject()
+                                                .put("type", "plain_text")
+                                                .put("text", ReportReason.INFO_DISCLOSURE.getDescription())
+                                                .put("emoji", true)
+                                        )
+                                        .put("value", ReportReason.INFO_DISCLOSURE.name())
+                                )
+                                .put(new JSONObject()
+                                        .put("text", new JSONObject()
+                                                .put("type", "plain_text")
+                                                .put("text", ReportReason.POLITICAL_RELIGIOUS.getDescription())
+                                                .put("emoji", true)
+                                        )
+                                        .put("value", ReportReason.POLITICAL_RELIGIOUS.name())
+                                )
+                                .put(new JSONObject()
+                                        .put("text", new JSONObject()
+                                                .put("type", "plain_text")
+                                                .put("text", ReportReason.OTHER.getDescription())
+                                                .put("emoji", true)
+                                        )
+                                        .put("value", ReportReason.OTHER.name())
+                                )
+                        )
+                        .put("action_id", "multi_static_select_reason_action")
+                )
+                .put("label", new JSONObject()
+                        .put("type", "plain_text")
+                        .put("text", ":pencil2: 사용자 " + userId + "에 대한 조치 이유")
+                        .put("emoji", true)
+                )
+        );
+
+        // 제출 버튼 추가
+        blocks.put(new JSONObject()
+                .put("type", "section")
+                .put("text", new JSONObject()
+                        .put("type", "mrkdwn")
+                        .put("text", "사용자에 대한 조치 및 이유를 선택하고 제출해주세요.")
+                )
+                .put("accessory", new JSONObject()
+                        .put("type", "button")
+                        .put("text", new JSONObject()
+                                .put("type", "plain_text")
+                                .put("text", "제출")
+                                .put("emoji", true)
+                        )
+                        .put("value", "submit_action")
+                        .put("action_id", "button_action")
+                )
+        );
+    }
+
 }

--- a/src/test/java/com/projectlyrics/server/domain/comment/service/CommentCommandServiceMockTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/comment/service/CommentCommandServiceMockTest.java
@@ -64,8 +64,8 @@ class CommentCommandServiceMockTest {
         when(noteMock.getSong()).thenReturn(songMock);
         when(noteQueryRepository.findById(anyLong())).thenReturn(Optional.of(noteMock));
         when(commentCommandRepository.save(any(Comment.class))).thenReturn(mock(Comment.class));
-        when(disciplineQueryRepository.existsDisciplineOfAll(anyLong())).thenReturn(false);
-        when(disciplineQueryRepository.existsDisciplineOfArtist(anyLong(), anyLong())).thenReturn(false);
+        when(disciplineQueryRepository.existsByAll(anyLong())).thenReturn(false);
+        when(disciplineQueryRepository.existsByArtist(anyLong(), anyLong())).thenReturn(false);
 
         // when
         commentCommandService.create(request, 1L);

--- a/src/test/java/com/projectlyrics/server/domain/comment/service/CommentCommandServiceMockTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/comment/service/CommentCommandServiceMockTest.java
@@ -1,26 +1,30 @@
 package com.projectlyrics.server.domain.comment.service;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.projectlyrics.server.domain.artist.entity.Artist;
 import com.projectlyrics.server.domain.comment.domain.Comment;
 import com.projectlyrics.server.domain.comment.dto.request.CommentCreateRequest;
 import com.projectlyrics.server.domain.comment.repository.CommentCommandRepository;
 import com.projectlyrics.server.domain.comment.repository.CommentQueryRepository;
+import com.projectlyrics.server.domain.discipline.repository.DisciplineQueryRepository;
 import com.projectlyrics.server.domain.note.entity.Note;
 import com.projectlyrics.server.domain.note.repository.NoteQueryRepository;
 import com.projectlyrics.server.domain.notification.domain.event.CommentEvent;
+import com.projectlyrics.server.domain.song.entity.Song;
 import com.projectlyrics.server.domain.user.entity.User;
 import com.projectlyrics.server.domain.user.repository.UserQueryRepository;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
-
-import java.util.Optional;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class CommentCommandServiceMockTest {
@@ -38,6 +42,9 @@ class CommentCommandServiceMockTest {
     private NoteQueryRepository noteQueryRepository;
 
     @Mock
+    private DisciplineQueryRepository disciplineQueryRepository;
+
+    @Mock
     private ApplicationEventPublisher eventPublisher;
 
     @InjectMocks
@@ -47,9 +54,18 @@ class CommentCommandServiceMockTest {
     void 댓글을_저장할_때_이벤트가_발행된다() {
         // given
         CommentCreateRequest request = new CommentCreateRequest("댓글 내용", 1L);
-        when(userQueryRepository.findById(anyLong())).thenReturn(Optional.of(mock(User.class)));
-        when(noteQueryRepository.findById(anyLong())).thenReturn(Optional.of(mock(Note.class)));
+        User userMock = mock(User.class);
+        when(userQueryRepository.findById(anyLong())).thenReturn(Optional.of(userMock));
+        Artist artistMock = mock(Artist.class);
+        when(artistMock.getId()).thenReturn(1L);
+        Song songMock = mock(Song.class);
+        when(songMock.getArtist()).thenReturn(artistMock);
+        Note noteMock = mock(Note.class);
+        when(noteMock.getSong()).thenReturn(songMock);
+        when(noteQueryRepository.findById(anyLong())).thenReturn(Optional.of(noteMock));
         when(commentCommandRepository.save(any(Comment.class))).thenReturn(mock(Comment.class));
+        when(disciplineQueryRepository.existsDisciplineOfAll(anyLong())).thenReturn(false);
+        when(disciplineQueryRepository.existsDisciplineOfArtist(anyLong(), anyLong())).thenReturn(false);
 
         // when
         commentCommandService.create(request, 1L);
@@ -57,4 +73,5 @@ class CommentCommandServiceMockTest {
         // then
         verify(eventPublisher).publishEvent(any(CommentEvent.class));
     }
+
 }

--- a/src/test/java/com/projectlyrics/server/domain/comment/service/CommentCommandServiceTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/comment/service/CommentCommandServiceTest.java
@@ -12,7 +12,7 @@ import com.projectlyrics.server.domain.comment.dto.request.CommentUpdateRequest;
 import com.projectlyrics.server.domain.comment.exception.InvalidCommentDeletionException;
 import com.projectlyrics.server.domain.comment.exception.InvalidCommentUpdateException;
 import com.projectlyrics.server.domain.comment.repository.CommentQueryRepository;
-import com.projectlyrics.server.domain.discipline.exception.InvaildDisciplineAction;
+import com.projectlyrics.server.domain.discipline.exception.InvaildDisciplineActionException;
 import com.projectlyrics.server.domain.discipline.repository.DisciplineCommandRepository;
 import com.projectlyrics.server.domain.note.dto.request.NoteCreateRequest;
 import com.projectlyrics.server.domain.note.entity.Note;
@@ -182,7 +182,7 @@ class CommentCommandServiceTest extends IntegrationTest {
 
         // when, then
         assertThatThrownBy(() -> sut.create(commentCreateRequest, user.getId()))
-                .isInstanceOf(InvaildDisciplineAction.class);
+                .isInstanceOf(InvaildDisciplineActionException.class);
     }
 
     @Test
@@ -196,6 +196,6 @@ class CommentCommandServiceTest extends IntegrationTest {
 
         // when, then
         assertThatThrownBy(() -> sut.create(commentCreateRequest, user.getId()))
-                .isInstanceOf(InvaildDisciplineAction.class);
+                .isInstanceOf(InvaildDisciplineActionException.class);
     }
 }

--- a/src/test/java/com/projectlyrics/server/domain/comment/service/CommentCommandServiceTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/comment/service/CommentCommandServiceTest.java
@@ -1,5 +1,9 @@
 package com.projectlyrics.server.domain.comment.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
 import com.projectlyrics.server.domain.artist.entity.Artist;
 import com.projectlyrics.server.domain.artist.repository.ArtistCommandRepository;
 import com.projectlyrics.server.domain.comment.domain.Comment;
@@ -8,6 +12,8 @@ import com.projectlyrics.server.domain.comment.dto.request.CommentUpdateRequest;
 import com.projectlyrics.server.domain.comment.exception.InvalidCommentDeletionException;
 import com.projectlyrics.server.domain.comment.exception.InvalidCommentUpdateException;
 import com.projectlyrics.server.domain.comment.repository.CommentQueryRepository;
+import com.projectlyrics.server.domain.discipline.exception.InvaildDisciplineAction;
+import com.projectlyrics.server.domain.discipline.repository.DisciplineCommandRepository;
 import com.projectlyrics.server.domain.note.dto.request.NoteCreateRequest;
 import com.projectlyrics.server.domain.note.entity.Note;
 import com.projectlyrics.server.domain.note.entity.NoteBackground;
@@ -21,15 +27,12 @@ import com.projectlyrics.server.domain.user.entity.User;
 import com.projectlyrics.server.domain.user.repository.UserCommandRepository;
 import com.projectlyrics.server.support.IntegrationTest;
 import com.projectlyrics.server.support.fixture.ArtistFixture;
+import com.projectlyrics.server.support.fixture.DisciplineFixture;
 import com.projectlyrics.server.support.fixture.SongFixture;
 import com.projectlyrics.server.support.fixture.UserFixture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
 class CommentCommandServiceTest extends IntegrationTest {
 
@@ -52,7 +55,11 @@ class CommentCommandServiceTest extends IntegrationTest {
     CommentQueryRepository commentQueryRepository;
 
     @Autowired
+    DisciplineCommandRepository disciplineCommandRepository;
+
+    @Autowired
     CommentCommandService sut;
+
 
     private User user;
     private Artist artist;
@@ -162,5 +169,33 @@ class CommentCommandServiceTest extends IntegrationTest {
         // when, then
         assertThatThrownBy(() -> sut.delete(comment.getId(), anonymousUser.getId()))
                 .isInstanceOf(InvalidCommentDeletionException.class);
+    }
+
+    @Test
+    void 작성자가_전체_글쓰기_제한_징계에_걸려_있다면_댓글을_생성할_수_없다() {
+        // given
+        CommentCreateRequest commentCreateRequest = new CommentCreateRequest(
+                "content",
+                note.getId()
+        );
+        disciplineCommandRepository.save(DisciplineFixture.createForAll(artist, user));
+
+        // when, then
+        assertThatThrownBy(() -> sut.create(commentCreateRequest, user.getId()))
+                .isInstanceOf(InvaildDisciplineAction.class);
+    }
+
+    @Test
+    void 작성자가_해당_아티스트에_대한_글쓰기_제한_징계에_걸려_있다면_댓글을_생성할_수_없다() {
+        // given
+        CommentCreateRequest commentCreateRequest = new CommentCreateRequest(
+                "content",
+                note.getId()
+        );
+        disciplineCommandRepository.save(DisciplineFixture.createForArtist(artist, user));
+
+        // when, then
+        assertThatThrownBy(() -> sut.create(commentCreateRequest, user.getId()))
+                .isInstanceOf(InvaildDisciplineAction.class);
     }
 }

--- a/src/test/java/com/projectlyrics/server/domain/comment/service/CommentCommandServiceTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/comment/service/CommentCommandServiceTest.java
@@ -12,7 +12,7 @@ import com.projectlyrics.server.domain.comment.dto.request.CommentUpdateRequest;
 import com.projectlyrics.server.domain.comment.exception.InvalidCommentDeletionException;
 import com.projectlyrics.server.domain.comment.exception.InvalidCommentUpdateException;
 import com.projectlyrics.server.domain.comment.repository.CommentQueryRepository;
-import com.projectlyrics.server.domain.discipline.exception.InvaildDisciplineActionException;
+import com.projectlyrics.server.domain.discipline.exception.InvalidDisciplineActionException;
 import com.projectlyrics.server.domain.discipline.repository.DisciplineCommandRepository;
 import com.projectlyrics.server.domain.note.dto.request.NoteCreateRequest;
 import com.projectlyrics.server.domain.note.entity.Note;
@@ -182,7 +182,7 @@ class CommentCommandServiceTest extends IntegrationTest {
 
         // when, then
         assertThatThrownBy(() -> sut.create(commentCreateRequest, user.getId()))
-                .isInstanceOf(InvaildDisciplineActionException.class);
+                .isInstanceOf(InvalidDisciplineActionException.class);
     }
 
     @Test
@@ -196,6 +196,6 @@ class CommentCommandServiceTest extends IntegrationTest {
 
         // when, then
         assertThatThrownBy(() -> sut.create(commentCreateRequest, user.getId()))
-                .isInstanceOf(InvaildDisciplineActionException.class);
+                .isInstanceOf(InvalidDisciplineActionException.class);
     }
 }

--- a/src/test/java/com/projectlyrics/server/domain/discipline/domain/DisciplineTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/discipline/domain/DisciplineTest.java
@@ -19,13 +19,15 @@ public class DisciplineTest {
         Artist artist = ArtistFixture.create();
         DisciplineReason disciplineReason = DisciplineReason.COMMERCIAL_ADS;
         DisciplineType disciplineType = DisciplineType.ALL_3MONTHS;
+        String notificationContent = "{시작시간}부터 {종료시간}까지";
 
         DisciplineCreate disciplineCreate = new DisciplineCreate(
                 user,
                 artist,
                 disciplineReason,
                 disciplineType,
-                LocalDateTime.now()
+                LocalDateTime.of(2024, 10, 7, 0, 0),
+                notificationContent
         );
 
         // when
@@ -40,7 +42,8 @@ public class DisciplineTest {
                 () -> assertThat(discipline.getStartTime().getMinute()).isEqualTo(0),
                 () -> assertThat(discipline.getStartTime().getSecond()).isEqualTo(0),
                 () -> assertThat(discipline.getStartTime().getNano()).isEqualTo(0),
-                () -> assertThat(discipline.getStartTime().plus(disciplineType.getPeriod())).isEqualTo(discipline.getEndTime())
+                () -> assertThat(discipline.getStartTime().plus(disciplineType.getPeriod())).isEqualTo(discipline.getEndTime()),
+                () -> assertThat(discipline.getNotificationContent()).isEqualTo("2024년 10월 7일 0시부터 2025년 1월 7일 0시까지")
         );
     }
 

--- a/src/test/java/com/projectlyrics/server/domain/discipline/domain/DisciplineTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/discipline/domain/DisciplineTest.java
@@ -7,6 +7,7 @@ import com.projectlyrics.server.domain.artist.entity.Artist;
 import com.projectlyrics.server.domain.user.entity.User;
 import com.projectlyrics.server.support.fixture.ArtistFixture;
 import com.projectlyrics.server.support.fixture.UserFixture;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;
 
 public class DisciplineTest {
@@ -23,7 +24,8 @@ public class DisciplineTest {
                 user,
                 artist,
                 disciplineReason,
-                disciplineType
+                disciplineType,
+                LocalDateTime.now()
         );
 
         // when

--- a/src/test/java/com/projectlyrics/server/domain/discipline/domain/DisciplineTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/discipline/domain/DisciplineTest.java
@@ -1,0 +1,43 @@
+package com.projectlyrics.server.domain.discipline.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.projectlyrics.server.domain.artist.entity.Artist;
+import com.projectlyrics.server.domain.report.domain.ReportReason;
+import com.projectlyrics.server.domain.user.entity.User;
+import com.projectlyrics.server.support.fixture.ArtistFixture;
+import com.projectlyrics.server.support.fixture.UserFixture;
+import org.junit.jupiter.api.Test;
+
+public class DisciplineTest {
+
+    @Test
+    void DisciplineCreate_객체로부터_Discipline_객체를_생성할_수_있다() {
+        // given
+        User user = UserFixture.create();
+        Artist artist = ArtistFixture.create();
+        ReportReason reportReason = ReportReason.COMMERCIAL_ADS;
+        DisciplineType disciplineType = DisciplineType.ALL_3MONTHS;
+
+        DisciplineCreate disciplineCreate = new DisciplineCreate(
+                user,
+                artist,
+                reportReason,
+                disciplineType
+        );
+
+        // when
+        Discipline discipline = Discipline.create(disciplineCreate);
+
+        // then
+        assertAll(
+                () -> assertThat(discipline.getUser().getId()).isEqualTo(user.getId()),
+                () -> assertThat(discipline.getArtist().getId()).isEqualTo(artist.getId()),
+                () -> assertThat(discipline.getReason()).isEqualTo(reportReason),
+                () -> assertThat(discipline.getType()).isEqualTo(disciplineType),
+                () -> assertThat(discipline.getStartTime().plus(disciplineType.getPeriod())).isEqualTo(discipline.getEndTime())
+        );
+    }
+
+}

--- a/src/test/java/com/projectlyrics/server/domain/discipline/domain/DisciplineTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/discipline/domain/DisciplineTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.projectlyrics.server.domain.artist.entity.Artist;
-import com.projectlyrics.server.domain.report.domain.ReportReason;
 import com.projectlyrics.server.domain.user.entity.User;
 import com.projectlyrics.server.support.fixture.ArtistFixture;
 import com.projectlyrics.server.support.fixture.UserFixture;
@@ -17,13 +16,13 @@ public class DisciplineTest {
         // given
         User user = UserFixture.create();
         Artist artist = ArtistFixture.create();
-        ReportReason reportReason = ReportReason.COMMERCIAL_ADS;
+        DisciplineReason disciplineReason = DisciplineReason.COMMERCIAL_ADS;
         DisciplineType disciplineType = DisciplineType.ALL_3MONTHS;
 
         DisciplineCreate disciplineCreate = new DisciplineCreate(
                 user,
                 artist,
-                reportReason,
+                disciplineReason,
                 disciplineType
         );
 
@@ -34,7 +33,7 @@ public class DisciplineTest {
         assertAll(
                 () -> assertThat(discipline.getUser().getId()).isEqualTo(user.getId()),
                 () -> assertThat(discipline.getArtist().getId()).isEqualTo(artist.getId()),
-                () -> assertThat(discipline.getReason()).isEqualTo(reportReason),
+                () -> assertThat(discipline.getReason()).isEqualTo(disciplineReason),
                 () -> assertThat(discipline.getType()).isEqualTo(disciplineType),
                 () -> assertThat(discipline.getStartTime().getMinute()).isEqualTo(0),
                 () -> assertThat(discipline.getStartTime().getSecond()).isEqualTo(0),

--- a/src/test/java/com/projectlyrics/server/domain/discipline/domain/DisciplineTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/discipline/domain/DisciplineTest.java
@@ -36,6 +36,9 @@ public class DisciplineTest {
                 () -> assertThat(discipline.getArtist().getId()).isEqualTo(artist.getId()),
                 () -> assertThat(discipline.getReason()).isEqualTo(reportReason),
                 () -> assertThat(discipline.getType()).isEqualTo(disciplineType),
+                () -> assertThat(discipline.getStartTime().getMinute()).isEqualTo(0),
+                () -> assertThat(discipline.getStartTime().getSecond()).isEqualTo(0),
+                () -> assertThat(discipline.getStartTime().getNano()).isEqualTo(0),
                 () -> assertThat(discipline.getStartTime().plus(disciplineType.getPeriod())).isEqualTo(discipline.getEndTime())
         );
     }

--- a/src/test/java/com/projectlyrics/server/domain/discipline/service/DisciplineCommandServiceTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/discipline/service/DisciplineCommandServiceTest.java
@@ -1,0 +1,98 @@
+package com.projectlyrics.server.domain.discipline.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.projectlyrics.server.domain.artist.entity.Artist;
+import com.projectlyrics.server.domain.artist.repository.ArtistCommandRepository;
+import com.projectlyrics.server.domain.discipline.domain.Discipline;
+import com.projectlyrics.server.domain.discipline.domain.DisciplineType;
+import com.projectlyrics.server.domain.discipline.dto.request.DisciplineCreateRequest;
+import com.projectlyrics.server.domain.discipline.repository.DisciplineQueryRepository;
+import com.projectlyrics.server.domain.report.domain.ReportReason;
+import com.projectlyrics.server.domain.user.entity.User;
+import com.projectlyrics.server.domain.user.repository.UserCommandRepository;
+import com.projectlyrics.server.support.IntegrationTest;
+import com.projectlyrics.server.support.fixture.ArtistFixture;
+import com.projectlyrics.server.support.fixture.UserFixture;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class DisciplineCommandServiceTest extends IntegrationTest {
+    @Autowired
+    UserCommandRepository userCommandRepository;
+
+    @Autowired
+    ArtistCommandRepository artistCommandRepository;
+
+    @Autowired
+    DisciplineQueryRepository disciplineQueryRepository;
+
+    @Autowired
+    DisciplineCommandService sut;
+
+    private User user;
+    private Artist artist;
+
+    @BeforeEach
+    void setUp() {
+        user = userCommandRepository.save(UserFixture.create());
+        artist = artistCommandRepository.save(ArtistFixture.create());
+    }
+
+    @Test
+    void 조치를_저장해야_한다() throws Exception {
+        // given
+        DisciplineCreateRequest request = new DisciplineCreateRequest(
+                user.getId(),
+                artist.getId(),
+                ReportReason.COMMERCIAL_ADS,
+                DisciplineType.ALL_3MONTHS
+        );
+
+        // when
+        Discipline discipline = sut.create(request);
+
+        // then
+        Optional<Discipline> result = disciplineQueryRepository.findById(discipline.getId());
+        assertAll(
+                () -> assertThat(result.isPresent()),
+                () -> assertThat(result.get().getId().equals(discipline.getId())),
+                () -> assertThat(result.get().getUser()).isEqualTo(discipline.getUser()),
+                () -> assertThat(result.get().getArtist()).isEqualTo(discipline.getArtist()),
+                () -> assertThat(result.get().getReason()).isEqualTo(discipline.getReason()),
+                () -> assertThat(result.get().getType()).isEqualTo(discipline.getType()),
+                () -> assertThat(result.get().getStartTime()).isEqualTo(discipline.getStartTime()),
+                () -> assertThat(result.get().getEndTime()).isEqualTo(discipline.getEndTime())
+        );
+    }
+
+    @Test
+    void 해당하는_가수가_null이더라도_정상적으로_조치를_저장해야_한다() throws Exception {
+        // given
+        DisciplineCreateRequest request = new DisciplineCreateRequest(
+                user.getId(),
+                null,
+                ReportReason.COMMERCIAL_ADS,
+                DisciplineType.ALL_3MONTHS
+        );
+
+        // when
+        Discipline discipline = sut.create(request);
+
+        // then
+        Optional<Discipline> result = disciplineQueryRepository.findById(discipline.getId());
+        assertAll(
+                () -> assertThat(result.isPresent()),
+                () -> assertThat(result.get().getId().equals(discipline.getId())),
+                () -> assertThat(result.get().getUser()).isEqualTo(discipline.getUser()),
+                () -> assertThat(result.get().getArtist()).isEqualTo(discipline.getArtist()),
+                () -> assertThat(result.get().getReason()).isEqualTo(discipline.getReason()),
+                () -> assertThat(result.get().getType()).isEqualTo(discipline.getType()),
+                () -> assertThat(result.get().getStartTime()).isEqualTo(discipline.getStartTime()),
+                () -> assertThat(result.get().getEndTime()).isEqualTo(discipline.getEndTime())
+        );
+    }
+}

--- a/src/test/java/com/projectlyrics/server/domain/discipline/service/DisciplineCommandServiceTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/discipline/service/DisciplineCommandServiceTest.java
@@ -15,6 +15,7 @@ import com.projectlyrics.server.domain.user.repository.UserCommandRepository;
 import com.projectlyrics.server.support.IntegrationTest;
 import com.projectlyrics.server.support.fixture.ArtistFixture;
 import com.projectlyrics.server.support.fixture.UserFixture;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -49,7 +50,8 @@ public class DisciplineCommandServiceTest extends IntegrationTest {
                 user.getId(),
                 artist.getId(),
                 DisciplineReason.COMMERCIAL_ADS,
-                DisciplineType.ALL_3MONTHS
+                DisciplineType.ALL_3MONTHS,
+                LocalDateTime.now()
         );
 
         // when
@@ -76,7 +78,8 @@ public class DisciplineCommandServiceTest extends IntegrationTest {
                 user.getId(),
                 null,
                 DisciplineReason.COMMERCIAL_ADS,
-                DisciplineType.ALL_3MONTHS
+                DisciplineType.ALL_3MONTHS,
+                LocalDateTime.now()
         );
 
         // when

--- a/src/test/java/com/projectlyrics/server/domain/discipline/service/DisciplineCommandServiceTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/discipline/service/DisciplineCommandServiceTest.java
@@ -55,35 +55,8 @@ public class DisciplineCommandServiceTest extends IntegrationTest {
                 artist.getId(),
                 DisciplineReason.COMMERCIAL_ADS,
                 DisciplineType.ALL_3MONTHS,
-                LocalDateTime.now()
-        );
-
-        // when
-        Discipline discipline = sut.create(request);
-
-        // then
-        Optional<Discipline> result = disciplineQueryRepository.findById(discipline.getId());
-        assertAll(
-                () -> assertThat(result.isPresent()),
-                () -> assertThat(result.get().getId().equals(discipline.getId())),
-                () -> assertThat(result.get().getUser()).isEqualTo(discipline.getUser()),
-                () -> assertThat(result.get().getArtist()).isEqualTo(discipline.getArtist()),
-                () -> assertThat(result.get().getReason()).isEqualTo(discipline.getReason()),
-                () -> assertThat(result.get().getType()).isEqualTo(discipline.getType()),
-                () -> assertThat(result.get().getStartTime()).isEqualTo(discipline.getStartTime()),
-                () -> assertThat(result.get().getEndTime()).isEqualTo(discipline.getEndTime())
-        );
-    }
-
-    @Test
-    void 해당하는_가수가_null이더라도_정상적으로_조치를_저장해야_한다() throws Exception {
-        // given
-        DisciplineCreateRequest request = new DisciplineCreateRequest(
-                user.getId(),
-                null,
-                DisciplineReason.COMMERCIAL_ADS,
-                DisciplineType.ALL_3MONTHS,
-                LocalDateTime.now()
+                LocalDateTime.now(),
+                "사용자에게 갈 알림 메세지입니다"
         );
 
         // when
@@ -109,10 +82,11 @@ public class DisciplineCommandServiceTest extends IntegrationTest {
         Long userId = user.getId();
         DisciplineCreateRequest request = new DisciplineCreateRequest(
                 user.getId(),
-                null,
+                artist.getId(),
                 DisciplineReason.COMMERCIAL_ADS,
                 DisciplineType.FORCED_WITHDRAWAL,
-                LocalDateTime.now()
+                LocalDateTime.now(),
+                "사용자에게 갈 알림 메세지입니다"
         );
 
         // when

--- a/src/test/java/com/projectlyrics/server/domain/discipline/service/DisciplineCommandServiceTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/discipline/service/DisciplineCommandServiceTest.java
@@ -12,6 +12,7 @@ import com.projectlyrics.server.domain.discipline.dto.request.DisciplineCreateRe
 import com.projectlyrics.server.domain.discipline.repository.DisciplineQueryRepository;
 import com.projectlyrics.server.domain.user.entity.User;
 import com.projectlyrics.server.domain.user.repository.UserCommandRepository;
+import com.projectlyrics.server.domain.user.repository.UserQueryRepository;
 import com.projectlyrics.server.support.IntegrationTest;
 import com.projectlyrics.server.support.fixture.ArtistFixture;
 import com.projectlyrics.server.support.fixture.UserFixture;
@@ -24,6 +25,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 public class DisciplineCommandServiceTest extends IntegrationTest {
     @Autowired
     UserCommandRepository userCommandRepository;
+
+    @Autowired
+    UserQueryRepository userQueryRepository;
 
     @Autowired
     ArtistCommandRepository artistCommandRepository;
@@ -96,6 +100,27 @@ public class DisciplineCommandServiceTest extends IntegrationTest {
                 () -> assertThat(result.get().getType()).isEqualTo(discipline.getType()),
                 () -> assertThat(result.get().getStartTime()).isEqualTo(discipline.getStartTime()),
                 () -> assertThat(result.get().getEndTime()).isEqualTo(discipline.getEndTime())
+        );
+    }
+
+    @Test
+    void 조치의_종류가_강제탈퇴일_경우_해당_사용자를_강제_탈퇴시켜야_한다() {
+        // given
+        Long userId = user.getId();
+        DisciplineCreateRequest request = new DisciplineCreateRequest(
+                user.getId(),
+                null,
+                DisciplineReason.COMMERCIAL_ADS,
+                DisciplineType.FORCED_WITHDRAWAL,
+                LocalDateTime.now()
+        );
+
+        // when
+        sut.create(request);
+
+        //then
+        assertAll(
+                () -> assertThat(userQueryRepository.findById(userId).isEmpty())
         );
     }
 }

--- a/src/test/java/com/projectlyrics/server/domain/discipline/service/DisciplineCommandServiceTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/discipline/service/DisciplineCommandServiceTest.java
@@ -6,10 +6,10 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import com.projectlyrics.server.domain.artist.entity.Artist;
 import com.projectlyrics.server.domain.artist.repository.ArtistCommandRepository;
 import com.projectlyrics.server.domain.discipline.domain.Discipline;
+import com.projectlyrics.server.domain.discipline.domain.DisciplineReason;
 import com.projectlyrics.server.domain.discipline.domain.DisciplineType;
 import com.projectlyrics.server.domain.discipline.dto.request.DisciplineCreateRequest;
 import com.projectlyrics.server.domain.discipline.repository.DisciplineQueryRepository;
-import com.projectlyrics.server.domain.report.domain.ReportReason;
 import com.projectlyrics.server.domain.user.entity.User;
 import com.projectlyrics.server.domain.user.repository.UserCommandRepository;
 import com.projectlyrics.server.support.IntegrationTest;
@@ -48,7 +48,7 @@ public class DisciplineCommandServiceTest extends IntegrationTest {
         DisciplineCreateRequest request = new DisciplineCreateRequest(
                 user.getId(),
                 artist.getId(),
-                ReportReason.COMMERCIAL_ADS,
+                DisciplineReason.COMMERCIAL_ADS,
                 DisciplineType.ALL_3MONTHS
         );
 
@@ -75,7 +75,7 @@ public class DisciplineCommandServiceTest extends IntegrationTest {
         DisciplineCreateRequest request = new DisciplineCreateRequest(
                 user.getId(),
                 null,
-                ReportReason.COMMERCIAL_ADS,
+                DisciplineReason.COMMERCIAL_ADS,
                 DisciplineType.ALL_3MONTHS
         );
 

--- a/src/test/java/com/projectlyrics/server/domain/note/service/NoteCommandServiceTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/note/service/NoteCommandServiceTest.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.projectlyrics.server.domain.artist.entity.Artist;
 import com.projectlyrics.server.domain.artist.repository.ArtistCommandRepository;
-import com.projectlyrics.server.domain.discipline.exception.InvaildDisciplineActionException;
+import com.projectlyrics.server.domain.discipline.exception.InvalidDisciplineActionException;
 import com.projectlyrics.server.domain.discipline.repository.DisciplineCommandRepository;
 import com.projectlyrics.server.domain.note.dto.request.NoteCreateRequest;
 import com.projectlyrics.server.domain.note.dto.request.NoteUpdateRequest;
@@ -276,7 +276,7 @@ class NoteCommandServiceTest extends IntegrationTest {
 
         // when, then
         assertThatThrownBy(() -> sut.create(request, user.getId()))
-                .isInstanceOf(InvaildDisciplineActionException.class);
+                .isInstanceOf(InvalidDisciplineActionException.class);
     }
 
     @Test
@@ -296,6 +296,6 @@ class NoteCommandServiceTest extends IntegrationTest {
 
         // when, then
         assertThatThrownBy(() -> sut.create(request, user.getId()))
-                .isInstanceOf(InvaildDisciplineActionException.class);
+                .isInstanceOf(InvalidDisciplineActionException.class);
     }
 }

--- a/src/test/java/com/projectlyrics/server/domain/note/service/NoteCommandServiceTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/note/service/NoteCommandServiceTest.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.projectlyrics.server.domain.artist.entity.Artist;
 import com.projectlyrics.server.domain.artist.repository.ArtistCommandRepository;
-import com.projectlyrics.server.domain.discipline.exception.InvaildDisciplineAction;
+import com.projectlyrics.server.domain.discipline.exception.InvaildDisciplineActionException;
 import com.projectlyrics.server.domain.discipline.repository.DisciplineCommandRepository;
 import com.projectlyrics.server.domain.note.dto.request.NoteCreateRequest;
 import com.projectlyrics.server.domain.note.dto.request.NoteUpdateRequest;
@@ -276,7 +276,7 @@ class NoteCommandServiceTest extends IntegrationTest {
 
         // when, then
         assertThatThrownBy(() -> sut.create(request, user.getId()))
-                .isInstanceOf(InvaildDisciplineAction.class);
+                .isInstanceOf(InvaildDisciplineActionException.class);
     }
 
     @Test
@@ -296,6 +296,6 @@ class NoteCommandServiceTest extends IntegrationTest {
 
         // when, then
         assertThatThrownBy(() -> sut.create(request, user.getId()))
-                .isInstanceOf(InvaildDisciplineAction.class);
+                .isInstanceOf(InvaildDisciplineActionException.class);
     }
 }

--- a/src/test/java/com/projectlyrics/server/domain/notification/service/NotificationCommandServiceTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/notification/service/NotificationCommandServiceTest.java
@@ -104,7 +104,7 @@ class NotificationCommandServiceTest extends IntegrationTest {
 
         comment = commentCommandRepository.save(Comment.create(CommentCreate.of("content", user, note)));
 
-        discipline = disciplineCommandRepository.save(Discipline.create(DisciplineCreate.of(user, artist, DisciplineReason.COMMERCIAL_ADS, DisciplineType.ALL_3MONTHS, LocalDateTime.now())));
+        discipline = disciplineCommandRepository.save(Discipline.create(DisciplineCreate.of(user, artist, DisciplineReason.COMMERCIAL_ADS, DisciplineType.ALL_3MONTHS, LocalDateTime.now(), "사용자에게 갈 알림 메세지입니다")));
 
     }
 

--- a/src/test/java/com/projectlyrics/server/domain/notification/service/NotificationCommandServiceTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/notification/service/NotificationCommandServiceTest.java
@@ -142,7 +142,6 @@ class NotificationCommandServiceTest extends IntegrationTest {
         // then
         List<Notification> result = notificationQueryRepository.findAllByReceiverId(user.getId(), null, PageRequest.ofSize(10))
                 .getContent();
-        System.out.println("------------------"+discipline.getUser().getId()+ "   " + user.getId()+"------------------");
         assertAll(
                 () -> assertThat(result.getFirst().getType()).isEqualTo(NotificationType.DISCIPLINE),
                 () -> assertThat(result.getFirst().getSender()).isEqualTo(user),

--- a/src/test/java/com/projectlyrics/server/domain/report/service/ReportCommandServiceTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/report/service/ReportCommandServiceTest.java
@@ -199,16 +199,12 @@ public class ReportCommandServiceTest extends IntegrationTest {
     }
 
     @Test
-    void 신고를_승인하면_해당_신고의_대상인_노트가_삭제된다() throws Exception {
+    void 해당_신고의_대상인_노트를_삭제해야_힌다() throws Exception {
         // given
         Report report = reportCommandRepository.save(ReportFixture.create(note,user));
-        ReportResolveRequest request = new ReportResolveRequest(
-                ApprovalStatus.ACCEPTED,
-                Boolean.TRUE
-        );
 
         // when
-        sut.resolve(request, report.getId());
+        sut.deleteReportedTarget(report.getId());
 
         // then
         assertAll(
@@ -217,16 +213,12 @@ public class ReportCommandServiceTest extends IntegrationTest {
     }
 
     @Test
-    void 신고를_승인하면_해당_신고의_대상인_댓글이_삭제된다() throws Exception {
+    void 해당_신고의_대상인_댓글을_삭제해야_힌다() throws Exception {
         // given
         Report report = reportCommandRepository.save(ReportFixture.create(comment,user));
-        ReportResolveRequest request = new ReportResolveRequest(
-                ApprovalStatus.ACCEPTED,
-                Boolean.TRUE
-        );
 
         // when
-        sut.resolve(request, report.getId());
+        sut.deleteReportedTarget(report.getId());
 
         // then
         assertAll(

--- a/src/test/java/com/projectlyrics/server/domain/report/service/ReportCommandServiceTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/report/service/ReportCommandServiceTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 
@@ -12,7 +11,6 @@ import com.projectlyrics.server.domain.artist.entity.Artist;
 import com.projectlyrics.server.domain.artist.repository.ArtistCommandRepository;
 import com.projectlyrics.server.domain.comment.domain.Comment;
 import com.projectlyrics.server.domain.comment.repository.CommentCommandRepository;
-import com.projectlyrics.server.domain.like.exception.LikeAlreadyExistsException;
 import com.projectlyrics.server.domain.note.dto.request.NoteCreateRequest;
 import com.projectlyrics.server.domain.note.entity.Note;
 import com.projectlyrics.server.domain.note.entity.NoteBackground;
@@ -77,7 +75,6 @@ public class ReportCommandServiceTest extends IntegrationTest {
     private Artist artist;
     private Song song;
     private Note note;
-
     private Comment comment;
 
     @BeforeEach

--- a/src/test/java/com/projectlyrics/server/support/ControllerTest.java
+++ b/src/test/java/com/projectlyrics/server/support/ControllerTest.java
@@ -12,6 +12,7 @@ import com.projectlyrics.server.domain.auth.service.AuthCommandService;
 import com.projectlyrics.server.domain.auth.service.AuthQueryService;
 import com.projectlyrics.server.domain.bookmark.service.BookmarkCommandService;
 import com.projectlyrics.server.domain.comment.service.CommentCommandService;
+import com.projectlyrics.server.domain.discipline.service.DisciplineCommandService;
 import com.projectlyrics.server.domain.favoriteartist.service.FavoriteArtistCommandService;
 import com.projectlyrics.server.domain.favoriteartist.service.FavoriteArtistQueryService;
 import com.projectlyrics.server.domain.like.service.LikeCommandService;
@@ -94,6 +95,9 @@ public abstract class ControllerTest {
 
     @MockBean
     protected ReportCommandService reportCommandService;
+
+    @MockBean
+    protected DisciplineCommandService disciplineCommandService;
 
     @MockBean
     protected SlackClient slackClient;

--- a/src/test/java/com/projectlyrics/server/support/fixture/DisciplineFixture.java
+++ b/src/test/java/com/projectlyrics/server/support/fixture/DisciplineFixture.java
@@ -6,6 +6,7 @@ import com.projectlyrics.server.domain.discipline.domain.DisciplineCreate;
 import com.projectlyrics.server.domain.discipline.domain.DisciplineReason;
 import com.projectlyrics.server.domain.discipline.domain.DisciplineType;
 import com.projectlyrics.server.domain.user.entity.User;
+import java.time.LocalDateTime;
 
 public class DisciplineFixture extends BaseFixture {
 
@@ -16,7 +17,8 @@ public class DisciplineFixture extends BaseFixture {
                         user,
                         artist,
                         DisciplineReason.COMMERCIAL_ADS,
-                        DisciplineType.ALL_3DAYS
+                        DisciplineType.ALL_3DAYS,
+                        LocalDateTime.now()
                 )
         );
     }
@@ -28,7 +30,8 @@ public class DisciplineFixture extends BaseFixture {
                         user,
                         artist,
                         DisciplineReason.COMMERCIAL_ADS,
-                        DisciplineType.ARTIST_3DAYS
+                        DisciplineType.ARTIST_3DAYS,
+                        LocalDateTime.now()
                 )
         );
     }

--- a/src/test/java/com/projectlyrics/server/support/fixture/DisciplineFixture.java
+++ b/src/test/java/com/projectlyrics/server/support/fixture/DisciplineFixture.java
@@ -1,0 +1,35 @@
+package com.projectlyrics.server.support.fixture;
+
+import com.projectlyrics.server.domain.artist.entity.Artist;
+import com.projectlyrics.server.domain.discipline.domain.Discipline;
+import com.projectlyrics.server.domain.discipline.domain.DisciplineCreate;
+import com.projectlyrics.server.domain.discipline.domain.DisciplineReason;
+import com.projectlyrics.server.domain.discipline.domain.DisciplineType;
+import com.projectlyrics.server.domain.user.entity.User;
+
+public class DisciplineFixture extends BaseFixture {
+
+    public static Discipline createForAll(Artist artist, User user) {
+        return Discipline.createWithId(
+                getUniqueId(),
+                DisciplineCreate.of(
+                        user,
+                        artist,
+                        DisciplineReason.COMMERCIAL_ADS,
+                        DisciplineType.ALL_3DAYS
+                )
+        );
+    }
+
+    public static Discipline createForArtist(Artist artist, User user) {
+        return Discipline.createWithId(
+                getUniqueId(),
+                DisciplineCreate.of(
+                        user,
+                        artist,
+                        DisciplineReason.COMMERCIAL_ADS,
+                        DisciplineType.ARTIST_3DAYS
+                )
+        );
+    }
+}

--- a/src/test/java/com/projectlyrics/server/support/fixture/DisciplineFixture.java
+++ b/src/test/java/com/projectlyrics/server/support/fixture/DisciplineFixture.java
@@ -18,7 +18,8 @@ public class DisciplineFixture extends BaseFixture {
                         artist,
                         DisciplineReason.COMMERCIAL_ADS,
                         DisciplineType.ALL_3DAYS,
-                        LocalDateTime.now()
+                        LocalDateTime.now(),
+                        "사용자에게 갈 알림 메세지입니다"
                 )
         );
     }
@@ -31,7 +32,8 @@ public class DisciplineFixture extends BaseFixture {
                         artist,
                         DisciplineReason.COMMERCIAL_ADS,
                         DisciplineType.ARTIST_3DAYS,
-                        LocalDateTime.now()
+                        LocalDateTime.now(),
+                        "사용자에게 갈 알림 메세지입니다"
                 )
         );
     }

--- a/src/test/java/com/projectlyrics/server/support/fixture/ReportFixture.java
+++ b/src/test/java/com/projectlyrics/server/support/fixture/ReportFixture.java
@@ -9,7 +9,7 @@ import com.projectlyrics.server.domain.user.entity.User;
 
 public class ReportFixture extends BaseFixture{
 
-    public static Report create(Note note,User reporter) {
+    public static Report create(Note note, User reporter) {
         return Report.createWithId(
                 getUniqueId(),
                 ReportCreate.of(
@@ -23,7 +23,7 @@ public class ReportFixture extends BaseFixture{
         );
     }
 
-    public static Report create(Comment comment,User reporter) {
+    public static Report create(Comment comment, User reporter) {
         return Report.createWithId(
                 getUniqueId(),
                 ReportCreate.of(

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -48,3 +48,5 @@ slack:
     secret: secret
   channel:
     id: secret
+
+admin: 1


### PR DESCRIPTION
# 🍃 **Pull Requests**

## ⛳️ **작업한 브랜치**
- [SCRUM-175]

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 조치 기능 개발
- 강제 탈퇴 로직 구현 및 회원 가입시 강제 탈퇴 이력 조회
- 글 작성 제한 조치가 적용된 사용자는 글 작성 못하도록 수정
- 조치시 알림 기능 개발
- 테스트 작성

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 아직 알림 문구가 픽스되지 않았기 때문에 후에 수정이 필요할 것 같습니다.
- 기존에 실패하던 알림 테스트 수정해서 되게 만들어놨습니다! (안되면 되도록...) 하지만 아직도 중복 관련 동시성 테스트는 해결하지 못했어요

[SCRUM-175]: https://projectlyrics.atlassian.net/browse/SCRUM-175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
----------------------------
### admin id 관련
말씀드린 대로 생성자 안에서 해보려고 했으나 그럴 경우 생성자를 2개 만들어야 합니다. 그래서 일단 그냥 필드 자체에서 했고, 테스트 통과하는 것도 확인했어요... 생성자 2개 만들기가 더 낫다고 생각하신다면 그렇게 바꾸겠습니다....
```
protected BaseEntity(
            @Value("${admin}") Long adminUserId
    ) {
        this.status = EntityStatusEnum.IN_USE;
        this.adminUserId = adminUserId;
    }

    protected BaseEntity() {this.status = EntityStatusEnum.IN_USE;}
```
생성자에서 하려면 위와 같이 해야 할 것 같습니다.