### PR TITLE
노트 쿼리 개선

### DIFF
--- a/src/main/java/com/projectlyrics/server/domain/bookmark/service/BookmarkCommandService.java
+++ b/src/main/java/com/projectlyrics/server/domain/bookmark/service/BookmarkCommandService.java
@@ -31,8 +31,7 @@ public class BookmarkCommandService {
     public synchronized Bookmark create(Long noteId, Long userId) {
         User user = userQueryRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
-        Note note = noteQueryRepository.findById(noteId)
-                .orElseThrow(NoteNotFoundException::new);
+        Note note = noteQueryRepository.findById(noteId);
 
         checkIfBookmarkExists(noteId, userId);
 

--- a/src/main/java/com/projectlyrics/server/domain/comment/service/CommentCommandService.java
+++ b/src/main/java/com/projectlyrics/server/domain/comment/service/CommentCommandService.java
@@ -40,8 +40,7 @@ public class CommentCommandService {
     public Comment create(CommentCreateRequest request, Long writerId) {
         User writer = userQueryRepository.findById(writerId)
                 .orElseThrow(UserNotFoundException::new);
-        Note note = noteQueryRepository.findById(request.noteId())
-                .orElseThrow(NoteNotFoundException::new);
+        Note note = noteQueryRepository.findById(request.noteId());
 
         checkDiscipline(note.getSong().getArtist().getId(), writerId);
 

--- a/src/main/java/com/projectlyrics/server/domain/like/service/LikeCommandService.java
+++ b/src/main/java/com/projectlyrics/server/domain/like/service/LikeCommandService.java
@@ -31,8 +31,7 @@ public class LikeCommandService {
     public synchronized Like create(Long noteId, Long userId) {
         User user = userQueryRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
-        Note note = noteQueryRepository.findById(noteId)
-                .orElseThrow(NoteNotFoundException::new);
+        Note note = noteQueryRepository.findById(noteId);
 
         checkIfLikeExists(noteId, userId);
 

--- a/src/main/java/com/projectlyrics/server/domain/note/repository/NoteQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/note/repository/NoteQueryRepository.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 
 public interface NoteQueryRepository {
 
-    Optional<Note> findById(Long id);
+    Note findById(Long id);
     Optional<Note> findById(Long id, Long userId);
 
     Slice<Note> findAllByUserId(boolean hasLyrics, Long artistId, Long userId, Long cursorId, Pageable pageable);

--- a/src/main/java/com/projectlyrics/server/domain/note/repository/NoteQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/note/repository/NoteQueryRepository.java
@@ -5,12 +5,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface NoteQueryRepository {
 
     Note findById(Long id);
-    Optional<Note> findById(Long id, Long userId);
 
     Slice<Note> findAllByUserId(boolean hasLyrics, Long artistId, Long userId, Long cursorId, Pageable pageable);
     Slice<Note> findAllByArtistIds(boolean hasLyrics, List<Long> artistsIds, Long userId, Long cursorId, Pageable pageable);

--- a/src/main/java/com/projectlyrics/server/domain/note/repository/impl/QueryDslNoteQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/note/repository/impl/QueryDslNoteQueryRepository.java
@@ -49,22 +49,6 @@ public class QueryDslNoteQueryRepository implements NoteQueryRepository {
     }
 
     @Override
-    public Optional<Note> findById(Long id, Long userId) {
-        return Optional.ofNullable(jpaQueryFactory
-                .selectFrom(note)
-                .leftJoin(note.lyrics).fetchJoin()
-                .join(note.publisher).fetchJoin()
-                .join(note.song).fetchJoin()
-                .join(song.artist).fetchJoin()
-                .leftJoin(note.comments, comment)
-                .where(
-                        note.id.eq(id),
-                        note.deletedAt.isNull()
-                )
-                .fetchOne());
-    }
-
-    @Override
     public Slice<Note> findAllByUserId(boolean hasLyrics, Long artistId, Long userId, Long cursorId, Pageable pageable) {
         List<Note> content = jpaQueryFactory
                 .selectFrom(note)

--- a/src/main/java/com/projectlyrics/server/domain/note/repository/impl/QueryDslNoteQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/note/repository/impl/QueryDslNoteQueryRepository.java
@@ -64,7 +64,6 @@ public class QueryDslNoteQueryRepository implements NoteQueryRepository {
                 .fetchOne());
     }
 
-
     @Override
     public Slice<Note> findAllByUserId(boolean hasLyrics, Long artistId, Long userId, Long cursorId, Pageable pageable) {
         List<Note> content = jpaQueryFactory

--- a/src/main/java/com/projectlyrics/server/domain/note/repository/impl/QueryDslNoteQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/note/repository/impl/QueryDslNoteQueryRepository.java
@@ -4,6 +4,7 @@ import static com.projectlyrics.server.domain.artist.entity.QArtist.artist;
 import static com.projectlyrics.server.domain.block.domain.QBlock.block;
 import static com.projectlyrics.server.domain.bookmark.domain.QBookmark.bookmark;
 import static com.projectlyrics.server.domain.comment.domain.QComment.comment;
+import static com.projectlyrics.server.domain.common.util.QueryDslUtils.hasLyrics;
 import static com.projectlyrics.server.domain.note.entity.QNote.note;
 import static com.projectlyrics.server.domain.song.entity.QSong.song;
 
@@ -58,7 +59,7 @@ public class QueryDslNoteQueryRepository implements NoteQueryRepository {
                 .join(song.artist, artist).fetchJoin()
                 .leftJoin(note.comments).fetchJoin()
                 .where(
-                        QueryDslUtils.hasLyrics(hasLyrics),
+                        hasLyrics(hasLyrics),
                         artistId == null ? null : artist.id.eq(artistId),
                         note.publisher.deletedAt.isNull(),
                         note.publisher.id.eq(userId),
@@ -87,7 +88,7 @@ public class QueryDslNoteQueryRepository implements NoteQueryRepository {
                 .join(song.artist).fetchJoin()
                 .leftJoin(note.comments).fetchJoin()
                 .where(
-                        QueryDslUtils.hasLyrics(hasLyrics),
+                        hasLyrics(hasLyrics),
                         note.song.artist.id.in(artistsIds),
                         note.deletedAt.isNull(),
                         QueryDslUtils.ltCursorId(cursorId, note.id),
@@ -114,7 +115,7 @@ public class QueryDslNoteQueryRepository implements NoteQueryRepository {
                 .join(song.artist).fetchJoin()
                 .leftJoin(note.comments).fetchJoin()
                 .where(
-                        QueryDslUtils.hasLyrics(hasLyrics),
+                        hasLyrics(hasLyrics),
                         note.song.artist.id.eq(artistId),
                         note.deletedAt.isNull(),
                         QueryDslUtils.ltCursorId(cursorId, note.id),
@@ -141,7 +142,7 @@ public class QueryDslNoteQueryRepository implements NoteQueryRepository {
                 .join(song.artist).fetchJoin()
                 .leftJoin(note.comments).fetchJoin()
                 .where(
-                        QueryDslUtils.hasLyrics(hasLyrics),
+                        hasLyrics(hasLyrics),
                         note.song.id.eq(songId),
                         note.deletedAt.isNull(),
                         QueryDslUtils.ltCursorId(cursorId, note.id),
@@ -170,7 +171,7 @@ public class QueryDslNoteQueryRepository implements NoteQueryRepository {
                 .where(
                         bookmark.user.id.eq(userId)
                                 .and(bookmark.deletedAt.isNull()),
-                        QueryDslUtils.hasLyrics(hasLyrics),
+                        hasLyrics(hasLyrics),
                         artistId == null ? null : note.song.artist.id.eq(artistId),
                         note.deletedAt.isNull(),
                         QueryDslUtils.ltCursorId(cursorId, note.id),

--- a/src/main/java/com/projectlyrics/server/domain/note/repository/impl/QueryDslNoteQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/note/repository/impl/QueryDslNoteQueryRepository.java
@@ -10,6 +10,7 @@ import static com.projectlyrics.server.domain.song.entity.QSong.song;
 import com.projectlyrics.server.domain.common.util.QueryDslUtils;
 import com.projectlyrics.server.domain.note.entity.Note;
 import com.projectlyrics.server.domain.note.entity.NoteStatus;
+import com.projectlyrics.server.domain.note.exception.NoteNotFoundException;
 import com.projectlyrics.server.domain.note.repository.NoteQueryRepository;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -30,21 +31,21 @@ public class QueryDslNoteQueryRepository implements NoteQueryRepository {
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public Optional<Note> findById(Long id) {
+    public Note findById(Long id) {
         return Optional.ofNullable(
-                jpaQueryFactory
-                        .selectFrom(note)
-                        .leftJoin(note.lyrics).fetchJoin()
-                        .join(note.publisher).fetchJoin()
-                        .join(note.song).fetchJoin()
-                        .join(song.artist).fetchJoin()
-                        .leftJoin(note.comments).fetchJoin()
-                        .where(
-                                note.id.eq(id),
-                                note.deletedAt.isNull()
-                        )
-                        .fetchOne()
-        );
+                        jpaQueryFactory
+                                .selectFrom(note)
+                                .leftJoin(note.lyrics).fetchJoin()
+                                .join(note.publisher).fetchJoin()
+                                .join(note.song).fetchJoin()
+                                .join(song.artist).fetchJoin()
+                                .leftJoin(note.comments, comment)
+                                .where(
+                                        note.id.eq(id),
+                                        note.deletedAt.isNull()
+                                )
+                                .fetchOne()
+                ).orElseThrow(NoteNotFoundException::new);
     }
 
     @Override

--- a/src/main/java/com/projectlyrics/server/domain/note/service/NoteCommandService.java
+++ b/src/main/java/com/projectlyrics/server/domain/note/service/NoteCommandService.java
@@ -66,18 +66,22 @@ public class NoteCommandService {
     }
 
     public void delete(long publisherId, long noteId) {
-        noteQueryRepository.findById(noteId)
-                .filter(note -> note.isPublisher(publisherId))
-                .ifPresentOrElse(
-                        note -> note.delete(publisherId, Clock.systemDefaultZone()),
-                        () -> { throw new InvalidNoteDeletionException(); });
+        Note note = noteQueryRepository.findById(noteId);
+
+        if (note.isPublisher(publisherId)) {
+            note.delete(publisherId, Clock.systemDefaultZone());
+        } else {
+            throw new InvalidNoteDeletionException();
+        }
     }
 
     public Note update(NoteUpdateRequest request, Long noteId, Long publisherId) {
-        Note note = noteQueryRepository.findById(noteId)
-                .filter(foundNote -> foundNote.isPublisher(publisherId))
-                .orElseThrow(InvalidNoteUpdateException::new);
+        Note note = noteQueryRepository.findById(noteId);
 
-        return note.update(NoteUpdate.from(request));
+        if (note.isPublisher(publisherId)) {
+            return note.update(NoteUpdate.from(request));
+        } else {
+            throw new InvalidNoteUpdateException();
+        }
     }
 }

--- a/src/main/java/com/projectlyrics/server/domain/note/service/NoteQueryService.java
+++ b/src/main/java/com/projectlyrics/server/domain/note/service/NoteQueryService.java
@@ -7,7 +7,6 @@ import com.projectlyrics.server.domain.favoriteartist.repository.FavoriteArtistQ
 import com.projectlyrics.server.domain.note.dto.response.NoteDetailResponse;
 import com.projectlyrics.server.domain.note.dto.response.NoteGetResponse;
 import com.projectlyrics.server.domain.note.entity.Note;
-import com.projectlyrics.server.domain.note.exception.NoteNotFoundException;
 import com.projectlyrics.server.domain.note.repository.NoteQueryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -27,8 +26,7 @@ public class NoteQueryService {
     private final FavoriteArtistQueryRepository favoriteArtistQueryRepository;
 
     public NoteDetailResponse getNoteById(Long noteId, Long userId) {
-        Note note = noteQueryRepository.findById(noteId, userId)
-                .orElseThrow(NoteNotFoundException::new);
+        Note note = noteQueryRepository.findById(noteId);
         List<Comment> comments = commentQueryRepository.findAllByNoteId(noteId, userId);
 
         return NoteDetailResponse.of(note, comments, userId);

--- a/src/main/java/com/projectlyrics/server/domain/report/service/ReportCommandService.java
+++ b/src/main/java/com/projectlyrics/server/domain/report/service/ReportCommandService.java
@@ -48,8 +48,7 @@ public class ReportCommandService {
         User reporter = userQueryRepository.findById(reporterId)
                 .orElseThrow(UserNotFoundException::new);
         Note note = Optional.ofNullable(request.noteId())
-                .map(noteId -> noteQueryRepository.findById(noteId)
-                        .orElseThrow(NoteNotFoundException::new))
+                .map(noteQueryRepository::findById)
                 .orElse(null);
         Comment comment = Optional.ofNullable(request.commentId())
                 .map(commentId -> commentQueryRepository.findById(commentId)
@@ -88,13 +87,8 @@ public class ReportCommandService {
                 .orElseThrow(ReportNotFoundException::new);
 
         if (report.getNote() != null) {
-                noteQueryRepository.findById(report.getNote().getId())
-                        .ifPresentOrElse(
-                                note -> note.delete(adminUserId, Clock.systemDefaultZone()),
-                                () -> {
-                                    throw new InvalidNoteDeletionException();
-                                }
-                        );
+                Note note = noteQueryRepository.findById(report.getNote().getId());
+                note.delete(adminUserId, Clock.systemDefaultZone());
         } else {
             commentQueryRepository.findById(report.getComment().getId())
                     .ifPresentOrElse(

--- a/src/test/java/com/projectlyrics/server/domain/auth/service/AuthCommandServiceIntegrationTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/auth/service/AuthCommandServiceIntegrationTest.java
@@ -327,7 +327,7 @@ public class AuthCommandServiceIntegrationTest extends IntegrationTest {
         assertThat(result.getSocialInfo().getSocialId()).isEqualTo(user.getSocialInfo().getSocialId());
         assertThat(result.getSocialInfo().getAuthProvider()).isEqualTo(user.getSocialInfo().getAuthProvider());
         assertThat(result.getRole()).isEqualTo(user.getRole());
-        assertThat(noteQueryRepository.findById(note.getId())).isNotEmpty();
+        assertThat(noteQueryRepository.findById(note.getId())).isNotNull();
     }
 
     private Note writeNote(Long userId) {

--- a/src/test/java/com/projectlyrics/server/domain/comment/service/CommentCommandServiceMockTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/comment/service/CommentCommandServiceMockTest.java
@@ -62,7 +62,7 @@ class CommentCommandServiceMockTest {
         when(songMock.getArtist()).thenReturn(artistMock);
         Note noteMock = mock(Note.class);
         when(noteMock.getSong()).thenReturn(songMock);
-        when(noteQueryRepository.findById(anyLong())).thenReturn(Optional.of(noteMock));
+        when(noteQueryRepository.findById(anyLong())).thenReturn(noteMock);
         when(commentCommandRepository.save(any(Comment.class))).thenReturn(mock(Comment.class));
         when(disciplineQueryRepository.existsByAll(anyLong())).thenReturn(false);
         when(disciplineQueryRepository.existsByArtist(anyLong(), anyLong())).thenReturn(false);


### PR DESCRIPTION
# 🍃 **Pull Requests**

## ⛳️ **작업한 브랜치**
- [SCRUM-196]

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- `NoteQueryRepository.findById(noteId)`의 반환 타입을 `Optional`에서 일반 객체로 수정했습니다.
  - 서비스 호출부 각각에서 `.orElseThrow()`를 호출할 필요성이 없다고 판단했습니다.

- `NoteQueryRepository.findById(noteId, userId)`를 제거했습니다.
  - 실제 구현해서 `userId`를 사용하지 않기 때문에 `NoteQueryRepository.findById(noteId)`를 사용하더라도 동일하게 작동합니다.

- `QueryDslNoteQueryRepository` 내 간단한 줄바꿈 수정했습니다.

- `QueryDslNoteQueryRepository` 내 `QueryDslUtils.hasLyrics`에 ***static import*** 적용했습니다.

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
