### PR TITLE
OpenSearch를 활용하도록 곡 검색 기능 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,6 +80,11 @@ dependencies {
 
     // json
     implementation 'org.json:json:20210307'
+
+    // Amazon OpenSearch
+    implementation("org.opensearch.client:opensearch-rest-client:2.11.0")
+    implementation("org.opensearch.client:opensearch-java:2.7.0")
+    implementation("jakarta.json:jakarta.json-api")
 }
 
 swaggerSources {

--- a/src/main/java/com/projectlyrics/server/domain/common/dto/util/OffsetBasePaginatedResponse.java
+++ b/src/main/java/com/projectlyrics/server/domain/common/dto/util/OffsetBasePaginatedResponse.java
@@ -17,4 +17,12 @@ public record OffsetBasePaginatedResponse<T>(
                 slice.getContent()
         );
     }
+
+    public static <T> OffsetBasePaginatedResponse<T> of(int pageNumber, int pageSize, List<T> data) {
+        if (data.size() > pageSize) {
+            return new OffsetBasePaginatedResponse<>(pageNumber, true, data);
+        }
+
+        return new OffsetBasePaginatedResponse<>(pageNumber, false, data);
+    }
 }

--- a/src/main/java/com/projectlyrics/server/domain/common/message/ErrorCode.java
+++ b/src/main/java/com/projectlyrics/server/domain/common/message/ErrorCode.java
@@ -109,6 +109,9 @@ public enum ErrorCode {
     // Block
     BLOCK_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "15000", "이미 차단을 추가한 상태입니다."),
     BLOCK_NOT_FOUND(HttpStatus.NOT_FOUND, "15001", "해당 차단을 조회할 수 없습니다."),
+
+    // Search
+    FAILED_TO_INDEX(HttpStatus.INTERNAL_SERVER_ERROR, "16000", "데이터를 인덱싱하는 데 실패했습니다."),
     ;
 
     private final HttpStatus responseStatus;

--- a/src/main/java/com/projectlyrics/server/domain/common/message/ErrorCode.java
+++ b/src/main/java/com/projectlyrics/server/domain/common/message/ErrorCode.java
@@ -112,6 +112,7 @@ public enum ErrorCode {
 
     // Search
     FAILED_TO_INDEX(HttpStatus.INTERNAL_SERVER_ERROR, "16000", "데이터를 인덱싱하는 데 실패했습니다."),
+    FAILED_TO_SEARCH(HttpStatus.INTERNAL_SERVER_ERROR, "16001", "데이터를 검색하는 데 실패했습니다."),
     ;
 
     private final HttpStatus responseStatus;

--- a/src/main/java/com/projectlyrics/server/domain/search/domain/SongSearch.java
+++ b/src/main/java/com/projectlyrics/server/domain/search/domain/SongSearch.java
@@ -6,8 +6,12 @@ import java.util.List;
 
 public record SongSearch(
         Long id,
-        String title,
-        String artistName
+        String korean_title,
+        String english_title,
+        String korean_artist_name,
+        String english_artist_name,
+        String korean_album_name,
+        String english_album_name
 ) {
     public static final String INDEX = "song";
     public static final List<String> FIELDS = List.of(
@@ -22,8 +26,17 @@ public record SongSearch(
     public static SongSearch from(Song song) {
         return new SongSearch(
                 song.getId(),
-                song.getName(),
-                song.getArtist().getName()
+                isKorean(song.getName()) ? song.getName() : null,
+                isKorean(song.getName()) ? null : song.getName(),
+                isKorean(song.getArtist().getName()) ? song.getArtist().getName() : null,
+                isKorean(song.getArtist().getName()) ? null : song.getArtist().getName(),
+                isKorean(song.getAlbumName()) ? song.getAlbumName() : null,
+                isKorean(song.getAlbumName()) ? null : song.getAlbumName()
         );
+    }
+
+    private static boolean isKorean(String input) {
+        String koreanRegex = "^[\\uAC00-\\uD7A3]+$";
+        return input.matches(koreanRegex);
     }
 }

--- a/src/main/java/com/projectlyrics/server/domain/search/domain/SongSearch.java
+++ b/src/main/java/com/projectlyrics/server/domain/search/domain/SongSearch.java
@@ -1,0 +1,17 @@
+package com.projectlyrics.server.domain.search.domain;
+
+import com.projectlyrics.server.domain.song.entity.Song;
+
+public record SongSearch(
+        Long id,
+        String title,
+        String artistName
+) {
+    public static SongSearch from(Song song) {
+        return new SongSearch(
+                song.getId(),
+                song.getName(),
+                song.getArtist().getName()
+        );
+    }
+}

--- a/src/main/java/com/projectlyrics/server/domain/search/domain/SongSearch.java
+++ b/src/main/java/com/projectlyrics/server/domain/search/domain/SongSearch.java
@@ -2,11 +2,23 @@ package com.projectlyrics.server.domain.search.domain;
 
 import com.projectlyrics.server.domain.song.entity.Song;
 
+import java.util.List;
+
 public record SongSearch(
         Long id,
         String title,
         String artistName
 ) {
+    public static final String INDEX = "song";
+    public static final List<String> FIELDS = List.of(
+            "korean_title",
+            "english_title",
+            "korean_artist_name",
+            "english_artist_name",
+            "korean_album_name",
+            "english_album_name"
+    );
+
     public static SongSearch from(Song song) {
         return new SongSearch(
                 song.getId(),

--- a/src/main/java/com/projectlyrics/server/domain/search/exception/FailedToIndexException.java
+++ b/src/main/java/com/projectlyrics/server/domain/search/exception/FailedToIndexException.java
@@ -1,0 +1,11 @@
+package com.projectlyrics.server.domain.search.exception;
+
+import com.projectlyrics.server.domain.common.message.ErrorCode;
+import com.projectlyrics.server.global.exception.FeelinException;
+
+public class FailedToIndexException extends FeelinException {
+
+    public FailedToIndexException() {
+        super(ErrorCode.FAILED_TO_INDEX);
+    }
+}

--- a/src/main/java/com/projectlyrics/server/domain/search/exception/FailedToSearchException.java
+++ b/src/main/java/com/projectlyrics/server/domain/search/exception/FailedToSearchException.java
@@ -1,0 +1,11 @@
+package com.projectlyrics.server.domain.search.exception;
+
+import com.projectlyrics.server.domain.common.message.ErrorCode;
+import com.projectlyrics.server.global.exception.FeelinException;
+
+public class FailedToSearchException extends FeelinException {
+
+    public FailedToSearchException() {
+        super(ErrorCode.FAILED_TO_SEARCH);
+    }
+}

--- a/src/main/java/com/projectlyrics/server/domain/search/repository/SearchRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/search/repository/SearchRepository.java
@@ -7,15 +7,15 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.Refresh;
-import org.opensearch.client.opensearch.core.IndexRequest;
-import org.opensearch.client.opensearch.core.SearchRequest;
-import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.opensearch.core.*;
+import org.opensearch.client.opensearch.core.bulk.BulkOperation;
+import org.opensearch.client.opensearch.core.bulk.CreateOperation;
 import org.opensearch.client.opensearch.core.search.Hit;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -24,7 +24,6 @@ public class SearchRepository {
 
     private final OpenSearchClient searchClient;
 
-    @Async
     public void index(SongSearch songSearch) {
         try {
             searchClient.index(IndexRequest.of(builder ->
@@ -36,6 +35,37 @@ public class SearchRepository {
             ));
         } catch (IOException e) {
             log.error("error occurred indexing a document.");
+            throw new FailedToIndexException();
+        }
+    }
+
+    public void bulkIndex(List<SongSearch> songSearchList) {
+        try {
+            BulkRequest.Builder bulkRequestBuilder = new BulkRequest.Builder();
+
+            songSearchList.forEach(search -> {
+                BulkOperation operation = new BulkOperation.Builder()
+                        .create(new CreateOperation.Builder<>()
+                                .index(SongSearch.INDEX)
+                                .id(search.id().toString())
+                                .document(search)
+                                .build())
+                        .build();
+
+                bulkRequestBuilder.operations(operation);
+            });
+
+            BulkResponse response = searchClient.bulk(bulkRequestBuilder.build());
+
+            if (response.errors()) {
+                response.items().forEach(item -> {
+                    if (Objects.nonNull(item.error())) {
+                        log.error(item.error().reason());
+                    }
+                });
+            }
+        } catch (IOException e) {
+            log.error("error occurred bulk-indexing a document.");
             throw new FailedToIndexException();
         }
     }

--- a/src/main/java/com/projectlyrics/server/domain/search/repository/SearchRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/search/repository/SearchRepository.java
@@ -1,0 +1,59 @@
+package com.projectlyrics.server.domain.search.repository;
+
+import com.projectlyrics.server.domain.search.domain.SongSearch;
+import com.projectlyrics.server.domain.search.exception.FailedToIndexException;
+import com.projectlyrics.server.domain.search.exception.FailedToSearchException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.Refresh;
+import org.opensearch.client.opensearch.core.IndexRequest;
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.opensearch.core.search.Hit;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class SearchRepository {
+
+    private final OpenSearchClient searchClient;
+
+    @Async
+    public void index(SongSearch songSearch) {
+        try {
+            searchClient.index(IndexRequest.of(builder ->
+                    builder
+                            .index(SongSearch.INDEX)
+                            .id(songSearch.id().toString())
+                            .document(songSearch)
+                            .refresh(Refresh.True)
+            ));
+        } catch (IOException e) {
+            log.error("error occurred indexing a document.");
+            throw new FailedToIndexException();
+        }
+    }
+
+    public List<SongSearch> search(String query) {
+        try {
+            SearchRequest request = new SearchRequest.Builder()
+                    .index(SongSearch.INDEX)
+                    .query(q -> q.queryString(qs -> qs.fields(SongSearch.FIELDS).query(query)))
+                    .build();
+            SearchResponse<SongSearch> response = searchClient.search(request, SongSearch.class);
+
+            return response.hits().hits().stream()
+                    .map(Hit::source)
+                    .toList();
+        } catch (IOException e) {
+            log.error("error occurred searching a document.");
+            throw new FailedToSearchException();
+        }
+    }
+}

--- a/src/main/java/com/projectlyrics/server/domain/search/repository/SearchRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/search/repository/SearchRepository.java
@@ -70,11 +70,13 @@ public class SearchRepository {
         }
     }
 
-    public List<SongSearch> search(String query) {
+    public List<SongSearch> search(String query, int pageNumber, int pageSize) {
         try {
             SearchRequest request = new SearchRequest.Builder()
                     .index(SongSearch.INDEX)
                     .query(q -> q.queryString(qs -> qs.fields(SongSearch.FIELDS).query(query)))
+                    .from(pageNumber * pageSize)
+                    .size(pageSize)
                     .build();
             SearchResponse<SongSearch> response = searchClient.search(request, SongSearch.class);
 

--- a/src/main/java/com/projectlyrics/server/domain/song/api/SongController.java
+++ b/src/main/java/com/projectlyrics/server/domain/song/api/SongController.java
@@ -24,7 +24,7 @@ public class SongController {
     @GetMapping("/search")
     public ResponseEntity<OffsetBasePaginatedResponse<SongSearchResponse>> searchSongs(
             @RequestParam(name = "query", required = false) String query,
-            @RequestParam(required = false, defaultValue = "0") int pageNumber,
+            @RequestParam(name = "pageNumber", required = false, defaultValue = "0") int pageNumber,
             @RequestParam(name = "pageSize", defaultValue = "10") int pageSize
     ) {
         return ResponseEntity

--- a/src/main/java/com/projectlyrics/server/domain/song/repository/SongQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/song/repository/SongQueryRepository.java
@@ -14,4 +14,5 @@ public interface SongQueryRepository {
     Slice<Song> findAllByQueryOrderByNoteCountDesc(String query, Pageable pageable);
     Slice<Song> findAllByQueryAndArtistId(Long artistId, String query, Long cursor, Pageable pageable);
     List<Song> findAll();
+    List<Song> findAllByIds(List<Long> ids);
 }

--- a/src/main/java/com/projectlyrics/server/domain/song/repository/SongQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/song/repository/SongQueryRepository.java
@@ -11,7 +11,7 @@ public interface SongQueryRepository {
 
     Optional<Song> findById(Long id);
     Optional<Song> findBySpotifyId(String spotifyId);
-    Slice<Song> findAllByQueryOrderByNoteCountDesc(String query, Pageable pageable);
+    Slice<Song> findAllOrderByNoteCountDesc(Pageable pageable);
     Slice<Song> findAllByQueryAndArtistId(Long artistId, String query, Long cursor, Pageable pageable);
     List<Song> findAll();
     List<Song> findAllByIds(List<Long> ids);

--- a/src/main/java/com/projectlyrics/server/domain/song/repository/SongQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/song/repository/SongQueryRepository.java
@@ -1,6 +1,8 @@
 package com.projectlyrics.server.domain.song.repository;
 
 import com.projectlyrics.server.domain.song.entity.Song;
+
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -11,4 +13,5 @@ public interface SongQueryRepository {
     Optional<Song> findBySpotifyId(String spotifyId);
     Slice<Song> findAllByQueryOrderByNoteCountDesc(String query, Pageable pageable);
     Slice<Song> findAllByQueryAndArtistId(Long artistId, String query, Long cursor, Pageable pageable);
+    List<Song> findAll();
 }

--- a/src/main/java/com/projectlyrics/server/domain/song/repository/impl/QueryDslSongQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/song/repository/impl/QueryDslSongQueryRepository.java
@@ -1,5 +1,6 @@
 package com.projectlyrics.server.domain.song.repository.impl;
 
+import static com.projectlyrics.server.domain.artist.entity.QArtist.artist;
 import static com.projectlyrics.server.domain.note.entity.QNote.note;
 import static com.projectlyrics.server.domain.song.entity.QSong.song;
 
@@ -91,5 +92,13 @@ public class QueryDslSongQueryRepository implements SongQueryRepository {
 
     private static BooleanExpression artistIdEq(Long artistId) {
         return Objects.isNull(artistId) ? null : song.artist.id.eq(artistId);
+    }
+
+    @Override
+    public List<Song> findAll() {
+        return jpaQueryFactory
+                .selectFrom(song)
+                .join(song.artist, artist).fetchJoin()
+                .fetch();
     }
 }

--- a/src/main/java/com/projectlyrics/server/domain/song/repository/impl/QueryDslSongQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/song/repository/impl/QueryDslSongQueryRepository.java
@@ -101,4 +101,13 @@ public class QueryDslSongQueryRepository implements SongQueryRepository {
                 .join(song.artist, artist).fetchJoin()
                 .fetch();
     }
+
+    @Override
+    public List<Song> findAllByIds(List<Long> ids) {
+        return jpaQueryFactory
+                .selectFrom(song)
+                .join(song.artist, artist).fetchJoin()
+                .where(song.id.in(ids))
+                .fetch();
+    }
 }

--- a/src/main/java/com/projectlyrics/server/domain/song/repository/impl/QueryDslSongQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/song/repository/impl/QueryDslSongQueryRepository.java
@@ -48,14 +48,11 @@ public class QueryDslSongQueryRepository implements SongQueryRepository {
     }
 
     @Override
-    public Slice<Song> findAllByQueryOrderByNoteCountDesc(String query, Pageable pageable) {
+    public Slice<Song> findAllOrderByNoteCountDesc(Pageable pageable) {
         List<Song> content = jpaQueryFactory
-                .select(song)
-                .from(song)
+                .selectFrom(song)
                 .leftJoin(song.notes, note)
-                .where(
-                        songNameContains(query)
-                )
+                .join(song.artist, artist).fetchJoin()
                 .groupBy(song.id)
                 .orderBy(
                         Expressions.numberTemplate(Long.class,

--- a/src/main/java/com/projectlyrics/server/domain/song/repository/impl/QueryDslSongQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/song/repository/impl/QueryDslSongQueryRepository.java
@@ -103,6 +103,7 @@ public class QueryDslSongQueryRepository implements SongQueryRepository {
     public List<Song> findAllByIds(List<Long> ids) {
         return jpaQueryFactory
                 .selectFrom(song)
+                .leftJoin(song.notes, note).fetchJoin()
                 .join(song.artist, artist).fetchJoin()
                 .where(song.id.in(ids))
                 .fetch();

--- a/src/main/java/com/projectlyrics/server/domain/song/service/SongQueryService.java
+++ b/src/main/java/com/projectlyrics/server/domain/song/service/SongQueryService.java
@@ -2,8 +2,11 @@ package com.projectlyrics.server.domain.song.service;
 
 import com.projectlyrics.server.domain.common.dto.util.CursorBasePaginatedResponse;
 import com.projectlyrics.server.domain.common.dto.util.OffsetBasePaginatedResponse;
+import com.projectlyrics.server.domain.search.domain.SongSearch;
+import com.projectlyrics.server.domain.search.repository.SearchRepository;
 import com.projectlyrics.server.domain.song.dto.response.SongGetResponse;
 import com.projectlyrics.server.domain.song.dto.response.SongSearchResponse;
+import com.projectlyrics.server.domain.song.entity.Song;
 import com.projectlyrics.server.domain.song.exception.SongNotFoundException;
 import com.projectlyrics.server.domain.song.repository.SongQueryRepository;
 import lombok.RequiredArgsConstructor;
@@ -11,18 +14,31 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.stream.Stream;
+
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class SongQueryService {
 
     private final SongQueryRepository songQueryRepository;
+    private final SearchRepository searchRepository;
 
     public OffsetBasePaginatedResponse<SongSearchResponse> searchSongs(String query, int pageNumber, int pageSize) {
-        return OffsetBasePaginatedResponse.of(
-                songQueryRepository.findAllByQueryOrderByNoteCountDesc(query, PageRequest.of(pageNumber, pageSize))
-                        .map(SongSearchResponse::from)
-        );
+        List<Long> searchedIds = searchRepository.search(query, pageNumber, pageSize + 1).stream()
+                .map(SongSearch::id)
+                .toList();
+        List<Song> songs = songQueryRepository.findAllByIds(searchedIds);
+        List<SongSearchResponse> response = searchedIds.stream()
+                .map(id -> songs.stream()
+                        .filter(song -> song.getId().equals(id))
+                        .findFirst()
+                        .get())
+                .map(SongSearchResponse::from)
+                .toList();
+
+        return OffsetBasePaginatedResponse.of(pageNumber, pageSize, response);
     }
 
     public CursorBasePaginatedResponse<SongGetResponse> searchSongsByArtist(Long artistId, String query, Long cursor, int size) {

--- a/src/main/java/com/projectlyrics/server/global/configuration/SearchConfig.java
+++ b/src/main/java/com/projectlyrics/server/global/configuration/SearchConfig.java
@@ -14,6 +14,7 @@ import org.opensearch.client.transport.rest_client.RestClientTransport;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -32,6 +33,7 @@ public class SearchConfig {
     @Value("${search.api.password}")
     private String password;
 
+    @Profile({"dev", "prod"})
     @Bean
     public OpenSearchClient openSearchClient() {
         return new OpenSearchClient(new RestClientTransport(restClient(), new JacksonJsonpMapper(new ObjectMapper())));

--- a/src/main/java/com/projectlyrics/server/global/configuration/SearchConfig.java
+++ b/src/main/java/com/projectlyrics/server/global/configuration/SearchConfig.java
@@ -33,7 +33,6 @@ public class SearchConfig {
     @Value("${search.api.password}")
     private String password;
 
-    @Profile({"dev", "prod"})
     @Bean
     public OpenSearchClient openSearchClient() {
         return new OpenSearchClient(new RestClientTransport(restClient(), new JacksonJsonpMapper(new ObjectMapper())));

--- a/src/main/java/com/projectlyrics/server/global/configuration/SearchConfig.java
+++ b/src/main/java/com/projectlyrics/server/global/configuration/SearchConfig.java
@@ -1,0 +1,54 @@
+package com.projectlyrics.server.global.configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.opensearch.client.RestClient;
+import org.opensearch.client.json.jackson.JacksonJsonpMapper;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.transport.rest_client.RestClientTransport;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Slf4j
+@RequiredArgsConstructor
+@Configuration
+public class SearchConfig {
+
+    @Value("${search.api.host}")
+    private String host;
+
+    @Value("${search.api.port}")
+    private int port;
+
+    @Value("${search.api.username}")
+    private String username;
+
+    @Value("${search.api.password}")
+    private String password;
+
+    @Bean
+    public OpenSearchClient openSearchClient() {
+        return new OpenSearchClient(new RestClientTransport(restClient(), new JacksonJsonpMapper(new ObjectMapper())));
+    }
+
+    @Bean
+    public RestClient restClient() {
+        BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+        credentialsProvider.setCredentials(
+                AuthScope.ANY,
+                new UsernamePasswordCredentials(username, password)
+        );
+
+        return RestClient.builder(new HttpHost(host, port, "https"))
+                .setHttpClientConfigCallback(httpClientBuilder -> httpClientBuilder
+                        .setDefaultCredentialsProvider(credentialsProvider)
+                )
+                .build();
+    }
+}

--- a/src/main/java/com/projectlyrics/server/global/dev/SongIndexer.java
+++ b/src/main/java/com/projectlyrics/server/global/dev/SongIndexer.java
@@ -1,0 +1,42 @@
+package com.projectlyrics.server.global.dev;
+
+import com.projectlyrics.server.ServerApplication;
+import com.projectlyrics.server.domain.search.domain.SongSearch;
+import com.projectlyrics.server.domain.search.repository.SearchRepository;
+import com.projectlyrics.server.domain.song.repository.SongQueryRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ConfigurableApplicationContext;
+
+import java.util.List;
+
+import static org.springframework.boot.WebApplicationType.NONE;
+
+@Slf4j
+public class SongIndexer {
+
+    public static void main(String[] args) {
+        ConfigurableApplicationContext context = new SpringApplicationBuilder()
+                .sources(ServerApplication.class)
+                .web(NONE)
+                .run(args);
+
+        index(context);
+
+        context.close();
+    }
+
+    private static void index(ConfigurableApplicationContext context) {
+        SearchRepository searchRepository = context.getBean(SearchRepository.class);
+        SongQueryRepository songQueryRepository = context.getBean(SongQueryRepository.class);
+
+        List<SongSearch> searches = songQueryRepository.findAll().stream()
+                .map(SongSearch::from)
+                .toList();
+
+        int limit = 100;
+        for (int offset = 31600; offset < searches.size(); offset += limit) {
+            searchRepository.bulkIndex(searches.subList(offset, offset + limit));
+        }
+    }
+}

--- a/src/test/java/com/projectlyrics/server/domain/artist/repository/ArtistQueryRepositoryTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/artist/repository/ArtistQueryRepositoryTest.java
@@ -28,9 +28,6 @@ public class ArtistQueryRepositoryTest {
     @Autowired
     private ArtistCommandRepository artistCommandRepository;
 
-    @MockBean
-    private OpenSearchClient openSearchClientp;
-
     @Test
     void id로_Optional로_감싼_아티스트를_조회한다() {
         // given

--- a/src/test/java/com/projectlyrics/server/domain/artist/repository/ArtistQueryRepositoryTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/artist/repository/ArtistQueryRepositoryTest.java
@@ -10,7 +10,9 @@ import com.projectlyrics.server.support.fixture.ArtistFixture;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
+import org.opensearch.client.opensearch.OpenSearchClient;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -25,6 +27,9 @@ public class ArtistQueryRepositoryTest {
 
     @Autowired
     private ArtistCommandRepository artistCommandRepository;
+
+    @MockBean
+    private OpenSearchClient openSearchClientp;
 
     @Test
     void id로_Optional로_감싼_아티스트를_조회한다() {

--- a/src/test/java/com/projectlyrics/server/domain/song/service/SongCommandServiceTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/song/service/SongCommandServiceTest.java
@@ -46,7 +46,7 @@ class SongCommandServiceTest extends IntegrationTest {
         Song song = sut.create(request);
 
         // then
-        Slice<Song> result = songQueryRepository.findAllByQueryOrderByNoteCountDesc(null, PageRequest.ofSize(5));
+        Slice<Song> result = songQueryRepository.findAllOrderByNoteCountDesc(PageRequest.ofSize(5));
         assertAll(
                 () -> assertThat(result.getContent().size()).isEqualTo(1),
                 () -> assertThat(result.getContent().getFirst().getId()).isEqualTo(song.getId()),

--- a/src/test/java/com/projectlyrics/server/domain/song/service/SongQueryServiceTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/song/service/SongQueryServiceTest.java
@@ -2,6 +2,9 @@ package com.projectlyrics.server.domain.song.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.when;
 
 import com.projectlyrics.server.domain.artist.entity.Artist;
 import com.projectlyrics.server.domain.artist.repository.ArtistCommandRepository;
@@ -13,6 +16,8 @@ import com.projectlyrics.server.domain.note.entity.NoteBackground;
 import com.projectlyrics.server.domain.note.entity.NoteCreate;
 import com.projectlyrics.server.domain.note.entity.NoteStatus;
 import com.projectlyrics.server.domain.note.repository.NoteCommandRepository;
+import com.projectlyrics.server.domain.search.domain.SongSearch;
+import com.projectlyrics.server.domain.search.repository.SearchRepository;
 import com.projectlyrics.server.domain.song.dto.request.SongCreateRequest;
 import com.projectlyrics.server.domain.song.dto.response.SongGetResponse;
 import com.projectlyrics.server.domain.song.dto.response.SongSearchResponse;
@@ -23,11 +28,14 @@ import com.projectlyrics.server.support.IntegrationTest;
 import com.projectlyrics.server.support.fixture.ArtistFixture;
 import com.projectlyrics.server.support.fixture.UserFixture;
 import java.time.LocalDate;
+import java.util.List;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 class SongQueryServiceTest extends IntegrationTest {
 
@@ -45,6 +53,9 @@ class SongQueryServiceTest extends IntegrationTest {
 
     @Autowired
     SongQueryService sut;
+
+    @MockBean
+    SearchRepository songSearchRepository;
 
     private User user;
     private Artist artist1;
@@ -103,6 +114,9 @@ class SongQueryServiceTest extends IntegrationTest {
                 artist1.getId()
         );
         Song song = songCommandService.create(request);
+
+        when(songSearchRepository.search(any(), anyInt(), anyInt()))
+                .thenReturn(List.of(new SongSearch(1L, null, null, null, null, null, null)));
 
         // when
         OffsetBasePaginatedResponse<SongSearchResponse> result = sut.searchSongs(query, 0, 5);

--- a/src/test/java/com/projectlyrics/server/support/IntegrationTest.java
+++ b/src/test/java/com/projectlyrics/server/support/IntegrationTest.java
@@ -2,14 +2,9 @@ package com.projectlyrics.server.support;
 
 import com.projectlyrics.server.support.db.DatabaseCleanerExtension;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.opensearch.client.opensearch.OpenSearchClient;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 
 @SpringBootTest
 @ExtendWith(DatabaseCleanerExtension.class)
 public abstract class IntegrationTest {
-
-    @MockBean
-    protected OpenSearchClient openSearchClient;
 }

--- a/src/test/java/com/projectlyrics/server/support/IntegrationTest.java
+++ b/src/test/java/com/projectlyrics/server/support/IntegrationTest.java
@@ -2,9 +2,14 @@ package com.projectlyrics.server.support;
 
 import com.projectlyrics.server.support.db.DatabaseCleanerExtension;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.opensearch.client.opensearch.OpenSearchClient;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 @SpringBootTest
 @ExtendWith(DatabaseCleanerExtension.class)
 public abstract class IntegrationTest {
+
+    @MockBean
+    protected OpenSearchClient openSearchClient;
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -27,6 +27,13 @@ admin: 1
 
 version: 0.0.1
 
+search:
+  api:
+    host: host
+    port: 443
+    username: username
+    password: password
+
 ---
 spring:
   config:


### PR DESCRIPTION
# 🍃 **Pull Requests**

## ⛳️ **작업한 브랜치**
- [SCRUM-195]

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 의존성 추가
    - `build.gradle`에 opensearch 의존성 추가
    - `SearchConfig`에서 `OpenSearchClient` 빈 등록

- `SongSearch` 정의
    - `id`, `title`, `artist_name`, `album_name`으로 구성
    - id를 제외한 3개 필드는 한국어와 영어를 서로 다른 프로퍼티로 저장했습니다.
        - opensearch에서 한국어와 영어 전용 분석기가 다르기 때문입니다.

- `SearchRepository` 정의
    - `index()`, `bulkIndex()` -> 저장
    - `search()` -> 검색(조회)

- `SongIndexer` 정의
    - DB에서 곡을 리스트로 읽어와 opensearch에 인덱싱하는 로직입니다.
    - 간단하게 IDE에서 `main()` 메서드를 호출해서 로직을 실행할 수 있습니다.

- `SongQueryService` 정의
    - opensearch에서 검색한 결과를 id 리스트로 받고, id 리스트로부터 in 절로 DB에 질의해서 받은 결과를 DTO로 변환해 반환하도록 했습니다.

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->


[SCRUM-195]: https://projectlyrics.atlassian.net/browse/SCRUM-195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ