### PR TITLE
추가 기능 구현

### DIFF
--- a/src/main/java/com/projectlyrics/server/domain/artist/api/ArtistController.java
+++ b/src/main/java/com/projectlyrics/server/domain/artist/api/ArtistController.java
@@ -13,7 +13,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -23,8 +22,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.Collections;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/artists")
@@ -94,11 +91,6 @@ public class ArtistController {
             @RequestParam(name = "size", defaultValue = "10") int size,
             @RequestParam(name = "query", required = false) String query
     ) {
-        if (!StringUtils.hasText(query)) {
-            return ResponseEntity.ok(
-                    new CursorBasePaginatedResponse<>(null, false, Collections.emptyList())
-            );
-        }
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(artistQueryService.searchArtists(query, cursor, PageRequest.of(0, size)));

--- a/src/main/java/com/projectlyrics/server/domain/artist/repository/impl/QueryDslArtistQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/artist/repository/impl/QueryDslArtistQueryRepository.java
@@ -1,12 +1,13 @@
 package com.projectlyrics.server.domain.artist.repository.impl;
 
+import static com.projectlyrics.server.domain.artist.entity.QArtist.*;
 import static com.querydsl.core.types.dsl.Expressions.anyOf;
 
 import com.projectlyrics.server.domain.artist.entity.Artist;
-import com.projectlyrics.server.domain.artist.entity.QArtist;
 import com.projectlyrics.server.domain.artist.repository.ArtistQueryRepository;
 import com.projectlyrics.server.domain.common.util.QueryDslUtils;
-import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import java.util.List;
@@ -23,28 +24,39 @@ import org.springframework.stereotype.Repository;
 public class QueryDslArtistQueryRepository implements ArtistQueryRepository {
 
     private final JPAQueryFactory jpaQueryFactory;
+    private static final OrderSpecifier[] artistNameOrder = {
+            new CaseBuilder()
+                    .when(artist.name.between("가", "힣")).then(1)
+                    .when(artist.name.between("A", "Z")).then(2)
+                    .when(artist.name.between("a", "z")).then(2)
+                    .otherwise(3)
+                    .asc(),
+            artist.name.asc()
+    };
 
     @Override
     public Optional<Artist> findById(Long artistId) {
         return Optional.ofNullable(
                 jpaQueryFactory
-                        .selectFrom(QArtist.artist)
+                        .selectFrom(artist)
                         .where(
-                                QArtist.artist.id.eq(artistId),
-                                QArtist.artist.deletedAt.isNull()
+                                artist.id.eq(artistId),
+                                artist.deletedAt.isNull()
                         )
-                        .fetchOne());
+                        .fetchOne()
+        );
     }
 
     @Override
     public Slice<Artist> findAll(Long cursor, Pageable pageable) {
         List<Artist> content = jpaQueryFactory
-                .selectFrom(QArtist.artist)
+                .selectFrom(artist)
                 .where(
-                        QueryDslUtils.gtCursorId(cursor, QArtist.artist.id),
-                        QArtist.artist.deletedAt.isNull()
+                        QueryDslUtils.gtCursorId(cursor, artist.id),
+                        artist.deletedAt.isNull()
                 )
                 .limit(pageable.getPageSize() + 1)
+                .orderBy(artistNameOrder)
                 .fetch();
 
         return new SliceImpl<>(content, pageable, QueryDslUtils.checkIfHasNext(pageable, content));
@@ -52,10 +64,10 @@ public class QueryDslArtistQueryRepository implements ArtistQueryRepository {
 
     @Override
     public List<Artist> findAllByIds(List<Long> artistIds) {
-        return jpaQueryFactory.selectFrom(QArtist.artist)
+        return jpaQueryFactory.selectFrom(artist)
                 .where(
-                        QArtist.artist.id.in(artistIds),
-                        QArtist.artist.deletedAt.isNull()
+                        artist.id.in(artistIds),
+                        artist.deletedAt.isNull()
                 )
                 .fetch();
     }
@@ -63,15 +75,18 @@ public class QueryDslArtistQueryRepository implements ArtistQueryRepository {
     @Override
     public Slice<Artist> findAllByQuery(String query, Long cursor, Pageable pageable) {
         List<Artist> content = jpaQueryFactory
-                .selectFrom(QArtist.artist)
+                .selectFrom(artist)
                 .where(
-                        QueryDslUtils.gtCursorId(cursor, QArtist.artist.id),
-                        QArtist.artist.deletedAt.isNull(),
+                        QueryDslUtils.gtCursorId(cursor, artist.id),
+                        artist.deletedAt.isNull(),
                         anyOf(
-                                QArtist.artist.name.contains(query)
+                                artist.name.containsIgnoreCase(query),
+                                artist.secondName.containsIgnoreCase(query),
+                                artist.thirdName.containsIgnoreCase(query)
                         )
                 )
                 .limit(pageable.getPageSize() + 1)
+                .orderBy(artistNameOrder)
                 .fetch();
 
         return new SliceImpl<>(content, pageable, QueryDslUtils.checkIfHasNext(pageable, content));

--- a/src/main/java/com/projectlyrics/server/domain/artist/service/ArtistQueryService.java
+++ b/src/main/java/com/projectlyrics/server/domain/artist/service/ArtistQueryService.java
@@ -11,8 +11,6 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 @Service
@@ -33,17 +31,9 @@ public class ArtistQueryService {
     }
 
     public CursorBasePaginatedResponse<ArtistGetResponse> searchArtists(String query, Long cursor, Pageable pageable) {
-        Slice<ArtistGetResponse> searchedArtists = artistQueryRepository.findAllByQuery(
-                        query,
-                        cursor,
-                        pageable
-                )
+        Slice<ArtistGetResponse> searchedArtists = artistQueryRepository.findAllByQuery(query, cursor, pageable)
                 .map(ArtistGetResponse::of);
 
         return CursorBasePaginatedResponse.of(searchedArtists);
-    }
-
-    public List<Artist> getArtistsByIds(List<Long> artistIds) {
-        return artistQueryRepository.findAllByIds(artistIds);
     }
 }

--- a/src/main/java/com/projectlyrics/server/domain/auth/service/AuthCommandService.java
+++ b/src/main/java/com/projectlyrics/server/domain/auth/service/AuthCommandService.java
@@ -105,6 +105,7 @@ public class AuthCommandService {
         favoriteArtistCommandRepository.deleteAllByUserId(userId);
         likeCommandRepository.deleteAllByUserId(userId);
         noteCommandRepository.deleteAllByPublisherId(userId);
-        userCommandRepository.deleteById(userId);
+
+        user.withdraw();
     }
 }

--- a/src/main/java/com/projectlyrics/server/domain/notification/domain/Notification.java
+++ b/src/main/java/com/projectlyrics/server/domain/notification/domain/Notification.java
@@ -89,22 +89,4 @@ public class Notification extends BaseEntity {
 
         checked = true;
     }
-
-    public Message getMessage() {
-        Message.Builder builder = Message.builder()
-                .setToken(receiver.getFcmToken());
-
-        switch (type) {
-            case COMMENT_ON_NOTE:
-                return builder
-                        .putData("type", type.name())
-                        .putData("senderId", sender.getId().toString())
-                        .putData("senderNickname", sender.getNickname().getValue())
-                        .putData("noteId", note.getId().toString())
-                        .putData("noteTitle", note.getContent())
-                        .build();
-            default:
-                throw new IllegalArgumentException("Invalid notification type");
-        }
-    }
 }

--- a/src/main/java/com/projectlyrics/server/domain/user/api/UserController.java
+++ b/src/main/java/com/projectlyrics/server/domain/user/api/UserController.java
@@ -2,12 +2,16 @@ package com.projectlyrics.server.domain.user.api;
 
 import com.projectlyrics.server.domain.auth.authentication.AuthContext;
 import com.projectlyrics.server.domain.auth.authentication.Authenticated;
+import com.projectlyrics.server.domain.user.dto.request.UserUpdateRequest;
 import com.projectlyrics.server.domain.user.dto.response.UserProfileResponse;
+import com.projectlyrics.server.domain.user.dto.response.UserUpdateResponse;
+import com.projectlyrics.server.domain.user.service.UserCommandService;
 import com.projectlyrics.server.domain.user.service.UserQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -17,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
 
     private final UserQueryService userQueryService;
+    private final UserCommandService userCommandService;
 
     @GetMapping
     public ResponseEntity<UserProfileResponse> getProfile(
@@ -25,5 +30,17 @@ public class UserController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(userQueryService.getById(authContext.getId()));
+    }
+
+    @PatchMapping
+    public ResponseEntity<UserUpdateResponse> update(
+            @Authenticated AuthContext authContext,
+            UserUpdateRequest request
+    ) {
+        userCommandService.update(request, authContext.getId());
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(new UserUpdateResponse(true));
     }
 }

--- a/src/main/java/com/projectlyrics/server/domain/user/api/UserController.java
+++ b/src/main/java/com/projectlyrics/server/domain/user/api/UserController.java
@@ -1,0 +1,29 @@
+package com.projectlyrics.server.domain.user.api;
+
+import com.projectlyrics.server.domain.auth.authentication.AuthContext;
+import com.projectlyrics.server.domain.auth.authentication.Authenticated;
+import com.projectlyrics.server.domain.user.dto.response.UserProfileResponse;
+import com.projectlyrics.server.domain.user.service.UserQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserQueryService userQueryService;
+
+    @GetMapping
+    public ResponseEntity<UserProfileResponse> getProfile(
+            @Authenticated AuthContext authContext
+    ) {
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(userQueryService.getById(authContext.getId()));
+    }
+}

--- a/src/main/java/com/projectlyrics/server/domain/user/dto/request/UserUpdateRequest.java
+++ b/src/main/java/com/projectlyrics/server/domain/user/dto/request/UserUpdateRequest.java
@@ -1,0 +1,9 @@
+package com.projectlyrics.server.domain.user.dto.request;
+
+import com.projectlyrics.server.domain.user.entity.ProfileCharacter;
+
+public record UserUpdateRequest(
+        String nickname,
+        ProfileCharacter profileCharacter
+) {
+}

--- a/src/main/java/com/projectlyrics/server/domain/user/dto/response/UserProfileResponse.java
+++ b/src/main/java/com/projectlyrics/server/domain/user/dto/response/UserProfileResponse.java
@@ -1,0 +1,23 @@
+package com.projectlyrics.server.domain.user.dto.response;
+
+import com.projectlyrics.server.domain.user.entity.AuthProvider;
+import com.projectlyrics.server.domain.user.entity.User;
+
+public record UserProfileResponse(
+        Long id,
+        String nickname,
+        String profileCharacterType,
+        String feedbackId,
+        AuthProvider authProvider
+) {
+
+    public static UserProfileResponse from(User user) {
+        return new UserProfileResponse(
+                user.getId(),
+                user.getNickname().getValue(),
+                user.getProfileCharacter().getType(),
+                user.getFeedbackId(),
+                user.getSocialInfo().getAuthProvider()
+        );
+    }
+}

--- a/src/main/java/com/projectlyrics/server/domain/user/dto/response/UserUpdateResponse.java
+++ b/src/main/java/com/projectlyrics/server/domain/user/dto/response/UserUpdateResponse.java
@@ -1,0 +1,6 @@
+package com.projectlyrics.server.domain.user.dto.response;
+
+public record UserUpdateResponse(
+        boolean success
+) {
+}

--- a/src/main/java/com/projectlyrics/server/domain/user/entity/TermsAgreements.java
+++ b/src/main/java/com/projectlyrics/server/domain/user/entity/TermsAgreements.java
@@ -1,8 +1,8 @@
 package com.projectlyrics.server.domain.user.entity;
 
 import com.projectlyrics.server.domain.auth.exception.NotAgreeToTermsException;
+import com.projectlyrics.server.domain.common.entity.BaseEntity;
 import jakarta.persistence.Column;
-import jakarta.persistence.Embeddable;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -12,12 +12,14 @@ import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
+import java.time.Clock;
+
 import static com.projectlyrics.server.domain.common.util.DomainUtils.checkNull;
 import static com.projectlyrics.server.domain.common.util.DomainUtils.checkString;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class TermsAgreements {
+public class TermsAgreements extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -39,14 +41,19 @@ public class TermsAgreements {
         if (!agree) {
             throw new NotAgreeToTermsException();
         }
+
         checkString(title);
-        this.agree = agree;
+        this.agree = true;
         this.title = title;
         this.agreement = agreement;
     }
 
-    void setUser(User user) {
+    public void setUser(User user) {
         checkNull(user);
         this.user = user;
+    }
+
+    public void delete() {
+        delete(user.getId(), Clock.systemDefaultZone());
     }
 }

--- a/src/main/java/com/projectlyrics/server/domain/user/entity/User.java
+++ b/src/main/java/com/projectlyrics/server/domain/user/entity/User.java
@@ -16,6 +16,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.Clock;
 import java.util.List;
 
 import static com.projectlyrics.server.domain.common.util.DomainUtils.checkEnum;
@@ -115,5 +116,13 @@ public class User extends BaseEntity {
                 userCreate.termsAgreements(),
                 userCreate.fcmToken()
         );
+    }
+
+    public void withdraw() {
+        nickname = null;
+        profileCharacter = null;
+        info = null;
+        termsAgreements.forEach(TermsAgreements::delete);
+        delete(id, Clock.systemDefaultZone());
     }
 }

--- a/src/main/java/com/projectlyrics/server/domain/user/entity/User.java
+++ b/src/main/java/com/projectlyrics/server/domain/user/entity/User.java
@@ -18,6 +18,7 @@ import lombok.NoArgsConstructor;
 
 import java.time.Clock;
 import java.util.List;
+import java.util.UUID;
 
 import static com.projectlyrics.server.domain.common.util.DomainUtils.checkEnum;
 import static com.projectlyrics.server.domain.common.util.DomainUtils.checkNull;
@@ -51,7 +52,7 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<TermsAgreements> termsAgreements;
 
-    private String fcmToken;
+    private String feedbackId;
 
     private User(
             Long id,
@@ -61,8 +62,7 @@ public class User extends BaseEntity {
             Role role,
             Gender gender,
             Integer birthYear,
-            List<TermsAgreements> termsAgreements,
-            String fcmToken
+            List<TermsAgreements> termsAgreements
     ) {
         checkNull(socialInfo);
         checkNull(termsAgreements);
@@ -75,7 +75,7 @@ public class User extends BaseEntity {
         this.info = new UserMetaInfo(gender, birthYear);
         this.termsAgreements = termsAgreements;
         termsAgreements.forEach(terms -> terms.setUser(this));
-        this.fcmToken = fcmToken;
+        this.feedbackId = UUID.randomUUID().toString();
     }
 
     private User(
@@ -85,10 +85,9 @@ public class User extends BaseEntity {
             Role role,
             Gender gender,
             Integer birthYear,
-            List<TermsAgreements> termsAgreements,
-            String fcmToken
+            List<TermsAgreements> termsAgreements
     ) {
-        this(null, socialInfo, nickname, profileCharacter, role, gender, birthYear, termsAgreements, fcmToken);
+        this(null, socialInfo, nickname, profileCharacter, role, gender, birthYear, termsAgreements);
     }
 
     public static User withId(
@@ -99,10 +98,9 @@ public class User extends BaseEntity {
             Role role,
             Gender gender,
             Integer birthYear,
-            List<TermsAgreements> termsAgreements,
-            String fcmToken
+            List<TermsAgreements> termsAgreements
     ) {
-        return new User(id, socialInfo, nickname, profileCharacter, role, gender, birthYear, termsAgreements, fcmToken);
+        return new User(id, socialInfo, nickname, profileCharacter, role, gender, birthYear, termsAgreements);
     }
 
     public static User create(UserCreate userCreate) {
@@ -113,8 +111,7 @@ public class User extends BaseEntity {
                 userCreate.role(),
                 userCreate.gender(),
                 userCreate.birthYear(),
-                userCreate.termsAgreements(),
-                userCreate.fcmToken()
+                userCreate.termsAgreements()
         );
     }
 

--- a/src/main/java/com/projectlyrics/server/domain/user/entity/User.java
+++ b/src/main/java/com/projectlyrics/server/domain/user/entity/User.java
@@ -1,6 +1,7 @@
 package com.projectlyrics.server.domain.user.entity;
 
 import com.projectlyrics.server.domain.common.entity.BaseEntity;
+import com.projectlyrics.server.domain.user.dto.request.UserUpdateRequest;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -18,6 +19,7 @@ import lombok.NoArgsConstructor;
 
 import java.time.Clock;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 import static com.projectlyrics.server.domain.common.util.DomainUtils.checkEnum;
@@ -121,5 +123,13 @@ public class User extends BaseEntity {
         info = null;
         termsAgreements.forEach(TermsAgreements::delete);
         delete(id, Clock.systemDefaultZone());
+    }
+
+    public void update(UserUpdateRequest request) {
+        if (Objects.nonNull(request.nickname()) && !request.nickname().isEmpty())
+            nickname = new Username(request.nickname());
+
+        if (Objects.nonNull(request.profileCharacter()))
+            profileCharacter = request.profileCharacter();
     }
 }

--- a/src/main/java/com/projectlyrics/server/domain/user/entity/UserCreate.java
+++ b/src/main/java/com/projectlyrics/server/domain/user/entity/UserCreate.java
@@ -12,7 +12,6 @@ public record UserCreate(
         Gender gender,
         Integer birthYear,
         List<TermsAgreements> termsAgreements,
-        String fcmToken,
         Role role
 ) {
 
@@ -30,7 +29,6 @@ public record UserCreate(
                 request.gender(),
                 Objects.nonNull(request.birthYear()) ? request.birthYear().getValue() : null,
                 termsList,
-                null,
                 role
         );
     }

--- a/src/main/java/com/projectlyrics/server/domain/user/entity/Username.java
+++ b/src/main/java/com/projectlyrics/server/domain/user/entity/Username.java
@@ -18,7 +18,7 @@ public class Username {
 
     private final static Pattern pattern = Pattern.compile("^[a-zA-Z0-9가-힣]{1,10}$");
 
-    @Column(name = "nickname", nullable = false)
+    @Column(name = "nickname")
     private String value;
 
     Username(String value) {

--- a/src/main/java/com/projectlyrics/server/domain/user/entity/Username.java
+++ b/src/main/java/com/projectlyrics/server/domain/user/entity/Username.java
@@ -7,6 +7,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 import static com.projectlyrics.server.domain.common.util.DomainUtils.checkString;
@@ -31,5 +32,18 @@ public class Username {
         if (!pattern.matcher(value).matches()) {
             throw new InvalidUsernameException();
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Username username = (Username) o;
+        return Objects.equals(value, username.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(value);
     }
 }

--- a/src/main/java/com/projectlyrics/server/domain/user/repository/UserCommandRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/user/repository/UserCommandRepository.java
@@ -3,6 +3,4 @@ package com.projectlyrics.server.domain.user.repository;
 import com.projectlyrics.server.domain.user.repository.impl.JpaUserCommandRepository;
 
 public interface UserCommandRepository extends JpaUserCommandRepository {
-
-    void deleteById(Long id);
 }

--- a/src/main/java/com/projectlyrics/server/domain/user/repository/UserQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/user/repository/UserQueryRepository.java
@@ -13,6 +13,8 @@ public interface UserQueryRepository {
 
     Optional<User> findById(Long id);
 
+    Optional<User> findDeletedBySocialIdAndAuthProvider(String socialId, AuthProvider authProvider);
+
     List<User> findAll();
 
     boolean existsBySocialInfo(SocialInfo socialInfo);

--- a/src/main/java/com/projectlyrics/server/domain/user/repository/impl/QueryDslUserQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/user/repository/impl/QueryDslUserQueryRepository.java
@@ -1,7 +1,7 @@
 package com.projectlyrics.server.domain.user.repository.impl;
 
+import com.projectlyrics.server.domain.common.entity.enumerate.EntityStatusEnum;
 import com.projectlyrics.server.domain.user.entity.AuthProvider;
-import com.projectlyrics.server.domain.user.entity.QUser;
 import com.projectlyrics.server.domain.user.entity.SocialInfo;
 import com.projectlyrics.server.domain.user.entity.User;
 import com.projectlyrics.server.domain.user.repository.UserQueryRepository;
@@ -43,6 +43,21 @@ public class QueryDslUserQueryRepository implements UserQueryRepository {
                         .where(
                                 user.id.eq(id),
                                 user.deletedAt.isNull()
+                        )
+                        .fetchOne()
+        );
+    }
+
+    @Override
+    public Optional<User> findDeletedBySocialIdAndAuthProvider(String socialId, AuthProvider authProvider) {
+        return Optional.ofNullable(
+                jpaQueryFactory
+                        .selectFrom(user)
+                        .where(
+                                user.socialInfo.socialId.eq(socialId),
+                                user.socialInfo.authProvider.eq(authProvider),
+                                user.status.eq(EntityStatusEnum.DELETED),
+                                user.deletedAt.isNotNull()
                         )
                         .fetchOne()
         );

--- a/src/main/java/com/projectlyrics/server/domain/user/service/UserCommandService.java
+++ b/src/main/java/com/projectlyrics/server/domain/user/service/UserCommandService.java
@@ -1,0 +1,24 @@
+package com.projectlyrics.server.domain.user.service;
+
+import com.projectlyrics.server.domain.user.dto.request.UserUpdateRequest;
+import com.projectlyrics.server.domain.user.entity.User;
+import com.projectlyrics.server.domain.user.exception.UserNotFoundException;
+import com.projectlyrics.server.domain.user.repository.UserQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class UserCommandService {
+
+    private final UserQueryRepository userQueryRepository;
+
+    public void update(UserUpdateRequest request, Long id) {
+        User user = userQueryRepository.findById(id)
+                .orElseThrow(UserNotFoundException::new);
+
+        user.update(request);
+    }
+}

--- a/src/main/java/com/projectlyrics/server/domain/user/service/UserQueryService.java
+++ b/src/main/java/com/projectlyrics/server/domain/user/service/UserQueryService.java
@@ -1,0 +1,21 @@
+package com.projectlyrics.server.domain.user.service;
+
+import com.projectlyrics.server.domain.user.dto.response.UserProfileResponse;
+import com.projectlyrics.server.domain.user.exception.UserNotFoundException;
+import com.projectlyrics.server.domain.user.repository.UserQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class UserQueryService {
+
+    private final UserQueryRepository userQueryRepository;
+
+    public UserProfileResponse getById(Long id) {
+        return UserProfileResponse.from(userQueryRepository.findById(id)
+                        .orElseThrow(UserNotFoundException::new));
+    }
+}

--- a/src/test/java/com/projectlyrics/server/domain/artist/service/ArtistQueryServiceIntegrationTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/artist/service/ArtistQueryServiceIntegrationTest.java
@@ -11,15 +11,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.SliceImpl;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 class ArtistQueryServiceIntegrationTest extends IntegrationTest {
 
@@ -89,6 +87,30 @@ class ArtistQueryServiceIntegrationTest extends IntegrationTest {
                     s.assertThat(response.data().size()).isEqualTo(1);
                     s.assertThat(response.data().get(0).name()).isEqualTo(artist1.getName());
                 }
+        );
+    }
+
+    @Test
+    void 한국어_영어_특수문자_순으로_아티스트를_정렬한다() {
+        // given
+        artistCommandRepository.save(ArtistFixture.create("실리카겔"));
+        artistCommandRepository.save(ArtistFixture.create("-"));
+        artistCommandRepository.save(ArtistFixture.create("검정치마"));
+        artistCommandRepository.save(ArtistFixture.create("!"));
+        artistCommandRepository.save(ArtistFixture.create("Pia"));
+        artistCommandRepository.save(ArtistFixture.create("Stone Temple Pilots"));
+
+        // when
+        CursorBasePaginatedResponse<ArtistGetResponse> result = sut.getArtistList(null, PageRequest.ofSize(10));
+
+        // then
+        assertAll(
+                () -> assertThat(result.data().get(0).name()).isEqualTo("검정치마"),
+                () -> assertThat(result.data().get(1).name()).isEqualTo("실리카겔"),
+                () -> assertThat(result.data().get(2).name()).isEqualTo("Pia"),
+                () -> assertThat(result.data().get(3).name()).isEqualTo("Stone Temple Pilots"),
+                () -> assertThat(result.data().get(4).name()).isEqualTo("!"),
+                () -> assertThat(result.data().get(5).name()).isEqualTo("-")
         );
     }
 

--- a/src/test/java/com/projectlyrics/server/domain/user/api/UserControllerTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/user/api/UserControllerTest.java
@@ -2,6 +2,7 @@ package com.projectlyrics.server.domain.user.api;
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
+import com.projectlyrics.server.domain.user.dto.request.UserUpdateRequest;
 import com.projectlyrics.server.domain.user.dto.response.UserProfileResponse;
 import com.projectlyrics.server.domain.user.entity.AuthProvider;
 import com.projectlyrics.server.domain.user.entity.ProfileCharacter;
@@ -18,6 +19,7 @@ import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -59,6 +61,45 @@ class UserControllerTest extends RestDocsTest {
                                         .description("인증 플랫폼" + getEnumValuesAsString(AuthProvider.class))
                         )
                         .responseSchema(Schema.schema("User Profile Response"))
+                        .build())
+        );
+    }
+
+    @Test
+    void 사용자의_프로필을_수정하면_200_응답을_해야_한다() throws Exception {
+        // given
+        UserUpdateRequest request = new UserUpdateRequest(
+                "검정치마",
+                ProfileCharacter.BRAIDED_HAIR
+        );
+
+        // when, then
+        mockMvc.perform(patch("/api/v1/notes/{noteId}", 1)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(request)))
+                .andDo(getUserUpdateDocument())
+                .andExpect(status().isOk());
+    }
+
+    private RestDocumentationResultHandler getUserUpdateDocument() {
+        return restDocs.document(
+                resource(ResourceSnippetParameters.builder()
+                        .tag("User API")
+                        .summary("사용자 프로필 수정 API")
+                        .requestHeaders(getAuthorizationHeader())
+                        .requestFields(
+                                fieldWithPath("nickname").type(JsonFieldType.STRING)
+                                        .description("사용자 닉네임"),
+                                fieldWithPath("profileCharacter").type(JsonFieldType.STRING)
+                                        .description("사용자 프로필 이미지 타입" + getEnumValuesAsString(ProfileCharacter.class))
+                        )
+                        .requestSchema(Schema.schema("Update User Request"))
+                        .responseFields(
+                                fieldWithPath("success").type(JsonFieldType.BOOLEAN)
+                                        .description("성공 여부")
+                        )
+                        .responseSchema(Schema.schema("Update User Response"))
                         .build())
         );
     }

--- a/src/test/java/com/projectlyrics/server/domain/user/api/UserControllerTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/user/api/UserControllerTest.java
@@ -1,0 +1,65 @@
+package com.projectlyrics.server.domain.user.api;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+import com.projectlyrics.server.domain.user.dto.response.UserProfileResponse;
+import com.projectlyrics.server.domain.user.entity.AuthProvider;
+import com.projectlyrics.server.domain.user.entity.ProfileCharacter;
+import com.projectlyrics.server.domain.user.entity.User;
+import com.projectlyrics.server.support.RestDocsTest;
+import com.projectlyrics.server.support.fixture.UserFixture;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class UserControllerTest extends RestDocsTest {
+
+    @Test
+    void 사용자의_프로필을_조회하면_데이터와_200응답을_해야_한다() throws Exception {
+        // given
+        User user = UserFixture.create();
+        UserProfileResponse result = UserProfileResponse.from(user);
+
+        given(userQueryService.getById(any()))
+                .willReturn(result);
+
+        // when, then
+        mockMvc.perform(get("/api/v1/users")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(getUserProfileDocument());
+    }
+
+    private RestDocumentationResultHandler getUserProfileDocument() {
+        return restDocs.document(
+                resource(ResourceSnippetParameters.builder()
+                        .tag("User API")
+                        .summary("사용자 프로필 조회 API")
+                        .requestHeaders(getAuthorizationHeader())
+                        .responseFields(
+                                fieldWithPath("id").type(JsonFieldType.NUMBER)
+                                        .description("사용자 Id"),
+                                fieldWithPath("nickname").type(JsonFieldType.STRING)
+                                        .description("사용자 닉네임"),
+                                fieldWithPath("profileCharacterType").type(JsonFieldType.STRING)
+                                        .description("사용자 프로필 이미지 타입" + getEnumValuesAsString(ProfileCharacter.class)),
+                                fieldWithPath("feedbackId").type(JsonFieldType.STRING)
+                                        .description("사용자 피드백 UUID"),
+                                fieldWithPath("authProvider").type(JsonFieldType.STRING)
+                                        .description("인증 플랫폼" + getEnumValuesAsString(AuthProvider.class))
+                        )
+                        .responseSchema(Schema.schema("User Profile Response"))
+                        .build())
+        );
+    }
+}

--- a/src/test/java/com/projectlyrics/server/domain/user/service/UserCommandServiceTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/user/service/UserCommandServiceTest.java
@@ -1,0 +1,73 @@
+package com.projectlyrics.server.domain.user.service;
+
+import com.projectlyrics.server.domain.user.dto.request.UserUpdateRequest;
+import com.projectlyrics.server.domain.user.entity.ProfileCharacter;
+import com.projectlyrics.server.domain.user.entity.User;
+import com.projectlyrics.server.domain.user.repository.UserCommandRepository;
+import com.projectlyrics.server.domain.user.repository.UserQueryRepository;
+import com.projectlyrics.server.support.IntegrationTest;
+import com.projectlyrics.server.support.fixture.UserFixture;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+class UserCommandServiceTest extends IntegrationTest {
+
+    @Autowired
+    UserCommandRepository userCommandRepository;
+
+    @Autowired
+    UserQueryRepository userQueryRepository;
+
+    @Autowired
+    UserCommandService userCommandService;
+
+    @Test
+    void 사용자의_닉네임을_수정할_수_있다() {
+        // given
+        String newNickname = "pepper";
+        UserUpdateRequest request = new UserUpdateRequest(newNickname, null);
+        User user = userCommandRepository.save(UserFixture.create());
+
+        // when
+        userCommandService.update(request, user.getId());
+        User result = userQueryRepository.findById(user.getId()).get();
+
+        // then
+        assertThat(result.getNickname().getValue()).isEqualTo(newNickname);
+    }
+
+    @Test
+    void 사용자의_프로필을_수정할_수_있다() {
+        // given
+        ProfileCharacter newProfileCharacter = ProfileCharacter.PARTED_HAIR;
+        UserUpdateRequest request = new UserUpdateRequest(null, newProfileCharacter);
+        User user = userCommandRepository.save(UserFixture.create());
+
+        // when
+        userCommandService.update(request, user.getId());
+        User result = userQueryRepository.findById(user.getId()).get();
+
+        // then
+        assertThat(result.getProfileCharacter()).isEqualTo(newProfileCharacter);
+    }
+
+    @Test
+    void 요청이_null이면_수정하지_않는다() {
+        // given
+        UserUpdateRequest request = new UserUpdateRequest(null, null);
+        User user = userCommandRepository.save(UserFixture.create());
+
+        // when
+        userCommandService.update(request, user.getId());
+        User result = userQueryRepository.findById(user.getId()).get();
+
+        // then
+        assertAll(
+                () -> assertThat(result.getNickname()).isEqualTo(user.getNickname()),
+                () -> assertThat(result.getProfileCharacter()).isEqualTo(user.getProfileCharacter())
+        );
+    }
+}

--- a/src/test/java/com/projectlyrics/server/domain/user/service/UserQueryServiceTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/user/service/UserQueryServiceTest.java
@@ -1,0 +1,39 @@
+package com.projectlyrics.server.domain.user.service;
+
+import com.projectlyrics.server.domain.user.dto.response.UserProfileResponse;
+import com.projectlyrics.server.domain.user.entity.User;
+import com.projectlyrics.server.domain.user.repository.UserCommandRepository;
+import com.projectlyrics.server.support.IntegrationTest;
+import com.projectlyrics.server.support.fixture.UserFixture;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+class UserQueryServiceTest extends IntegrationTest {
+
+    @Autowired
+    UserCommandRepository userCommandRepository;
+
+    @Autowired
+    UserQueryService sut;
+
+    @Test
+    void 사용자의_프로필을_조회할_수_있다() {
+        // given
+        User user = userCommandRepository.save(UserFixture.create());
+
+        // when
+        UserProfileResponse result = sut.getById(user.getId());
+
+        // then
+        assertAll(
+                () -> assertThat(result.id()).isEqualTo(user.getId()),
+                () -> assertThat(result.nickname()).isEqualTo(user.getNickname().getValue()),
+                () -> assertThat(result.profileCharacterType()).isEqualTo(user.getProfileCharacter().getType()),
+                () -> assertThat(result.feedbackId()).isEqualTo(user.getFeedbackId()),
+                () -> assertThat(result.authProvider()).isEqualTo(user.getSocialInfo().getAuthProvider())
+        );
+    }
+}

--- a/src/test/java/com/projectlyrics/server/support/ControllerTest.java
+++ b/src/test/java/com/projectlyrics/server/support/ControllerTest.java
@@ -23,6 +23,7 @@ import com.projectlyrics.server.domain.notification.service.NotificationQuerySer
 import com.projectlyrics.server.domain.report.service.ReportCommandService;
 import com.projectlyrics.server.domain.song.service.SongQueryService;
 import com.projectlyrics.server.domain.user.entity.Role;
+import com.projectlyrics.server.domain.user.service.UserCommandService;
 import com.projectlyrics.server.domain.user.service.UserQueryService;
 import com.projectlyrics.server.global.configuration.ClockConfig;
 import com.projectlyrics.server.global.slack.SlackClient;
@@ -102,6 +103,9 @@ public abstract class ControllerTest {
 
     @MockBean
     protected UserQueryService userQueryService;
+
+    @MockBean
+    protected UserCommandService userCommandService;
 
     @MockBean
     protected SlackClient slackClient;

--- a/src/test/java/com/projectlyrics/server/support/ControllerTest.java
+++ b/src/test/java/com/projectlyrics/server/support/ControllerTest.java
@@ -23,6 +23,7 @@ import com.projectlyrics.server.domain.notification.service.NotificationQuerySer
 import com.projectlyrics.server.domain.report.service.ReportCommandService;
 import com.projectlyrics.server.domain.song.service.SongQueryService;
 import com.projectlyrics.server.domain.user.entity.Role;
+import com.projectlyrics.server.domain.user.service.UserQueryService;
 import com.projectlyrics.server.global.configuration.ClockConfig;
 import com.projectlyrics.server.global.slack.SlackClient;
 import org.junit.jupiter.api.BeforeEach;
@@ -98,6 +99,9 @@ public abstract class ControllerTest {
 
     @MockBean
     protected ReportCommandService reportCommandService;
+
+    @MockBean
+    protected UserQueryService userQueryService;
 
     @MockBean
     protected SlackClient slackClient;

--- a/src/test/java/com/projectlyrics/server/support/fixture/UserFixture.java
+++ b/src/test/java/com/projectlyrics/server/support/fixture/UserFixture.java
@@ -21,7 +21,6 @@ public class UserFixture extends BaseFixture {
     private int birthYear = 1999;
     private Role role = Role.USER;
     private List<TermsAgreements> termsAgreements = List.of(new TermsAgreements(true, "title", "agreement"));
-    private String fcmToken = "fcmToken";
 
     private UserFixture() {
     }
@@ -35,8 +34,7 @@ public class UserFixture extends BaseFixture {
                 Role.USER,
                 Gender.MALE,
                 1999,
-                List.of(new TermsAgreements(true, "title", "agreement")),
-                "fcmToken"
+                List.of(new TermsAgreements(true, "title", "agreement"))
         );
     }
 
@@ -45,7 +43,7 @@ public class UserFixture extends BaseFixture {
     }
 
     public User build() {
-        return User.withId(id, socialInfo, nickname, profileCharacter, role, gender, birthYear, termsAgreements, fcmToken);
+        return User.withId(id, socialInfo, nickname, profileCharacter, role, gender, birthYear, termsAgreements);
     }
 
     public UserFixture role(Role role) {


### PR DESCRIPTION
# 🍃 **Pull Requests**

## ⛳️ **작업한 브랜치**
- [SCRUM-185]

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 사용자 자체 탈퇴 시 로직 변경
    - 기존에는 DB에서 모두 삭제했으나, id와 탈퇴 경로, 소셜 로그인 정보를 남김
- 아티스트 가나다 순 정렬
- fcm 관련 로직을 삭제
- 사용자 프로필 조회, 수정 API 추가

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->


[SCRUM-185]: https://projectlyrics.atlassian.net/browse/SCRUM-185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ