### PR TITLE
JwtProvider 리팩토링

### DIFF
--- a/src/main/java/com/projectlyrics/server/domain/auth/authentication/jwt/JwtProvider.java
+++ b/src/main/java/com/projectlyrics/server/domain/auth/authentication/jwt/JwtProvider.java
@@ -17,20 +17,29 @@ import java.util.Date;
 @Component
 public class JwtProvider {
 
-    private static final String TOKEN_TYPE = "tokenType";
-    private static final String ACCESS_TOKEN_TYPE = "accessToken";
-    private static final String REFRESH_TOKEN_TYPE = "refreshToken";
-    private static final long ACCESS_TOKEN_EXPIRATION_TIME = 1000L * 60 * 60 * 3;
-    private static final long REFRESH_TOKEN_EXPIRATION_TIME = 1000L * 60 * 60 * 24 * 7 * 3;
-
+    private final String TOKEN_TYPE;
+    private final String ACCESS_TOKEN_TYPE;
+    private final String REFRESH_TOKEN_TYPE;
+    private final long ACCESS_TOKEN_EXPIRATION_TIME;
+    private final long REFRESH_TOKEN_EXPIRATION_TIME;
     private final Key key;
     private final Clock clock;
 
     public JwtProvider(
-            @Value("${jwt.secret}") String key,
+            @Value("${jwt.token.type}") String tokenType,
+            @Value("${jwt.token.access-token-type}") String accessTokenType,
+            @Value("${jwt.token.refresh-token-type}") String refreshTokenType,
+            @Value("${jwt.token.expiration.access-token}") long accessTokenExpirationTime,
+            @Value("${jwt.token.expiration.refresh-token}") long refreshTokenExpirationTime,
+            @Value("${jwt.secret}") String secretKey,
             Clock clock
     ) {
-        this.key = Keys.hmacShaKeyFor(key.getBytes(StandardCharsets.UTF_8));
+        this.TOKEN_TYPE = tokenType;
+        this.ACCESS_TOKEN_TYPE = accessTokenType;
+        this.REFRESH_TOKEN_TYPE = refreshTokenType;
+        this.ACCESS_TOKEN_EXPIRATION_TIME = accessTokenExpirationTime;
+        this.REFRESH_TOKEN_EXPIRATION_TIME = refreshTokenExpirationTime;
+        this.key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
         this.clock = clock;
     }
 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -3,7 +3,14 @@ spring:
     active: test
 
 jwt:
-  secret: lyrics2024lyrics2024lyrics2024lyrics2024lyrics2024lyrics2024lyrics2024lyrics2024lyrics2024
+  secret: secretsecretsecretsecretsecretsecretsecretsecretsecretsecretsecretsecret
+  token:
+    type: secret
+    access-token-type: secret
+    refresh-token-type: secret
+    expiration:
+      access-token: 100000
+      refresh-token: 1000000
 
 logging:
   pattern:


### PR DESCRIPTION
# 🍃 **Pull Requests**

## ⛳️ **작업한 브랜치**
- Resolved: [SCRUM-197](https://projectlyrics.atlassian.net/browse/SCRUM-197?atlOrigin=eyJpIjoiOWViYTU3YzdhN2QwNDc3ZWFmYTNjNTU2OTgwMmU3NDEiLCJwIjoiamlyYS1zbGFjay1pbnQifQ)

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 보안을 위해 JwtProvider 내 상수들을 yml로 이동했습니다.
- 생성자 주입을 통해 yml 내 정보들로 상수들을 초기화할 수 있도록 하였습니다.
- test 내 yml의 jwt secret를 변경하면서, AuthControllerTest 내에서 yml의 jwt secret을 가지고 만료된 토큰을 생성하는 함수를 새롭게 추가했습니다.

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- yml을 업데이트했습니다.

[SCRUM-197]: https://projectlyrics.atlassian.net/browse/SCRUM-197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ