### PR TITLE
아티스트 정렬 기준 변경에 따른 테스트 수정

### DIFF
--- a/src/main/java/com/projectlyrics/server/domain/artist/api/ArtistController.java
+++ b/src/main/java/com/projectlyrics/server/domain/artist/api/ArtistController.java
@@ -23,6 +23,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Objects;
+
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/artists")
 @RestController
@@ -91,6 +93,12 @@ public class ArtistController {
             @RequestParam(name = "size", defaultValue = "10") int size,
             @RequestParam(name = "query", required = false) String query
     ) {
+        if (Objects.isNull(query) || query.isEmpty()) {
+            ResponseEntity
+                    .status(HttpStatus.OK)
+                    .body(artistQueryService.getArtistList(cursor, PageRequest.of(0, size)));
+        }
+
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(artistQueryService.searchArtists(query, cursor, PageRequest.of(0, size)));

--- a/src/test/java/com/projectlyrics/server/domain/artist/api/ArtistControllerTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/artist/api/ArtistControllerTest.java
@@ -270,28 +270,6 @@ class ArtistControllerTest extends RestDocsTest {
                 .andDo(getArtistSearchDocument());
     }
 
-    @Test
-    void 검색어가_null이거나_공백인_경우_아티스트를_검색하면_빈_데이터와_200응답을_해야_한다() throws Exception {
-        // given
-        CursorBasePaginatedResponse<ArtistGetResponse> response = new CursorBasePaginatedResponse<>(
-                null,
-                false,
-                new ArrayList<>()
-        );
-
-        //when then
-        mockMvc.perform(get("/api/v1/artists/search")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .param("query", " ")
-                        .param("cursor", "1")
-                        .param("size", "10"))
-                .andExpect(status().isOk())
-                .andExpect(content().json(mapper.writeValueAsString(response)))
-                .andDo(print())
-                .andDo(getArtistSearchDocument());
-    }
-
     private RestDocumentationResultHandler getArtistSearchDocument() {
         ParameterDescriptorWithType[] pagingQueryParameters = getCursorBasePagingQueryParameters();
 

--- a/src/test/java/com/projectlyrics/server/domain/artist/service/ArtistQueryServiceIntegrationTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/artist/service/ArtistQueryServiceIntegrationTest.java
@@ -57,14 +57,12 @@ class ArtistQueryServiceIntegrationTest extends IntegrationTest {
         CursorBasePaginatedResponse<ArtistGetResponse> response = sut.getArtistList(cursor, pageable);
 
         //then
-        assertSoftly(s -> {
-                    s.assertThat(response.hasNext()).isFalse();
-                    s.assertThat(response.data().size()).isEqualTo(artistList.size());
-                    for (int i = 0; i < artistList.size(); i++) {
-                        s.assertThat(response.data().get(i).id()).isEqualTo(artistList.get(i).getId());
-                        s.assertThat(response.data().get(i).name()).isEqualTo(artistList.get(i).getName());
-                    }
-                }
+        assertAll(
+                () -> assertThat(response.hasNext()).isFalse(),
+                () -> assertThat(response.data()).hasSize(3),
+                () -> assertThat(response.data().get(0).name()).isEqualTo("너드커넥션"),
+                () -> assertThat(response.data().get(1).name()).isEqualTo("실리카겔"),
+                () -> assertThat(response.data().get(2).name()).isEqualTo("잔나비")
         );
     }
 


### PR DESCRIPTION
# 🍃 **Pull Requests**

## ⛳️ **작업한 브랜치**
- [SCRUM-185]

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 아티스트 정렬 기준을 가나다 순으로 변경하면서 일부 테스트가 깨졌음
    - 테스트 assertion 문을 변경된 정렬 기준에 맞춰 수정
- 아티스트 검색 query가 없을 경우, 가나다 순으로 정렬된 기본 아티스트를 제공하도록 수정

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->


[SCRUM-185]: https://projectlyrics.atlassian.net/browse/SCRUM-185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ