### PR TITLE
Notification 응답에 created_at 필드 추가

### DIFF
--- a/src/main/java/com/projectlyrics/server/domain/notification/api/dto/response/NotificationGetResponse.java
+++ b/src/main/java/com/projectlyrics/server/domain/notification/api/dto/response/NotificationGetResponse.java
@@ -1,12 +1,17 @@
 package com.projectlyrics.server.domain.notification.api.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.projectlyrics.server.domain.common.dto.util.CursorResponse;
 import com.projectlyrics.server.domain.notification.domain.NotificationType;
+
+import java.time.LocalDateTime;
 
 public record NotificationGetResponse(
         Long id,
         NotificationType type,
         String content,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+        LocalDateTime createdAt,
         boolean checked,
         Long noteId,
         String noteContent,

--- a/src/main/java/com/projectlyrics/server/domain/notification/repository/impl/QueryDslNotificationQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/notification/repository/impl/QueryDslNotificationQueryRepository.java
@@ -33,6 +33,7 @@ public class QueryDslNotificationQueryRepository implements NotificationQueryRep
             notification.id,
             notification.type,
             notification.content,
+            notification.createdAt,
             notification.checked,
             note.id,
             note.content,

--- a/src/test/java/com/projectlyrics/server/domain/notification/api/NotificationControllerTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/notification/api/NotificationControllerTest.java
@@ -14,6 +14,7 @@ import org.springframework.http.MediaType;
 import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.restdocs.payload.JsonFieldType;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -102,6 +103,7 @@ class NotificationControllerTest extends RestDocsTest {
                     id,
                     NotificationType.PUBLIC,
                     "notification content",
+                    LocalDateTime.now(),
                     false,
                     1L,
                     "note content",
@@ -147,6 +149,8 @@ class NotificationControllerTest extends RestDocsTest {
                                         .description("알림 타입 " + getEnumValuesAsString(NotificationType.class)),
                                 fieldWithPath("data[].content").type(JsonFieldType.STRING)
                                         .description("알림 내용 (전체 알림의 경우)"),
+                                fieldWithPath("data[].createdAt").type(JsonFieldType.STRING)
+                                        .description("알림 생성 시간 (ISO-8601 표준)"),
                                 fieldWithPath("data[].checked").type(JsonFieldType.BOOLEAN)
                                         .description("알림 확인 여부"),
                                 fieldWithPath("data[].noteId").type(JsonFieldType.NUMBER)


### PR DESCRIPTION
# 🍃 **Pull Requests**

## ⛳️ **작업한 브랜치**
- [SCRUM-184]

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- NotifcationGetResponse에 `created_at` 필드 추가 및 `@JsonFormat` 달아서 초 단위까지 문자열로 변환해 출력하도록 설정
- QueryDslNotificationQueryRepository에서 생성자로 DTO 정의할 때 `notification.created_at` 추가
- NotificationControllerTest에서 RestDocs 위해 응답 내 바뀐 필드 반영

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 테스트 결과 하단 사진처럼 출력 잘되고 있습니다
<img width="211" alt="image" src="https://github.com/user-attachments/assets/67bdc1c6-77cd-4805-b698-410f8bee5d21">

[SCRUM-184]: https://projectlyrics.atlassian.net/browse/SCRUM-184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ