### PR TITLE
이벤트 기능 수정

### DIFF
--- a/src/main/java/com/projectlyrics/server/domain/auth/authentication/interceptor/AuthInterceptor.java
+++ b/src/main/java/com/projectlyrics/server/domain/auth/authentication/interceptor/AuthInterceptor.java
@@ -42,7 +42,7 @@ public class AuthInterceptor implements HandlerInterceptor {
                 requestURI.equals("/api/v1/notes/artists") ||
                 requestURI.equals("/api/v1/notes/songs") ||
                 requestURI.matches("/api/v1/songs/.*") ||
-                (requestURI.matches("/api/v1/events/.*") && requestMethod.equalsIgnoreCase(HttpMethod.GET.name())) );
+                (requestURI.matches("/api/v1/events") && requestMethod.equalsIgnoreCase(HttpMethod.GET.name())) );
     }
 
     private void setAuthContext(HttpServletRequest request) {

--- a/src/main/java/com/projectlyrics/server/domain/common/entity/BaseEntity.java
+++ b/src/main/java/com/projectlyrics/server/domain/common/entity/BaseEntity.java
@@ -76,8 +76,4 @@ public abstract class BaseEntity {
         this.deletedAt = null;
         this.deletedBy = null;
     }
-
-    public void touch() {
-        this.updatedAt = LocalDateTime.now();
-    }
 }

--- a/src/main/java/com/projectlyrics/server/domain/event/api/EventController.java
+++ b/src/main/java/com/projectlyrics/server/domain/event/api/EventController.java
@@ -5,20 +5,30 @@ import com.projectlyrics.server.domain.auth.authentication.Authenticated;
 import com.projectlyrics.server.domain.common.dto.util.CursorBasePaginatedResponse;
 import com.projectlyrics.server.domain.event.dto.request.EventCreateRequest;
 import com.projectlyrics.server.domain.event.dto.response.EventCreateResponse;
+import com.projectlyrics.server.domain.event.dto.response.EventCursorBasePaginatedResponse;
 import com.projectlyrics.server.domain.event.dto.response.EventGetResponse;
 import com.projectlyrics.server.domain.event.dto.response.EventRefusalResponse;
 import com.projectlyrics.server.domain.event.service.EventCommandService;
 import com.projectlyrics.server.domain.event.service.EventQueryService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/events")
 @RequiredArgsConstructor
 public class EventController {
 
+    @Value("${event.refusal_period:1}")
+    private int refusalPeriod;
     private final EventCommandService eventCommandService;
     private final EventQueryService eventQueryService;
 
@@ -33,7 +43,7 @@ public class EventController {
     }
 
     @GetMapping
-    public ResponseEntity<CursorBasePaginatedResponse<EventGetResponse>> getAllExceptRefused(
+    public ResponseEntity<EventCursorBasePaginatedResponse> getAllExceptRefused(
             @Authenticated AuthContext authContext,
             @RequestHeader("Device-Id") String deviceId,
             @RequestParam(name = "cursor", required = false) Long cursor,
@@ -49,7 +59,7 @@ public class EventController {
 
         return ResponseEntity
                 .status(HttpStatus.OK)
-                .body(response);
+                .body(new EventCursorBasePaginatedResponse(refusalPeriod, response));
     }
 
     @PostMapping("/refuse")
@@ -59,9 +69,9 @@ public class EventController {
             @RequestParam("eventId") Long eventId
     ) {
         if (authContext.isAnonymous()) {
-            eventCommandService.refuseByDeviceId(eventId, deviceId);
+            eventCommandService.refuseByDeviceId(eventId, deviceId, refusalPeriod);
         } else {
-            eventCommandService.refuseByUser(eventId, authContext.getId());
+            eventCommandService.refuseByUser(eventId, authContext.getId(), refusalPeriod);
         }
 
         return ResponseEntity

--- a/src/main/java/com/projectlyrics/server/domain/event/domain/Event.java
+++ b/src/main/java/com/projectlyrics/server/domain/event/domain/Event.java
@@ -27,15 +27,18 @@ public class Event extends BaseEntity {
 
     private String imageUrl;
     private String redirectUrl;
+    private String buttonText;
     private LocalDateTime dueDate;
 
     private Event(
             String imageUrl,
             String redirectUrl,
+            String buttonText,
             LocalDateTime dueDate
     ) {
         this.imageUrl = imageUrl;
         this.redirectUrl = redirectUrl;
+        this.buttonText = buttonText;
         this.dueDate = dueDate;
     }
 
@@ -43,6 +46,7 @@ public class Event extends BaseEntity {
         return new Event(
                 eventCreate.imageUrl(),
                 eventCreate.redirectUrl(),
+                eventCreate.buttonText(),
                 eventCreate.dueDate()
         );
     }
@@ -52,6 +56,7 @@ public class Event extends BaseEntity {
                 id,
                 eventCreate.imageUrl(),
                 eventCreate.redirectUrl(),
+                eventCreate.buttonText(),
                 eventCreate.dueDate()
         );
     }

--- a/src/main/java/com/projectlyrics/server/domain/event/domain/Event.java
+++ b/src/main/java/com/projectlyrics/server/domain/event/domain/Event.java
@@ -25,27 +25,23 @@ public class Event extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String popupImageUrl;
-    private String bannerImageUrl;
+    private String imageUrl;
     private String redirectUrl;
     private LocalDateTime dueDate;
 
     private Event(
-            String popupImageUrl,
-            String bannerImageUrl,
+            String imageUrl,
             String redirectUrl,
             LocalDateTime dueDate
     ) {
-        this.popupImageUrl = popupImageUrl;
-        this.bannerImageUrl = bannerImageUrl;
+        this.imageUrl = imageUrl;
         this.redirectUrl = redirectUrl;
         this.dueDate = dueDate;
     }
 
     public static Event create(EventCreate eventCreate) {
         return new Event(
-                eventCreate.popupImageUrl(),
-                eventCreate.bannerImageUrl(),
+                eventCreate.imageUrl(),
                 eventCreate.redirectUrl(),
                 eventCreate.dueDate()
         );
@@ -54,8 +50,7 @@ public class Event extends BaseEntity {
     public static Event createWithId(Long id, EventCreate eventCreate) {
         return new Event(
                 id,
-                eventCreate.popupImageUrl(),
-                eventCreate.bannerImageUrl(),
+                eventCreate.imageUrl(),
                 eventCreate.redirectUrl(),
                 eventCreate.dueDate()
         );

--- a/src/main/java/com/projectlyrics/server/domain/event/domain/Event.java
+++ b/src/main/java/com/projectlyrics/server/domain/event/domain/Event.java
@@ -25,23 +25,27 @@ public class Event extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String imageUrl;
+    private String popupImageUrl;
+    private String bannerImageUrl;
     private String redirectUrl;
     private LocalDateTime dueDate;
 
     private Event(
-            String imageUrl,
+            String popupImageUrl,
+            String bannerImageUrl,
             String redirectUrl,
             LocalDateTime dueDate
     ) {
-        this.imageUrl = imageUrl;
+        this.popupImageUrl = popupImageUrl;
+        this.bannerImageUrl = bannerImageUrl;
         this.redirectUrl = redirectUrl;
         this.dueDate = dueDate;
     }
 
     public static Event create(EventCreate eventCreate) {
         return new Event(
-                eventCreate.imageUrl(),
+                eventCreate.popupImageUrl(),
+                eventCreate.bannerImageUrl(),
                 eventCreate.redirectUrl(),
                 eventCreate.dueDate()
         );
@@ -50,7 +54,8 @@ public class Event extends BaseEntity {
     public static Event createWithId(Long id, EventCreate eventCreate) {
         return new Event(
                 id,
-                eventCreate.imageUrl(),
+                eventCreate.popupImageUrl(),
+                eventCreate.bannerImageUrl(),
                 eventCreate.redirectUrl(),
                 eventCreate.dueDate()
         );

--- a/src/main/java/com/projectlyrics/server/domain/event/domain/EventCreate.java
+++ b/src/main/java/com/projectlyrics/server/domain/event/domain/EventCreate.java
@@ -5,13 +5,15 @@ import com.projectlyrics.server.domain.event.dto.request.EventCreateRequest;
 import java.time.LocalDateTime;
 
 public record EventCreate(
-        String imageUrl,
+        String popupImageUrl,
+        String bannerImageUrl,
         String redirectUrl,
         LocalDateTime dueDate
 ) {
     public static EventCreate of(EventCreateRequest request) {
         return new EventCreate(
-                request.imageUrl(),
+                request.popupImageUrl(),
+                request.bannerImageUrl(),
                 request.redirectUrl(),
                 request.dueDate().atStartOfDay()
         );

--- a/src/main/java/com/projectlyrics/server/domain/event/domain/EventCreate.java
+++ b/src/main/java/com/projectlyrics/server/domain/event/domain/EventCreate.java
@@ -7,12 +7,14 @@ import java.time.LocalDateTime;
 public record EventCreate(
         String imageUrl,
         String redirectUrl,
+        String buttonText,
         LocalDateTime dueDate
 ) {
     public static EventCreate of(EventCreateRequest request) {
         return new EventCreate(
                 request.imageUrl(),
                 request.redirectUrl(),
+                request.buttonText(),
                 request.dueDate().atStartOfDay()
         );
     }

--- a/src/main/java/com/projectlyrics/server/domain/event/domain/EventCreate.java
+++ b/src/main/java/com/projectlyrics/server/domain/event/domain/EventCreate.java
@@ -5,15 +5,13 @@ import com.projectlyrics.server.domain.event.dto.request.EventCreateRequest;
 import java.time.LocalDateTime;
 
 public record EventCreate(
-        String popupImageUrl,
-        String bannerImageUrl,
+        String imageUrl,
         String redirectUrl,
         LocalDateTime dueDate
 ) {
     public static EventCreate of(EventCreateRequest request) {
         return new EventCreate(
-                request.popupImageUrl(),
-                request.bannerImageUrl(),
+                request.imageUrl(),
                 request.redirectUrl(),
                 request.dueDate().atStartOfDay()
         );

--- a/src/main/java/com/projectlyrics/server/domain/event/domain/EventRefusal.java
+++ b/src/main/java/com/projectlyrics/server/domain/event/domain/EventRefusal.java
@@ -2,11 +2,20 @@ package com.projectlyrics.server.domain.event.domain;
 
 import com.projectlyrics.server.domain.common.entity.BaseEntity;
 import com.projectlyrics.server.domain.user.entity.User;
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @Entity
@@ -28,37 +37,46 @@ public class EventRefusal extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private User user;
 
+    @Setter
+    private LocalDate deadline;
+
     private String deviceId;
 
     private EventRefusal(
             Event event,
-            User user
+            User user,
+            LocalDate deadline
     ) {
         this.refusal = true;
         this.event = event;
         this.user = user;
+        this.deadline = deadline;
     }
 
     private EventRefusal(
             Event event,
-            String deviceId
+            String deviceId,
+            LocalDate deadline
     ) {
         this.refusal = true;
         this.event = event;
         this.deviceId = deviceId;
+        this.deadline = deadline;
     }
 
     public static EventRefusal create(EventRefusalCreateByUser eventRefusalCreateByUser) {
         return new EventRefusal(
                 eventRefusalCreateByUser.event(),
-                eventRefusalCreateByUser.user()
+                eventRefusalCreateByUser.user(),
+                LocalDate.now().plusDays(eventRefusalCreateByUser.refusalPeriod())
         );
     }
 
     public static EventRefusal create(EventRefusalCreateByDevice eventRefusalCreateByDevice) {
         return new EventRefusal(
                 eventRefusalCreateByDevice.event(),
-                eventRefusalCreateByDevice.deviceId()
+                eventRefusalCreateByDevice.deviceId(),
+                LocalDate.now().plusDays(eventRefusalCreateByDevice.refusalPeriod())
         );
     }
 }

--- a/src/main/java/com/projectlyrics/server/domain/event/domain/EventRefusalCreateByDevice.java
+++ b/src/main/java/com/projectlyrics/server/domain/event/domain/EventRefusalCreateByDevice.java
@@ -2,6 +2,7 @@ package com.projectlyrics.server.domain.event.domain;
 
 public record EventRefusalCreateByDevice(
         Event event,
-        String deviceId
+        String deviceId,
+        int refusalPeriod
 ) {
 }

--- a/src/main/java/com/projectlyrics/server/domain/event/domain/EventRefusalCreateByUser.java
+++ b/src/main/java/com/projectlyrics/server/domain/event/domain/EventRefusalCreateByUser.java
@@ -4,6 +4,7 @@ import com.projectlyrics.server.domain.user.entity.User;
 
 public record EventRefusalCreateByUser(
         Event event,
-        User user
+        User user,
+        int refusalPeriod
 ) {
 }

--- a/src/main/java/com/projectlyrics/server/domain/event/dto/request/EventCreateRequest.java
+++ b/src/main/java/com/projectlyrics/server/domain/event/dto/request/EventCreateRequest.java
@@ -5,7 +5,8 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDate;
 
 public record EventCreateRequest(
-        String imageUrl,
+        String popupImageUrl,
+        String bannerImageUrl,
         String redirectUrl,
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
         LocalDate dueDate

--- a/src/main/java/com/projectlyrics/server/domain/event/dto/request/EventCreateRequest.java
+++ b/src/main/java/com/projectlyrics/server/domain/event/dto/request/EventCreateRequest.java
@@ -7,6 +7,7 @@ import java.time.LocalDate;
 public record EventCreateRequest(
         String imageUrl,
         String redirectUrl,
+        String buttonText,
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
         LocalDate dueDate
 ) {

--- a/src/main/java/com/projectlyrics/server/domain/event/dto/request/EventCreateRequest.java
+++ b/src/main/java/com/projectlyrics/server/domain/event/dto/request/EventCreateRequest.java
@@ -5,8 +5,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDate;
 
 public record EventCreateRequest(
-        String popupImageUrl,
-        String bannerImageUrl,
+        String imageUrl,
         String redirectUrl,
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
         LocalDate dueDate

--- a/src/main/java/com/projectlyrics/server/domain/event/dto/response/EventCursorBasePaginatedResponse.java
+++ b/src/main/java/com/projectlyrics/server/domain/event/dto/response/EventCursorBasePaginatedResponse.java
@@ -1,0 +1,10 @@
+package com.projectlyrics.server.domain.event.dto.response;
+
+import com.projectlyrics.server.domain.common.dto.util.CursorBasePaginatedResponse;
+
+public record EventCursorBasePaginatedResponse (
+        int refusalPeriod,
+        CursorBasePaginatedResponse<EventGetResponse> event
+
+) {
+}

--- a/src/main/java/com/projectlyrics/server/domain/event/dto/response/EventGetResponse.java
+++ b/src/main/java/com/projectlyrics/server/domain/event/dto/response/EventGetResponse.java
@@ -5,16 +5,14 @@ import com.projectlyrics.server.domain.event.domain.Event;
 
 public record EventGetResponse (
         Long id,
-        String popupImageUrl,
-        String bannerImageUrl,
+        String imageUrl,
         String redirectUrl
 ) implements CursorResponse {
 
     public static EventGetResponse of(Event event) {
         return new EventGetResponse(
                 event.getId(),
-                event.getPopupImageUrl(),
-                event.getBannerImageUrl(),
+                event.getImageUrl(),
                 event.getRedirectUrl()
         );
     }

--- a/src/main/java/com/projectlyrics/server/domain/event/dto/response/EventGetResponse.java
+++ b/src/main/java/com/projectlyrics/server/domain/event/dto/response/EventGetResponse.java
@@ -6,14 +6,16 @@ import com.projectlyrics.server.domain.event.domain.Event;
 public record EventGetResponse (
         Long id,
         String imageUrl,
-        String redirectUrl
+        String redirectUrl,
+        String buttonText
 ) implements CursorResponse {
 
     public static EventGetResponse of(Event event) {
         return new EventGetResponse(
                 event.getId(),
                 event.getImageUrl(),
-                event.getRedirectUrl()
+                event.getRedirectUrl(),
+                event.getButtonText()
         );
     }
 

--- a/src/main/java/com/projectlyrics/server/domain/event/dto/response/EventGetResponse.java
+++ b/src/main/java/com/projectlyrics/server/domain/event/dto/response/EventGetResponse.java
@@ -5,14 +5,16 @@ import com.projectlyrics.server.domain.event.domain.Event;
 
 public record EventGetResponse (
         Long id,
-        String imageUrl,
+        String popupImageUrl,
+        String bannerImageUrl,
         String redirectUrl
 ) implements CursorResponse {
 
     public static EventGetResponse of(Event event) {
         return new EventGetResponse(
                 event.getId(),
-                event.getImageUrl(),
+                event.getPopupImageUrl(),
+                event.getBannerImageUrl(),
                 event.getRedirectUrl()
         );
     }

--- a/src/main/java/com/projectlyrics/server/domain/event/repository/impl/QueryDslEventQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/event/repository/impl/QueryDslEventQueryRepository.java
@@ -57,7 +57,7 @@ public class QueryDslEventQueryRepository implements EventQueryRepository {
                         eventRefusal.event.eq(event)
                                 .and(filterCondition)
                                 .and(eventRefusal.deletedAt.isNull())
-                                .and(eventRefusal.updatedAt.goe(LocalDate.now().atStartOfDay()))
+                                .and(eventRefusal.deadline.after(LocalDate.now()))
                 )
                 .fetchJoin()
                 .where(

--- a/src/test/java/com/projectlyrics/server/domain/event/api/EventControllerTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/event/api/EventControllerTest.java
@@ -39,6 +39,7 @@ class EventControllerTest extends RestDocsTest {
         EventCreateRequest request = new EventCreateRequest(
                 "imageUrl",
                 "redirectUrl",
+                "button",
                 LocalDate.now()
         );
 
@@ -62,6 +63,8 @@ class EventControllerTest extends RestDocsTest {
                                         .description("이미지 URL"),
                                 fieldWithPath("redirectUrl").type(JsonFieldType.STRING)
                                         .description("리다이렉트 URL"),
+                                fieldWithPath("buttonText").type(JsonFieldType.STRING)
+                                        .description("버튼 문구"),
                                 fieldWithPath("dueDate").type(JsonFieldType.STRING)
                                         .description("이벤트 마감일")
                         )
@@ -152,6 +155,8 @@ class EventControllerTest extends RestDocsTest {
                                         .description("이벤트 Id"),
                                 fieldWithPath("data[].imageUrl").type(JsonFieldType.STRING)
                                         .description("이미지 url"),
+                                fieldWithPath("data[].buttonText").type(JsonFieldType.STRING)
+                                        .description("버튼 문구"),
                                 fieldWithPath("data[].redirectUrl").type(JsonFieldType.STRING)
                                         .description("리다이렉트 url")
                         )

--- a/src/test/java/com/projectlyrics/server/domain/event/api/EventControllerTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/event/api/EventControllerTest.java
@@ -139,30 +139,35 @@ class EventControllerTest extends RestDocsTest {
 
     private RestDocumentationResultHandler getAllExceptRefusedDocument() {
 
-        return restDocs.document(
+        RestDocumentationResultHandler document = restDocs.document(
                 resource(ResourceSnippetParameters.builder()
                         .tag("Event API")
                         .summary("진행 중인 모든 이벤트 리스트 조회 API (사용자가 거부한 이벤트 제외)")
                         .requestHeaders(getAuthorizationHeader())
                         .responseFields(
-                                fieldWithPath("nextCursor").type(JsonFieldType.NUMBER)
+                                fieldWithPath("refusalPeriod").type(JsonFieldType.NUMBER)
+                                        .description("거절 기간(1:하루동안 보지 않기/7:일주일간 보지 않기)"),
+                                fieldWithPath("event").type(JsonFieldType.OBJECT)
+                                        .description("이벤트 페이지네이션 관련 데아터"),
+                                fieldWithPath("event.nextCursor").type(JsonFieldType.NUMBER)
                                         .description("다음 cursor에 쓰일 값"),
-                                fieldWithPath("hasNext").type(JsonFieldType.BOOLEAN)
+                                fieldWithPath("event.hasNext").type(JsonFieldType.BOOLEAN)
                                         .description("다음 데이터 존재 여부"),
-                                fieldWithPath("data").type(JsonFieldType.ARRAY)
+                                fieldWithPath("event.data").type(JsonFieldType.ARRAY)
                                         .description("데이터"),
-                                fieldWithPath("data[].id").type(JsonFieldType.NUMBER)
+                                fieldWithPath("event.data[].id").type(JsonFieldType.NUMBER)
                                         .description("이벤트 Id"),
-                                fieldWithPath("data[].imageUrl").type(JsonFieldType.STRING)
+                                fieldWithPath("event.data[].imageUrl").type(JsonFieldType.STRING)
                                         .description("이미지 url"),
-                                fieldWithPath("data[].buttonText").type(JsonFieldType.STRING)
+                                fieldWithPath("event.data[].buttonText").type(JsonFieldType.STRING)
                                         .description("버튼 문구"),
-                                fieldWithPath("data[].redirectUrl").type(JsonFieldType.STRING)
+                                fieldWithPath("event.data[].redirectUrl").type(JsonFieldType.STRING)
                                         .description("리다이렉트 url")
                         )
                         .responseSchema(Schema.schema("Event List Response"))
                         .build()
                 )
         );
+        return document;
     }
 }

--- a/src/test/java/com/projectlyrics/server/domain/event/api/EventControllerTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/event/api/EventControllerTest.java
@@ -37,8 +37,7 @@ class EventControllerTest extends RestDocsTest {
     void 이벤트를_저장하면_200응답을_해야_한다() throws Exception {
         // given
         EventCreateRequest request = new EventCreateRequest(
-                "popupImageUrl",
-                "bannerImageUrl",
+                "imageUrl",
                 "redirectUrl",
                 LocalDate.now()
         );
@@ -59,10 +58,8 @@ class EventControllerTest extends RestDocsTest {
                         .summary("이벤트 등록 API")
                         .requestHeaders(getAuthorizationHeader())
                         .requestFields(
-                                fieldWithPath("popupImageUrl").type(JsonFieldType.STRING)
-                                        .description("팝업 이미지 url"),
-                                fieldWithPath("bannerImageUrl").type(JsonFieldType.STRING)
-                                        .description("배너 이미지 url"),
+                                fieldWithPath("imageUrl").type(JsonFieldType.STRING)
+                                        .description("이미지 URL"),
                                 fieldWithPath("redirectUrl").type(JsonFieldType.STRING)
                                         .description("리다이렉트 URL"),
                                 fieldWithPath("dueDate").type(JsonFieldType.STRING)
@@ -153,10 +150,8 @@ class EventControllerTest extends RestDocsTest {
                                         .description("데이터"),
                                 fieldWithPath("data[].id").type(JsonFieldType.NUMBER)
                                         .description("이벤트 Id"),
-                                fieldWithPath("data[].popupImageUrl").type(JsonFieldType.STRING)
-                                        .description("팝업 이미지 url"),
-                                fieldWithPath("data[].bannerImageUrl").type(JsonFieldType.STRING)
-                                        .description("배너 이미지 url"),
+                                fieldWithPath("data[].imageUrl").type(JsonFieldType.STRING)
+                                        .description("이미지 url"),
                                 fieldWithPath("data[].redirectUrl").type(JsonFieldType.STRING)
                                         .description("리다이렉트 url")
                         )

--- a/src/test/java/com/projectlyrics/server/domain/event/api/EventControllerTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/event/api/EventControllerTest.java
@@ -37,7 +37,8 @@ class EventControllerTest extends RestDocsTest {
     void 이벤트를_저장하면_200응답을_해야_한다() throws Exception {
         // given
         EventCreateRequest request = new EventCreateRequest(
-                "imageUrl",
+                "popupImageUrl",
+                "bannerImageUrl",
                 "redirectUrl",
                 LocalDate.now()
         );
@@ -58,8 +59,10 @@ class EventControllerTest extends RestDocsTest {
                         .summary("이벤트 등록 API")
                         .requestHeaders(getAuthorizationHeader())
                         .requestFields(
-                                fieldWithPath("imageUrl").type(JsonFieldType.STRING)
-                                        .description("이미지 URL"),
+                                fieldWithPath("popupImageUrl").type(JsonFieldType.STRING)
+                                        .description("팝업 이미지 url"),
+                                fieldWithPath("bannerImageUrl").type(JsonFieldType.STRING)
+                                        .description("배너 이미지 url"),
                                 fieldWithPath("redirectUrl").type(JsonFieldType.STRING)
                                         .description("리다이렉트 URL"),
                                 fieldWithPath("dueDate").type(JsonFieldType.STRING)
@@ -150,8 +153,10 @@ class EventControllerTest extends RestDocsTest {
                                         .description("데이터"),
                                 fieldWithPath("data[].id").type(JsonFieldType.NUMBER)
                                         .description("이벤트 Id"),
-                                fieldWithPath("data[].imageUrl").type(JsonFieldType.STRING)
-                                        .description("이미지 url"),
+                                fieldWithPath("data[].popupImageUrl").type(JsonFieldType.STRING)
+                                        .description("팝업 이미지 url"),
+                                fieldWithPath("data[].bannerImageUrl").type(JsonFieldType.STRING)
+                                        .description("배너 이미지 url"),
                                 fieldWithPath("data[].redirectUrl").type(JsonFieldType.STRING)
                                         .description("리다이렉트 url")
                         )

--- a/src/test/java/com/projectlyrics/server/domain/event/service/EventCommandServiceTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/event/service/EventCommandServiceTest.java
@@ -33,7 +33,7 @@ class EventCommandServiceTest extends IntegrationTest {
     @Test
     void 이벤트를_발행해야_한다() {
         // given
-        EventCreateRequest request = new EventCreateRequest("imageUrl", "redirectUrl", LocalDate.now());
+        EventCreateRequest request = new EventCreateRequest("popupImageUrl", "bannerImageUrl", "redirectUrl", LocalDate.now());
 
         // when
         Event event = sut.create(request);
@@ -41,7 +41,8 @@ class EventCommandServiceTest extends IntegrationTest {
         // then
         Event result = eventQueryRepository.findById(event.getId());
         assertAll(
-                () -> assertThat(result.getImageUrl()).isEqualTo(request.imageUrl()),
+                () -> assertThat(result.getPopupImageUrl()).isEqualTo(request.popupImageUrl()),
+                () -> assertThat(result.getBannerImageUrl()).isEqualTo(request.bannerImageUrl()),
                 () -> assertThat(result.getRedirectUrl()).isEqualTo(request.redirectUrl()),
                 () -> assertThat(result.getDueDate()).isEqualTo(request.dueDate().atStartOfDay())
         );
@@ -52,7 +53,7 @@ class EventCommandServiceTest extends IntegrationTest {
         // given
         User user = userCommandRepository.save(UserFixture.create());
 
-        EventCreateRequest request = new EventCreateRequest("imageUrl", "redirectUrl", LocalDate.now());
+        EventCreateRequest request = new EventCreateRequest("popupImageUrl", "bannerImageUrl", "redirectUrl", LocalDate.now());
         Event event = sut.create(request);
 
         // when
@@ -72,7 +73,7 @@ class EventCommandServiceTest extends IntegrationTest {
         // given
         String deviceId = "DEVICE_ID";
 
-        EventCreateRequest request = new EventCreateRequest("imageUrl", "redirectUrl", LocalDate.now());
+        EventCreateRequest request = new EventCreateRequest("popupImageUrl", "bannerImageUrl", "redirectUrl", LocalDate.now());
         Event event = sut.create(request);
 
         // when
@@ -92,7 +93,7 @@ class EventCommandServiceTest extends IntegrationTest {
         // given
         User user = userCommandRepository.save(UserFixture.create());
 
-        EventCreateRequest request = new EventCreateRequest("imageUrl", "redirectUrl", LocalDate.now());
+        EventCreateRequest request = new EventCreateRequest("popupImageUrl", "bannerImageUrl", "redirectUrl", LocalDate.now());
         Event event = sut.create(request);
 
         // when
@@ -118,7 +119,7 @@ class EventCommandServiceTest extends IntegrationTest {
         // given
         String deviceId = "DEVICE_ID";
 
-        EventCreateRequest request = new EventCreateRequest("imageUrl", "redirectUrl", LocalDate.now());
+        EventCreateRequest request = new EventCreateRequest("popupImageUrl", "bannerImageUrl", "redirectUrl", LocalDate.now());
         Event event = sut.create(request);
 
         // when

--- a/src/test/java/com/projectlyrics/server/domain/event/service/EventCommandServiceTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/event/service/EventCommandServiceTest.java
@@ -33,7 +33,7 @@ class EventCommandServiceTest extends IntegrationTest {
     @Test
     void 이벤트를_발행해야_한다() {
         // given
-        EventCreateRequest request = new EventCreateRequest("popupImageUrl", "bannerImageUrl", "redirectUrl", LocalDate.now());
+        EventCreateRequest request = new EventCreateRequest("imageUrl", "redirectUrl", LocalDate.now());
 
         // when
         Event event = sut.create(request);
@@ -41,8 +41,7 @@ class EventCommandServiceTest extends IntegrationTest {
         // then
         Event result = eventQueryRepository.findById(event.getId());
         assertAll(
-                () -> assertThat(result.getPopupImageUrl()).isEqualTo(request.popupImageUrl()),
-                () -> assertThat(result.getBannerImageUrl()).isEqualTo(request.bannerImageUrl()),
+                () -> assertThat(result.getImageUrl()).isEqualTo(request.imageUrl()),
                 () -> assertThat(result.getRedirectUrl()).isEqualTo(request.redirectUrl()),
                 () -> assertThat(result.getDueDate()).isEqualTo(request.dueDate().atStartOfDay())
         );
@@ -53,7 +52,7 @@ class EventCommandServiceTest extends IntegrationTest {
         // given
         User user = userCommandRepository.save(UserFixture.create());
 
-        EventCreateRequest request = new EventCreateRequest("popupImageUrl", "bannerImageUrl", "redirectUrl", LocalDate.now());
+        EventCreateRequest request = new EventCreateRequest("imageUrl", "redirectUrl", LocalDate.now());
         Event event = sut.create(request);
 
         // when
@@ -73,7 +72,7 @@ class EventCommandServiceTest extends IntegrationTest {
         // given
         String deviceId = "DEVICE_ID";
 
-        EventCreateRequest request = new EventCreateRequest("popupImageUrl", "bannerImageUrl", "redirectUrl", LocalDate.now());
+        EventCreateRequest request = new EventCreateRequest("imageUrl", "redirectUrl", LocalDate.now());
         Event event = sut.create(request);
 
         // when
@@ -93,7 +92,7 @@ class EventCommandServiceTest extends IntegrationTest {
         // given
         User user = userCommandRepository.save(UserFixture.create());
 
-        EventCreateRequest request = new EventCreateRequest("popupImageUrl", "bannerImageUrl", "redirectUrl", LocalDate.now());
+        EventCreateRequest request = new EventCreateRequest("imageUrl", "redirectUrl", LocalDate.now());
         Event event = sut.create(request);
 
         // when
@@ -119,7 +118,7 @@ class EventCommandServiceTest extends IntegrationTest {
         // given
         String deviceId = "DEVICE_ID";
 
-        EventCreateRequest request = new EventCreateRequest("popupImageUrl", "bannerImageUrl", "redirectUrl", LocalDate.now());
+        EventCreateRequest request = new EventCreateRequest("imageUrl", "redirectUrl", LocalDate.now());
         Event event = sut.create(request);
 
         // when

--- a/src/test/java/com/projectlyrics/server/domain/event/service/EventCommandServiceTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/event/service/EventCommandServiceTest.java
@@ -56,7 +56,7 @@ class EventCommandServiceTest extends IntegrationTest {
         Event event = sut.create(request);
 
         // when
-        sut.refuseByUser(event.getId(), user.getId());
+        sut.refuseByUser(event.getId(), user.getId(), 1);
 
         // then
         EventRefusal result = eventRefusalQueryRepository.findByEventIdAndUserId(event.getId(), user.getId());
@@ -76,7 +76,7 @@ class EventCommandServiceTest extends IntegrationTest {
         Event event = sut.create(request);
 
         // when
-        sut.refuseByDeviceId(event.getId(), deviceId);
+        sut.refuseByDeviceId(event.getId(), deviceId, 1);
 
         // then
         EventRefusal result = eventRefusalQueryRepository.findByEventIdAndDeviceId(event.getId(), deviceId);
@@ -88,7 +88,7 @@ class EventCommandServiceTest extends IntegrationTest {
     }
 
     @Test
-    void 동일_유저와_이벤트의_거부_기록이_있으면_updatedAt만_갱신한다() {
+    void 동일_유저와_이벤트의_거부_기록이_있으면_deadline만_갱신한다() {
         // given
         User user = userCommandRepository.save(UserFixture.create());
 
@@ -96,25 +96,20 @@ class EventCommandServiceTest extends IntegrationTest {
         Event event = sut.create(request);
 
         // when
-        EventRefusal eventRefusalBefore = sut.refuseByUser(event.getId(), user.getId());
-        try {
-            Thread.sleep(2000);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt(); // 2초 대기
-        }
-        EventRefusal eventRefusalAfter = sut.refuseByUser(event.getId(), user.getId());
+        EventRefusal eventRefusalBefore = sut.refuseByUser(event.getId(), user.getId(),1);
+        EventRefusal eventRefusalAfter = sut.refuseByUser(event.getId(), user.getId(), 2);
 
         // then
         assertAll(
                 () -> assertThat(eventRefusalBefore.getId()).isEqualTo(eventRefusalAfter.getId()),
                 () -> assertThat(eventRefusalBefore.getEvent().getId()).isEqualTo(eventRefusalAfter.getEvent().getId()),
                 () -> assertThat(eventRefusalBefore.getUser().getId()).isEqualTo(eventRefusalAfter.getUser().getId()),
-                () -> assertThat(eventRefusalBefore.getUpdatedAt().plusSeconds(1).isBefore(eventRefusalAfter.getUpdatedAt()))
+                () -> assertThat(eventRefusalBefore.getDeadline().isEqual(eventRefusalAfter.getDeadline()))
         );
     }
 
     @Test
-    void 동일_디바이스id와_이벤트의_거부_기록이_있으면_updatedAt만_갱신한다() {
+    void 동일_디바이스id와_이벤트의_거부_기록이_있으면_deadline만_갱신한다() {
         // given
         String deviceId = "DEVICE_ID";
 
@@ -122,20 +117,15 @@ class EventCommandServiceTest extends IntegrationTest {
         Event event = sut.create(request);
 
         // when
-        EventRefusal eventRefusalBefore = sut.refuseByDeviceId(event.getId(), deviceId);
-        try {
-            Thread.sleep(2000);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt(); // 2초 대기
-        }
-        EventRefusal eventRefusalAfter = sut.refuseByDeviceId(event.getId(), deviceId);
+        EventRefusal eventRefusalBefore = sut.refuseByDeviceId(event.getId(), deviceId,1);
+        EventRefusal eventRefusalAfter = sut.refuseByDeviceId(event.getId(), deviceId,2);
 
         // then
         assertAll(
                 () -> assertThat(eventRefusalBefore.getId()).isEqualTo(eventRefusalAfter.getId()),
                 () -> assertThat(eventRefusalBefore.getEvent().getId()).isEqualTo(eventRefusalAfter.getEvent().getId()),
                 () -> assertThat(eventRefusalBefore.getDeviceId()).isEqualTo(eventRefusalAfter.getDeviceId()),
-                () -> assertThat(eventRefusalBefore.getUpdatedAt().plusSeconds(1).isBefore(eventRefusalAfter.getUpdatedAt()))
+                () -> assertThat(eventRefusalBefore.getDeadline().isEqual(eventRefusalAfter.getDeadline()))
         );
     }
 }

--- a/src/test/java/com/projectlyrics/server/domain/event/service/EventCommandServiceTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/event/service/EventCommandServiceTest.java
@@ -33,7 +33,7 @@ class EventCommandServiceTest extends IntegrationTest {
     @Test
     void 이벤트를_발행해야_한다() {
         // given
-        EventCreateRequest request = new EventCreateRequest("imageUrl", "redirectUrl", LocalDate.now());
+        EventCreateRequest request = new EventCreateRequest("imageUrl", "redirectUrl", "button", LocalDate.now());
 
         // when
         Event event = sut.create(request);
@@ -52,7 +52,7 @@ class EventCommandServiceTest extends IntegrationTest {
         // given
         User user = userCommandRepository.save(UserFixture.create());
 
-        EventCreateRequest request = new EventCreateRequest("imageUrl", "redirectUrl", LocalDate.now());
+        EventCreateRequest request = new EventCreateRequest("imageUrl", "redirectUrl", "button", LocalDate.now());
         Event event = sut.create(request);
 
         // when
@@ -72,7 +72,7 @@ class EventCommandServiceTest extends IntegrationTest {
         // given
         String deviceId = "DEVICE_ID";
 
-        EventCreateRequest request = new EventCreateRequest("imageUrl", "redirectUrl", LocalDate.now());
+        EventCreateRequest request = new EventCreateRequest("imageUrl", "redirectUrl", "button", LocalDate.now());
         Event event = sut.create(request);
 
         // when
@@ -92,7 +92,7 @@ class EventCommandServiceTest extends IntegrationTest {
         // given
         User user = userCommandRepository.save(UserFixture.create());
 
-        EventCreateRequest request = new EventCreateRequest("imageUrl", "redirectUrl", LocalDate.now());
+        EventCreateRequest request = new EventCreateRequest("imageUrl", "redirectUrl", "button", LocalDate.now());
         Event event = sut.create(request);
 
         // when
@@ -118,7 +118,7 @@ class EventCommandServiceTest extends IntegrationTest {
         // given
         String deviceId = "DEVICE_ID";
 
-        EventCreateRequest request = new EventCreateRequest("imageUrl", "redirectUrl", LocalDate.now());
+        EventCreateRequest request = new EventCreateRequest("imageUrl", "redirectUrl", "buttton", LocalDate.now());
         Event event = sut.create(request);
 
         // when

--- a/src/test/java/com/projectlyrics/server/domain/event/service/EventQueryServiceTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/event/service/EventQueryServiceTest.java
@@ -61,11 +61,13 @@ public class EventQueryServiceTest extends IntegrationTest {
         activeEventCreateRequest = new EventCreateRequest(
                 "imageUrl",
                 "redirectUrl",
+                "button",
                 LocalDate.now().plusDays(1)
         );
         expiredEventCreateRequest = new EventCreateRequest(
                 "imageUrl",
                 "redirectUrl",
+                "button",
                 LocalDate.now().minusDays(1)
         );
     }

--- a/src/test/java/com/projectlyrics/server/domain/event/service/EventQueryServiceTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/event/service/EventQueryServiceTest.java
@@ -59,14 +59,12 @@ public class EventQueryServiceTest extends IntegrationTest {
     void setUp() {
         user = userCommandRepository.save(UserFixture.create());
         activeEventCreateRequest = new EventCreateRequest(
-                "popupImageUrl",
-                "bannerImageUrl",
+                "imageUrl",
                 "redirectUrl",
                 LocalDate.now().plusDays(1)
         );
         expiredEventCreateRequest = new EventCreateRequest(
-                "popupImageUrl",
-                "bannerImageUrl",
+                "imageUrl",
                 "redirectUrl",
                 LocalDate.now().minusDays(1)
         );

--- a/src/test/java/com/projectlyrics/server/domain/event/service/EventQueryServiceTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/event/service/EventQueryServiceTest.java
@@ -19,18 +19,13 @@ import com.projectlyrics.server.domain.user.entity.User;
 import com.projectlyrics.server.domain.user.repository.UserCommandRepository;
 import com.projectlyrics.server.support.IntegrationTest;
 import com.projectlyrics.server.support.fixture.UserFixture;
-import jakarta.persistence.EntityManager;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
 public class EventQueryServiceTest extends IntegrationTest {
-
-    @Autowired
-    private EntityManager entityManager;
 
     @Autowired
     UserCommandRepository userCommandRepository;
@@ -118,55 +113,9 @@ public class EventQueryServiceTest extends IntegrationTest {
         );
     }
 
-    @Test
-    void 진행_중인_모든_이벤트_조회시_해당_사용자_id로_이벤트를_거부한_내역이_있으면_제외해야_한다() {
-        // given
-        Event activeEvent1 = eventCommandRepository.save(Event.create(EventCreate.of(activeEventCreateRequest)));
-        Event activeEvent2 = eventCommandRepository.save(Event.create(EventCreate.of(activeEventCreateRequest)));
-        eventCommandRepository.save(Event.create(EventCreate.of(expiredEventCreateRequest)));
-        Event activeEvent3 = eventCommandRepository.save(Event.create(EventCreate.of(activeEventCreateRequest)));
-        Event activeEvent4 = eventCommandRepository.save(Event.create(EventCreate.of(activeEventCreateRequest)));
-        eventCommandRepository.save(Event.create(EventCreate.of(expiredEventCreateRequest)));
-        eventRefusalCommandRepository.save(EventRefusal.create(new EventRefusalCreateByUser(activeEvent1, user)));
-        eventRefusalCommandRepository.save(EventRefusal.create(new EventRefusalCreateByUser(activeEvent3, user)));
-
-        // when
-        CursorBasePaginatedResponse<EventGetResponse> result = sut.getAllExceptRefusedByUser(user.getId(), null, 6);
-
-        // then
-        assertAll(
-                () -> assertThat(result.data().size()).isEqualTo(2),
-                () -> assertThat(result.data().get(0).id()).isEqualTo(activeEvent4.getId()),
-                () -> assertThat(result.data().get(1).id()).isEqualTo(activeEvent2.getId())
-        );
-    }
-
-    @Test
-    void 진행_중인_모든_이벤트_조회시_해당_디바이스_id로_이벤트를_거부한_내역이_있으면_제외해야_한다() {
-        // given
-        Event activeEvent1 = eventCommandRepository.save(Event.create(EventCreate.of(activeEventCreateRequest)));
-        Event activeEvent2 = eventCommandRepository.save(Event.create(EventCreate.of(activeEventCreateRequest)));
-        eventCommandRepository.save(Event.create(EventCreate.of(expiredEventCreateRequest)));
-        Event activeEvent3 = eventCommandRepository.save(Event.create(EventCreate.of(activeEventCreateRequest)));
-        Event activeEvent4 = eventCommandRepository.save(Event.create(EventCreate.of(activeEventCreateRequest)));
-        eventCommandRepository.save(Event.create(EventCreate.of(expiredEventCreateRequest)));
-        eventRefusalCommandRepository.save(EventRefusal.create(new EventRefusalCreateByDevice(activeEvent1, deviceId)));
-        eventRefusalCommandRepository.save(EventRefusal.create(new EventRefusalCreateByDevice(activeEvent3, deviceId)));
-
-        // when
-        CursorBasePaginatedResponse<EventGetResponse> result = sut.getAllExceptRefusedByDeviceId(deviceId, null, 6);
-
-        // then
-        assertAll(
-                () -> assertThat(result.data().size()).isEqualTo(2),
-                () -> assertThat(result.data().get(0).id()).isEqualTo(activeEvent4.getId()),
-                () -> assertThat(result.data().get(1).id()).isEqualTo(activeEvent2.getId())
-        );
-    }
-
     @Transactional
     @Test
-    void 사용자id로_진행_중인_이벤트_조회시_오늘_거부한_이벤트는_제외되고_나머지는_조회되어야_한다() throws Exception{
+    void 사용자id로_진행_중인_이벤트_조회시_해당_다바이스id의_거부_만료_기간이_남아있다면_해당_이벤트가_제외되어야_한다() throws Exception{
         // given
         Event activeEvent1 = eventCommandRepository.save(Event.create(EventCreate.of(activeEventCreateRequest)));
         Event activeEvent2 = eventCommandRepository.save(Event.create(EventCreate.of(activeEventCreateRequest)));
@@ -174,17 +123,8 @@ public class EventQueryServiceTest extends IntegrationTest {
         Event activeEvent3 = eventCommandRepository.save(Event.create(EventCreate.of(activeEventCreateRequest)));
         Event activeEvent4 = eventCommandRepository.save(Event.create(EventCreate.of(activeEventCreateRequest)));
         eventCommandRepository.save(Event.create(EventCreate.of(expiredEventCreateRequest)));
-        EventRefusal refusal = eventRefusalCommandRepository.save(
-                EventRefusal.create(new EventRefusalCreateByUser(activeEvent1, user)));
-        eventRefusalCommandRepository.save(EventRefusal.create(new EventRefusalCreateByUser(activeEvent3, user)));
-
-        entityManager.createQuery("UPDATE EventRefusal er SET er.updatedAt = :updatedAt WHERE er.id = :id")
-                .setParameter("updatedAt", LocalDateTime.now().minusDays(1))  // 하루 전으로 설정
-                .setParameter("id", refusal.getId())
-                .executeUpdate();
-
-        entityManager.flush();  // 변경 사항을 DB에 반영
-        entityManager.clear();
+        eventRefusalCommandRepository.save(EventRefusal.create(new EventRefusalCreateByUser(activeEvent1, user, 0)));
+        eventRefusalCommandRepository.save(EventRefusal.create(new EventRefusalCreateByUser(activeEvent3, user, 1)));
 
         // when
         CursorBasePaginatedResponse<EventGetResponse> result = sut.getAllExceptRefusedByUser(user.getId(), null, 6);
@@ -200,7 +140,7 @@ public class EventQueryServiceTest extends IntegrationTest {
 
     @Transactional
     @Test
-    void 디바이스id로_진행_중인_이벤트_조회시_오늘_거부한_이벤트는_제외되고_나머지는_조회되어야_한다() throws Exception{
+    void 디바이스id로_진행_중인_이벤트_조회시_해당_다바이스id의_거부_만료_기간이_남아있다면_해당_이벤트가_제외되어야_한다() {
         // given
         Event activeEvent1 = eventCommandRepository.save(Event.create(EventCreate.of(activeEventCreateRequest)));
         Event activeEvent2 = eventCommandRepository.save(Event.create(EventCreate.of(activeEventCreateRequest)));
@@ -208,17 +148,8 @@ public class EventQueryServiceTest extends IntegrationTest {
         Event activeEvent3 = eventCommandRepository.save(Event.create(EventCreate.of(activeEventCreateRequest)));
         Event activeEvent4 = eventCommandRepository.save(Event.create(EventCreate.of(activeEventCreateRequest)));
         eventCommandRepository.save(Event.create(EventCreate.of(expiredEventCreateRequest)));
-        EventRefusal refusal = eventRefusalCommandRepository.save(
-                EventRefusal.create(new EventRefusalCreateByDevice(activeEvent1, deviceId)));
-        eventRefusalCommandRepository.save(EventRefusal.create(new EventRefusalCreateByDevice(activeEvent3, deviceId)));
-
-        entityManager.createQuery("UPDATE EventRefusal er SET er.updatedAt = :updatedAt WHERE er.id = :id")
-                .setParameter("updatedAt", LocalDateTime.now().minusDays(1))  // 하루 전으로 설정
-                .setParameter("id", refusal.getId())
-                .executeUpdate();
-
-        entityManager.flush();  // 변경 사항을 DB에 반영
-        entityManager.clear();
+        eventRefusalCommandRepository.save(EventRefusal.create(new EventRefusalCreateByDevice(activeEvent1, deviceId, 0)));
+        eventRefusalCommandRepository.save(EventRefusal.create(new EventRefusalCreateByDevice(activeEvent3, deviceId, 1)));
 
         // when
         CursorBasePaginatedResponse<EventGetResponse> result = sut.getAllExceptRefusedByDeviceId(deviceId, null, 6);

--- a/src/test/java/com/projectlyrics/server/domain/event/service/EventQueryServiceTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/event/service/EventQueryServiceTest.java
@@ -59,12 +59,14 @@ public class EventQueryServiceTest extends IntegrationTest {
     void setUp() {
         user = userCommandRepository.save(UserFixture.create());
         activeEventCreateRequest = new EventCreateRequest(
-                "imageUrl",
+                "popupImageUrl",
+                "bannerImageUrl",
                 "redirectUrl",
                 LocalDate.now().plusDays(1)
         );
         expiredEventCreateRequest = new EventCreateRequest(
-                "imageUrl",
+                "popupImageUrl",
+                "bannerImageUrl",
                 "redirectUrl",
                 LocalDate.now().minusDays(1)
         );

--- a/src/test/java/com/projectlyrics/server/support/fixture/EventFixture.java
+++ b/src/test/java/com/projectlyrics/server/support/fixture/EventFixture.java
@@ -16,8 +16,7 @@ public class EventFixture extends BaseFixture{
         return Event.createWithId(
                 getUniqueId(),
                 new EventCreate(
-                        "popupImageUrl",
-                        "bannerImageUrl",
+                      "imageUrl",
                         "redirectUrl",
                         LocalDate.now().atTime(23, 59, 59)
                 )

--- a/src/test/java/com/projectlyrics/server/support/fixture/EventFixture.java
+++ b/src/test/java/com/projectlyrics/server/support/fixture/EventFixture.java
@@ -18,6 +18,7 @@ public class EventFixture extends BaseFixture{
                 new EventCreate(
                       "imageUrl",
                         "redirectUrl",
+                        "button",
                         LocalDate.now().atTime(23, 59, 59)
                 )
         );

--- a/src/test/java/com/projectlyrics/server/support/fixture/EventFixture.java
+++ b/src/test/java/com/projectlyrics/server/support/fixture/EventFixture.java
@@ -16,7 +16,8 @@ public class EventFixture extends BaseFixture{
         return Event.createWithId(
                 getUniqueId(),
                 new EventCreate(
-                      "imageUrl",
+                        "popupImageUrl",
+                        "bannerImageUrl",
                         "redirectUrl",
                         LocalDate.now().atTime(23, 59, 59)
                 )


### PR DESCRIPTION
# 🍃 **Pull Requests**

## ⛳️ **작업한 브랜치**
- Resolved: [SCRUM-198]

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- event 목록 조회시 토큰 없이 접근 가능하도록 수정
- event 엔티티에 버튼 문구 포함하도록 수정
- eventRefusal의 기한을 yml을 통해서 유동적으로 변경할 수 있도록 수정 (eventRefusal 내에 deadline 필드 추가)
- event 목록 조회시, 하루동안 보지 않기/일주일 동안 보지 않기 버튼 변경할 수 있도록 응답에 refusalPeriod 포함

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- application.yml이 업데이트되었습니다. (yml 값을 기반으로 eventRefusal 기간을 따지게 됩니다.)
- 기존 CursorBasePaginatedResponse에서 eventRefusal을 포함하는 새로운 레코드 EventCursorBasePaginatedResponse를 만들었습니다. 이벤트 조회시 응답이 조금 더 복잡한 형태로 나오고 있는데 혹시 해당 구조 관련해서 더 좋은 아이디어가 있다면 알려주세요~
```
{
  "refusalPeriod": 7,
  "event": {
    "nextCursor": 11,
    "hasNext": true,
    "data": [
      {
        "id": 2,
        "imageUrl": "https://example.com/image2.jpg",
        "redirectUrl": "https://example.com/event/2",
        "buttonText": "참여하기"
      },
      {
        "id": 3,
        "imageUrl": "https://example.com/image3.jpg",
        "redirectUrl": "https://example.com/event/3",
        "buttonText": "신청하기"
      },
      {
        "id": 4,
        "imageUrl": "https://example.com/image4.jpg",
        "redirectUrl": "https://example.com/event/4",
        "buttonText": "이벤트 보기"
      }
    ]
  }
}
```


[SCRUM-198]: https://projectlyrics.atlassian.net/browse/SCRUM-198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ