### PR TITLE
곡 크롤링 자동화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -115,6 +115,6 @@ tasks.named('test') {
 }
 
 task runSongCollector(type: JavaExec) {
-    mainClass = 'com.projectlyrics.server.global.dev.SongCollectorRunner'
+    mainClass = 'com.projectlyrics.server.global.dev.cron.SongCollectorRunner'
     classpath = sourceSets.main.runtimeClasspath
 }

--- a/build.gradle
+++ b/build.gradle
@@ -113,3 +113,8 @@ bootJar {
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+task runSongCollector(type: JavaExec) {
+    mainClass = 'com.projectlyrics.server.global.dev.SongCollectorRunner'
+    classpath = sourceSets.main.runtimeClasspath
+}

--- a/buildspec/collect-new-songs.yml
+++ b/buildspec/collect-new-songs.yml
@@ -1,0 +1,20 @@
+version: 0.2
+
+phases:
+  install:
+    runtime-versions:
+      java: corretto21
+    commands:
+      - echo "java 21 installed"
+  pre_build:
+    commands:
+      - echo "downloading application.yml from S3..."
+      - aws s3 cp s3://my-config-bucket/application.yml src/main/resources/application.yml
+  build:
+    commands:
+      - echo "running song collector..."
+      - chmod +x ./gradlew
+      - ./gradlew runSongCollector -x test
+artifacts:
+  files:
+    - '**/*'

--- a/src/main/java/com/projectlyrics/server/domain/artist/repository/ArtistQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/artist/repository/ArtistQueryRepository.java
@@ -16,5 +16,7 @@ public interface ArtistQueryRepository {
 
     Slice<Artist> findAll(Pageable pageable);
 
+    List<Artist> findAll();
+
     List<Artist> findAllByIds(List<Long> artistIds);
 }

--- a/src/main/java/com/projectlyrics/server/domain/artist/repository/impl/QueryDslArtistQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/artist/repository/impl/QueryDslArtistQueryRepository.java
@@ -61,6 +61,13 @@ public class QueryDslArtistQueryRepository implements ArtistQueryRepository {
     }
 
     @Override
+    public List<Artist> findAll() {
+        return jpaQueryFactory
+                .selectFrom(artist)
+                .fetch();
+    }
+
+    @Override
     public List<Artist> findAllByIds(List<Long> artistIds) {
         return jpaQueryFactory.selectFrom(artist)
                 .where(

--- a/src/main/java/com/projectlyrics/server/domain/song/entity/Song.java
+++ b/src/main/java/com/projectlyrics/server/domain/song/entity/Song.java
@@ -1,7 +1,10 @@
 package com.projectlyrics.server.domain.song.entity;
 
 import com.projectlyrics.server.domain.artist.entity.Artist;
+import com.projectlyrics.server.domain.common.entity.BaseEntity;
 import com.projectlyrics.server.domain.note.entity.Note;
+import com.projectlyrics.server.global.dev.cron.dto.Album;
+import com.projectlyrics.server.global.dev.cron.dto.Track;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
@@ -23,6 +26,7 @@ public class Song {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(unique = true, nullable = false)
     private String spotifyId;
     private String name;
     private LocalDate releaseDate;
@@ -59,6 +63,19 @@ public class Song {
         this.artist = artist;
     }
 
+    public Song(
+            Album album,
+            Track track,
+            Artist artist
+    ) {
+        this.spotifyId = track.getId();
+        this.name = track.getName();
+        this.releaseDate = album.getDate();
+        this.albumName = album.getName();
+        this.imageUrl = album.getImages().getFirst().getUrl();
+        this.artist = artist;
+    }
+
     public static Song create(SongCreate songCreate) {
         return new Song(
                 songCreate.id(),
@@ -72,6 +89,8 @@ public class Song {
     }
 
     public List<Note> getNotes() {
-        return notes.stream().filter(note -> note.isInUse()).toList();
+        return notes.stream()
+                .filter(BaseEntity::isInUse)
+                .toList();
     }
 }

--- a/src/main/java/com/projectlyrics/server/domain/song/repository/SongQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/song/repository/SongQueryRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Slice;
 public interface SongQueryRepository {
 
     Optional<Song> findById(Long id);
+    Optional<Song> findBySpotifyId(String spotifyId);
     Slice<Song> findAllByQueryOrderByNoteCountDesc(String query, Pageable pageable);
     Slice<Song> findAllByQueryAndArtistId(Long artistId, String query, Long cursor, Pageable pageable);
 }

--- a/src/main/java/com/projectlyrics/server/domain/song/repository/impl/QueryDslSongQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/song/repository/impl/QueryDslSongQueryRepository.java
@@ -42,7 +42,7 @@ public class QueryDslSongQueryRepository implements SongQueryRepository {
                 jpaQueryFactory
                         .selectFrom(song)
                         .where(song.spotifyId.eq(spotifyId))
-                        .fetchOne()
+                        .fetchFirst()
         );
     }
 

--- a/src/main/java/com/projectlyrics/server/domain/song/repository/impl/QueryDslSongQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/song/repository/impl/QueryDslSongQueryRepository.java
@@ -24,6 +24,29 @@ public class QueryDslSongQueryRepository implements SongQueryRepository {
 
     private final JPAQueryFactory jpaQueryFactory;
 
+    @Override
+    public Optional<Song> findById(Long id) {
+        return Optional.ofNullable(
+                jpaQueryFactory
+                        .select(song)
+                        .from(song)
+                        .leftJoin(song.notes, note)
+                        .where(song.id.eq(id))
+                        .fetchOne()
+        );
+    }
+
+    @Override
+    public Optional<Song> findBySpotifyId(String spotifyId) {
+        return Optional.ofNullable(
+                jpaQueryFactory
+                        .selectFrom(song)
+                        .where(song.spotifyId.eq(spotifyId))
+                        .fetchOne()
+        );
+    }
+
+    @Override
     public Slice<Song> findAllByQueryOrderByNoteCountDesc(String query, Pageable pageable) {
         List<Song> content = jpaQueryFactory
                 .select(song)
@@ -68,19 +91,5 @@ public class QueryDslSongQueryRepository implements SongQueryRepository {
 
     private static BooleanExpression artistIdEq(Long artistId) {
         return Objects.isNull(artistId) ? null : song.artist.id.eq(artistId);
-    }
-
-    @Override
-    public Optional<Song> findById(Long id) {
-        return Optional.ofNullable(
-                jpaQueryFactory
-                        .select(song)
-                        .from(song)
-                        .leftJoin(song.notes, note)
-                        .where(
-                                song.id.eq(id)
-                        )
-                        .fetchOne()
-        );
     }
 }

--- a/src/main/java/com/projectlyrics/server/global/dev/cron/AccessTokenProvider.java
+++ b/src/main/java/com/projectlyrics/server/global/dev/cron/AccessTokenProvider.java
@@ -1,0 +1,50 @@
+package com.projectlyrics.server.global.dev.cron;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.projectlyrics.server.global.dev.cron.dto.AccessTokenResponse;
+import lombok.extern.slf4j.Slf4j;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.List;
+
+@Slf4j
+public class AccessTokenProvider {
+
+    private static final HttpClient client = HttpClient.newHttpClient();
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static final List<List<String>> clients = List.of(
+            List.of("eca1c80ae65f48d79242eeca56fec1b4", "c227f04fbccc46e6a828600ae301bfc1"),
+            List.of("a3192d4c8a3d4f55a41fca4a85cd528f", "02d6de87c507475d82e5257d019e50e9"),
+            List.of("9e31198370b148af914a1613ecd76c03", "d9f5c815851c45fe9b768e80e14381cc"),
+            List.of("916497d2cb2443af82c15c77d24ff278", "dbc8b0b1256b422faccfdbe52abd04ec")
+    );
+    private static int index = 0;
+
+    public static String get() {
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create("https://accounts.spotify.com/api/token"))
+                    .header("Content-Type", "application/x-www-form-urlencoded")
+                    .POST(HttpRequest.BodyPublishers.ofString("grant_type=client_credentials&client_id=" + clients.get(index).get(0) + "&client_secret=" + clients.get(index).get(1)))
+                    .build();
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+            return objectMapper.readValue(response.body(), AccessTokenResponse.class)
+                    .getAccess_token();
+        } catch (Exception e) {
+            log.error("failed to get access token from spotify");
+            return null;
+        }
+    }
+
+    public static void change() {
+        ++index;
+
+        if (index == clients.size()) {
+            index = 0;
+        }
+    }
+}

--- a/src/main/java/com/projectlyrics/server/global/dev/cron/HttpRequestClient.java
+++ b/src/main/java/com/projectlyrics/server/global/dev/cron/HttpRequestClient.java
@@ -1,0 +1,21 @@
+package com.projectlyrics.server.global.dev.cron;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+public class HttpRequestClient {
+
+    private static final HttpClient client = HttpClient.newHttpClient();
+    private static final String accessToken = AccessTokenProvider.get();
+
+    public static HttpResponse<String> send(String url) throws Exception {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .header("Authorization", "Bearer " + accessToken)
+                .build();
+
+        return client.send(request, HttpResponse.BodyHandlers.ofString());
+    }
+}

--- a/src/main/java/com/projectlyrics/server/global/dev/cron/HttpRequestClient.java
+++ b/src/main/java/com/projectlyrics/server/global/dev/cron/HttpRequestClient.java
@@ -8,12 +8,11 @@ import java.net.http.HttpResponse;
 public class HttpRequestClient {
 
     private static final HttpClient client = HttpClient.newHttpClient();
-    private static final String accessToken = AccessTokenProvider.get();
 
     public static HttpResponse<String> send(String url) throws Exception {
         HttpRequest request = HttpRequest.newBuilder()
                 .uri(URI.create(url))
-                .header("Authorization", "Bearer " + accessToken)
+                .header("Authorization", "Bearer " + AccessTokenProvider.get())
                 .build();
 
         return client.send(request, HttpResponse.BodyHandlers.ofString());

--- a/src/main/java/com/projectlyrics/server/global/dev/cron/SongCollector.java
+++ b/src/main/java/com/projectlyrics/server/global/dev/cron/SongCollector.java
@@ -1,0 +1,26 @@
+package com.projectlyrics.server.global.dev.cron;
+
+import com.projectlyrics.server.domain.artist.entity.Artist;
+import com.projectlyrics.server.domain.artist.repository.ArtistQueryRepository;
+import com.projectlyrics.server.domain.song.entity.Song;
+import com.projectlyrics.server.domain.song.repository.SongQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Component
+public class SongCollector {
+
+    private final ArtistQueryRepository artistQueryRepository;
+    private final SongQueryRepository songQueryRepository;
+
+    public void collect() {
+
+    }
+
+    public List<Artist> getArtists() {
+        return artistQueryRepository.findAll();
+    }
+}

--- a/src/main/java/com/projectlyrics/server/global/dev/cron/SongCollector.java
+++ b/src/main/java/com/projectlyrics/server/global/dev/cron/SongCollector.java
@@ -16,6 +16,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
 import java.net.http.HttpResponse;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -31,7 +32,9 @@ public class SongCollector {
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
     public void collect() {
-        for (Artist artist : artistQueryRepository.findAll()) {
+        List<Artist> artists = artistQueryRepository.findAll();
+
+        for (Artist artist : subList(artists)) {
             List<Song> newSongs = getSongs(artist)
                     .stream()
                     .filter(this::notRegistered)
@@ -39,6 +42,16 @@ public class SongCollector {
 
             songCommandRepository.saveAll(newSongs);
         }
+    }
+
+    private List<Artist> subList(List<Artist> artists) {
+        int now = LocalDateTime.now().getHour();
+        int size = artists.size() / 23;
+
+        int from = now * size;
+        int to = Math.min(from + size, artists.size());
+
+        return artists.subList(from, to);
     }
 
     private static List<Song> getSongs(Artist artist) {

--- a/src/main/java/com/projectlyrics/server/global/dev/cron/SongCollector.java
+++ b/src/main/java/com/projectlyrics/server/global/dev/cron/SongCollector.java
@@ -34,7 +34,7 @@ public class SongCollector {
         for (Artist artist : artistQueryRepository.findAll()) {
             List<Song> newSongs = getSongs(artist)
                     .stream()
-                    .filter(this::exists)
+                    .filter(this::notRegistered)
                     .toList();
 
             songCommandRepository.saveAll(newSongs);
@@ -112,9 +112,9 @@ public class SongCollector {
         return Objects.nonNull(response) && Objects.nonNull(response.getNext());
     }
 
-    private boolean exists(Song song) {
+    private boolean notRegistered(Song song) {
         return songQueryRepository.findBySpotifyId(song.getSpotifyId())
-                .isPresent();
+                .isEmpty();
     }
 
     // TODO: 슬랙으로 보내야 함

--- a/src/main/java/com/projectlyrics/server/global/dev/cron/SongCollector.java
+++ b/src/main/java/com/projectlyrics/server/global/dev/cron/SongCollector.java
@@ -47,6 +47,7 @@ public class SongCollector {
         List<Song> songs = new ArrayList<>();
         AlbumListResponse albumListResponse = null;
 
+        log.info("songs of {} is being collected", artist.getName());
         try {
             do {
                 response = HttpRequestClient.send(url);
@@ -66,7 +67,7 @@ public class SongCollector {
                 }
             } while (isFailed(response) || hasNext(albumListResponse));
         } catch (Exception e) {
-            log.error("failed to get albums of an artist {} at all", artist.getId());
+            log.error("failed to get albums of an artist {} of id {} at all", artist.getName(), artist.getId());
         }
 
         return songs;
@@ -89,7 +90,7 @@ public class SongCollector {
                 }
             } while (isFailed(response) || hasNext(trackListResponse));
         } catch (Exception e) {
-            log.error("failed to get songs of an album at all");
+            log.error("failed to get songs of an album {} of artist {} of id {} at all", album.getName(), album.getId(), album.getId());
         }
 
         return tracks;

--- a/src/main/java/com/projectlyrics/server/global/dev/cron/SongCollector.java
+++ b/src/main/java/com/projectlyrics/server/global/dev/cron/SongCollector.java
@@ -43,7 +43,7 @@ public class SongCollector {
 
     private static List<Song> getSongs(Artist artist) {
         HttpResponse<String> response;
-        String url = "https://api.spotify.com/v1/artists/" + artist.getSpotifyId() + "/albums?limit=50&market=KR&locale=ko_KR";
+        String url = "https://api.spotify.com/v1/artists/" + artist.getSpotifyId() + "/albums?limit=50&market=KR&locale=ko_KR&include_groups=album,single";
         List<Song> songs = new ArrayList<>();
         AlbumListResponse albumListResponse = null;
 

--- a/src/main/java/com/projectlyrics/server/global/dev/cron/SongCollector.java
+++ b/src/main/java/com/projectlyrics/server/global/dev/cron/SongCollector.java
@@ -1,26 +1,123 @@
 package com.projectlyrics.server.global.dev.cron;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.projectlyrics.server.domain.artist.entity.Artist;
 import com.projectlyrics.server.domain.artist.repository.ArtistQueryRepository;
 import com.projectlyrics.server.domain.song.entity.Song;
+import com.projectlyrics.server.domain.song.repository.SongCommandRepository;
 import com.projectlyrics.server.domain.song.repository.SongQueryRepository;
+import com.projectlyrics.server.global.dev.cron.dto.Album;
+import com.projectlyrics.server.global.dev.cron.dto.AlbumListResponse;
+import com.projectlyrics.server.global.dev.cron.dto.Track;
+import com.projectlyrics.server.global.dev.cron.dto.TrackListResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
+import java.net.http.HttpResponse;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
+@Slf4j
 @RequiredArgsConstructor
 @Component
 public class SongCollector {
 
     private final ArtistQueryRepository artistQueryRepository;
+    private final SongCommandRepository songCommandRepository;
     private final SongQueryRepository songQueryRepository;
+    private static final ObjectMapper objectMapper = new ObjectMapper();
 
     public void collect() {
+        for (Artist artist : artistQueryRepository.findAll()) {
+            List<Song> newSongs = getSongs(artist)
+                    .stream()
+                    .filter(this::exists)
+                    .toList();
 
+            songCommandRepository.saveAll(newSongs);
+        }
     }
 
-    public List<Artist> getArtists() {
-        return artistQueryRepository.findAll();
+    private static List<Song> getSongs(Artist artist) {
+        HttpResponse<String> response;
+        String url = "https://api.spotify.com/v1/artists/" + artist.getSpotifyId() + "/albums?limit=50&market=KR&locale=ko_KR";
+        List<Song> songs = new ArrayList<>();
+        AlbumListResponse albumListResponse = null;
+
+        try {
+            do {
+                response = HttpRequestClient.send(url);
+
+                if (isSuccess(response)) {
+                    albumListResponse = objectMapper.readValue(response.body(), AlbumListResponse.class);
+
+                    for (Album album : albumListResponse.getItems()) {
+                        songs.addAll(
+                                getTracks(album).stream()
+                                        .map(track -> new Song(album, track, artist))
+                                        .toList()
+                        );
+                    }
+
+                    url = albumListResponse.getNext();
+                }
+            } while (isFailed(response) || hasNext(albumListResponse));
+        } catch (Exception e) {
+            log.error("failed to get albums of an artist {} at all", artist.getId());
+        }
+
+        return songs;
+    }
+
+    private static List<Track> getTracks(Album album) {
+        HttpResponse<String> response;
+        String url = "https://api.spotify.com/v1/albums/" + album.getId() + "/tracks?limit=50&market=KR&locale=ko_KR";
+        List<Track> tracks = new ArrayList<>();
+        TrackListResponse trackListResponse = null;
+
+        try {
+            do {
+                response = HttpRequestClient.send(url);
+
+                if (isSuccess(response)) {
+                    trackListResponse = objectMapper.readValue(response.body(), TrackListResponse.class);
+                    tracks.addAll(trackListResponse.getItems());
+                    url = trackListResponse.getNext();
+                }
+            } while (isFailed(response) || hasNext(trackListResponse));
+        } catch (Exception e) {
+            log.error("failed to get songs of an album at all");
+        }
+
+        return tracks;
+    }
+
+    private static boolean isSuccess(HttpResponse<?> response) {
+        return response.statusCode() == HttpStatus.OK.value();
+    }
+
+    private static boolean isFailed(HttpResponse<?> response) {
+        AccessTokenProvider.change();
+        return response.statusCode() != HttpStatus.OK.value();
+    }
+
+    private static boolean hasNext(AlbumListResponse response) {
+        return Objects.nonNull(response) && Objects.nonNull(response.getNext());
+    }
+
+    private static boolean hasNext(TrackListResponse response) {
+        return Objects.nonNull(response) && Objects.nonNull(response.getNext());
+    }
+
+    private boolean exists(Song song) {
+        return songQueryRepository.findBySpotifyId(song.getSpotifyId())
+                .isPresent();
+    }
+
+    // TODO: 슬랙으로 보내야 함
+    private void print(List<Song> songs) {
     }
 }

--- a/src/main/java/com/projectlyrics/server/global/dev/cron/SongCollectorRunner.java
+++ b/src/main/java/com/projectlyrics/server/global/dev/cron/SongCollectorRunner.java
@@ -20,11 +20,9 @@ public class SongCollectorRunner {
                 .web(NONE)
                 .run(args);
 
-        collect();
+        SongCollector songCollector = context.getBean(SongCollector.class);
+        songCollector.collect();
 
         context.close();
-    }
-
-    private static void collect() {
     }
 }

--- a/src/main/java/com/projectlyrics/server/global/dev/cron/SongCollectorRunner.java
+++ b/src/main/java/com/projectlyrics/server/global/dev/cron/SongCollectorRunner.java
@@ -1,0 +1,30 @@
+package com.projectlyrics.server.global.dev.cron;
+
+import com.projectlyrics.server.ServerApplication;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ConfigurableApplicationContext;
+
+import static org.springframework.boot.WebApplicationType.NONE;
+
+@Slf4j
+public class SongCollectorRunner {
+
+    private static ConfigurableApplicationContext context;
+
+    public static void main(String[] args) {
+        log.info("song collector starts collecting!");
+
+        context = new SpringApplicationBuilder()
+                .sources(ServerApplication.class)
+                .web(NONE)
+                .run(args);
+
+        collect();
+
+        context.close();
+    }
+
+    private static void collect() {
+    }
+}

--- a/src/main/java/com/projectlyrics/server/global/dev/cron/dto/AccessTokenResponse.java
+++ b/src/main/java/com/projectlyrics/server/global/dev/cron/dto/AccessTokenResponse.java
@@ -1,0 +1,13 @@
+package com.projectlyrics.server.global.dev.cron.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AccessTokenResponse {
+
+    private String access_token;
+
+    public String getAccess_token() {
+        return access_token;
+    }
+}

--- a/src/main/java/com/projectlyrics/server/global/dev/cron/dto/Album.java
+++ b/src/main/java/com/projectlyrics/server/global/dev/cron/dto/Album.java
@@ -1,9 +1,14 @@
 package com.projectlyrics.server.global.dev.cron.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.Setter;
 
+import java.time.LocalDate;
 import java.util.List;
 
+@Setter
+@Getter
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Album {
 
@@ -20,43 +25,7 @@ public class Album {
         this.id = id;
     }
 
-    public int getTotal_tracks() {
-        return total_tracks;
-    }
-
-    public String getId() {
-        return id;
-    }
-
-    public List<Image> getImages() {
-        return images;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public String getRelease_date() {
-        return release_date;
-    }
-
-    public void setTotal_tracks(int total_tracks) {
-        this.total_tracks = total_tracks;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
-
-    public void setImages(List<Image> images) {
-        this.images = images;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public void setRelease_date(String release_date) {
-        this.release_date = release_date;
+    public LocalDate getDate() {
+        return LocalDate.parse(release_date);
     }
 }

--- a/src/main/java/com/projectlyrics/server/global/dev/cron/dto/Album.java
+++ b/src/main/java/com/projectlyrics/server/global/dev/cron/dto/Album.java
@@ -1,0 +1,62 @@
+package com.projectlyrics.server.global.dev.cron.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Album {
+
+    private int total_tracks;
+    private String id;
+    private List<Image> images;
+    private String name;
+    private String release_date;
+
+    public Album() {
+    }
+
+    public Album(String id) {
+        this.id = id;
+    }
+
+    public int getTotal_tracks() {
+        return total_tracks;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public List<Image> getImages() {
+        return images;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getRelease_date() {
+        return release_date;
+    }
+
+    public void setTotal_tracks(int total_tracks) {
+        this.total_tracks = total_tracks;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public void setImages(List<Image> images) {
+        this.images = images;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setRelease_date(String release_date) {
+        this.release_date = release_date;
+    }
+}

--- a/src/main/java/com/projectlyrics/server/global/dev/cron/dto/AlbumListResponse.java
+++ b/src/main/java/com/projectlyrics/server/global/dev/cron/dto/AlbumListResponse.java
@@ -1,0 +1,31 @@
+package com.projectlyrics.server.global.dev.cron.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AlbumListResponse {
+
+    private String next;
+    private List<Album> items;
+
+    public AlbumListResponse() {
+    }
+
+    public String getNext() {
+        return next;
+    }
+
+    public List<Album> getItems() {
+        return items;
+    }
+
+    public void setNext(String next) {
+        this.next = next;
+    }
+
+    public void setItems(List<Album> items) {
+        this.items = items;
+    }
+}

--- a/src/main/java/com/projectlyrics/server/global/dev/cron/dto/Artist.java
+++ b/src/main/java/com/projectlyrics/server/global/dev/cron/dto/Artist.java
@@ -1,0 +1,20 @@
+package com.projectlyrics.server.global.dev.cron.dto;
+
+public class Artist {
+
+    private Long id;
+    private String spotifyId;
+
+    public Artist(Long id, String spotifyId) {
+        this.id = id;
+        this.spotifyId = spotifyId;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getSpotifyId() {
+        return spotifyId;
+    }
+}

--- a/src/main/java/com/projectlyrics/server/global/dev/cron/dto/ArtistOfTrack.java
+++ b/src/main/java/com/projectlyrics/server/global/dev/cron/dto/ArtistOfTrack.java
@@ -1,0 +1,20 @@
+package com.projectlyrics.server.global.dev.cron.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ArtistOfTrack {
+
+    private String id;
+
+    public ArtistOfTrack() {
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+}

--- a/src/main/java/com/projectlyrics/server/global/dev/cron/dto/Image.java
+++ b/src/main/java/com/projectlyrics/server/global/dev/cron/dto/Image.java
@@ -1,0 +1,13 @@
+package com.projectlyrics.server.global.dev.cron.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Image {
+
+    private String url;
+
+    public String getUrl() {
+        return url;
+    }
+}

--- a/src/main/java/com/projectlyrics/server/global/dev/cron/dto/Song.java
+++ b/src/main/java/com/projectlyrics/server/global/dev/cron/dto/Song.java
@@ -1,0 +1,46 @@
+package com.projectlyrics.server.global.dev.cron.dto;
+
+public class Song {
+
+    Long id;
+    String spotifyId;
+    String name;
+    String releaseDate;
+    String albumName;
+    String imageUrl;
+    Long artistId;
+
+    public Song(
+            Long id,
+            String spotifyId,
+            String name,
+            String releaseDate,
+            String albumName,
+            String imageUrl,
+            Long artistId
+    ) {
+        this.id = id;
+        this.spotifyId = spotifyId;
+        this.name = name;
+        this.releaseDate = releaseDate;
+        this.albumName = albumName;
+        this.imageUrl = imageUrl;
+        this.artistId = artistId;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public static Song of(Album album, Track track) {
+        return new Song(
+                null,
+                track.getId(),
+                track.getName(),
+                album.getRelease_date(),
+                album.getName(),
+                album.getImages().get(0).getUrl(),
+                null
+        );
+    }
+}

--- a/src/main/java/com/projectlyrics/server/global/dev/cron/dto/Track.java
+++ b/src/main/java/com/projectlyrics/server/global/dev/cron/dto/Track.java
@@ -1,0 +1,30 @@
+package com.projectlyrics.server.global.dev.cron.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Track {
+
+    private String id;
+    private String name;
+    private int track_number;
+    private List<ArtistOfTrack> artists;
+
+    public String getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getTrack_number() {
+        return track_number;
+    }
+
+    public List<ArtistOfTrack> getArtists() {
+        return artists;
+    }
+}

--- a/src/main/java/com/projectlyrics/server/global/dev/cron/dto/Track.java
+++ b/src/main/java/com/projectlyrics/server/global/dev/cron/dto/Track.java
@@ -1,9 +1,11 @@
 package com.projectlyrics.server.global.dev.cron.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
 
 import java.util.List;
 
+@Getter
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Track {
 
@@ -11,20 +13,4 @@ public class Track {
     private String name;
     private int track_number;
     private List<ArtistOfTrack> artists;
-
-    public String getId() {
-        return id;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public int getTrack_number() {
-        return track_number;
-    }
-
-    public List<ArtistOfTrack> getArtists() {
-        return artists;
-    }
 }

--- a/src/main/java/com/projectlyrics/server/global/dev/cron/dto/TrackListResponse.java
+++ b/src/main/java/com/projectlyrics/server/global/dev/cron/dto/TrackListResponse.java
@@ -1,0 +1,20 @@
+package com.projectlyrics.server.global.dev.cron.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class TrackListResponse {
+
+    private List<Track> items;
+    private String next;
+
+    public List<Track> getItems() {
+        return items;
+    }
+
+    public String getNext() {
+        return next;
+    }
+}

--- a/src/test/java/com/projectlyrics/server/domain/song/service/SongQueryServiceTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/song/service/SongQueryServiceTest.java
@@ -62,7 +62,7 @@ class SongQueryServiceTest extends IntegrationTest {
 
         requestOfArtist1 = new SongCreateRequest(
                 1L,
-                "spotifyId",
+                "spotifyId1",
                 "Kiss And Tell",
                 LocalDate.now(),
                 "albumName",
@@ -71,7 +71,7 @@ class SongQueryServiceTest extends IntegrationTest {
         );
         requestOfArtist2 = new SongCreateRequest(
                 2L,
-                "spotifyId",
+                "spotifyId2",
                 "Kiss And Tell",
                 LocalDate.now(),
                 "albumName",
@@ -80,7 +80,7 @@ class SongQueryServiceTest extends IntegrationTest {
         );
         request2OfArtist2 = new SongCreateRequest(
                 3L,
-                "spotifyId",
+                "spotifyId3",
                 "Kiss And Tell",
                 LocalDate.now(),
                 "albumName",
@@ -193,7 +193,7 @@ class SongQueryServiceTest extends IntegrationTest {
         for (int i = 0; i < 5; i++) {
             SongCreateRequest request = new SongCreateRequest(
                     (long) (i + 1),
-                    "spotifyId",
+                    "spotifyId" + i,
                     "Kiss And Tell",
                     LocalDate.now(),
                     "albumName",

--- a/src/test/java/com/projectlyrics/server/support/fixture/SongFixture.java
+++ b/src/test/java/com/projectlyrics/server/support/fixture/SongFixture.java
@@ -9,10 +9,11 @@ import java.time.LocalDate;
 public class SongFixture extends BaseFixture {
 
     public static Song create() {
+        long id = getUniqueId();
         return Song.create(
                 new SongCreate(
-                        getUniqueId(),
-                        "24ebPi6UpTNw2vdzxGbO9n",
+                        id,
+                        "24ebPi6UpTNw2vdzxGbO9n" + id,
                         "Flying Bob",
                         LocalDate.parse("2022-09-15"),
                         "TEEN TROUBLES",
@@ -23,10 +24,12 @@ public class SongFixture extends BaseFixture {
     }
 
     public static Song create(Artist artist) {
+        long id = getUniqueId();
+
         return Song.create(
                 new SongCreate(
-                        getUniqueId(),
-                        "24ebPi6UpTNw2vdzxGbO9n",
+                        id,
+                        "24ebPi6UpTNw2vdzxGbO9n" + id,
                         "Flying Bob",
                         LocalDate.parse("2022-09-15"),
                         "TEEN TROUBLES",


### PR DESCRIPTION
# 🍃 **Pull Requests**

## ⛳️ **작업한 브랜치**
- Resolved: [SCRUM-194]

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 기존에 로컬에서 작업했던 코드를 여기에 편입했고, 그 과정에서 약간의 변화가 있었습니다.
     - `/global/dev/cron`에서 작업했습니다.
     - SongCollectorRunner에서 스프링 애플리케이션을 웹 서버를 끈 상태로 실행합니다. 
          - 따라서 저희 API 서버는 사용하지 않습니다. (아마도?)
     - 매 시간마다 전체 아티스트의 1/24만큼 돌아가면서 크롤링하고, DB에 없다면 저장합니다.

&nbsp;

- 이 과정을 Amazon CodeBuild를 통해 실행할 겁니다.
    - 이는, 웹 서버와 크론 작업 서버의 리소스를 분리하기 위함입니다.
    - `buildspec/collect-new-songs.yml`에 CodeBuild에게 제공하는 빌드 파일이 있습니다.

## 🚨 참고 사항
- S3에 `application.yml`을 저장해서 CodeBuild가 사용할 계획입니다.

[SCRUM-194]: https://projectlyrics.atlassian.net/browse/SCRUM-194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ