### PR TITLE
배너 기능 개발

### DIFF
--- a/src/main/java/com/projectlyrics/server/domain/auth/authentication/interceptor/AuthInterceptor.java
+++ b/src/main/java/com/projectlyrics/server/domain/auth/authentication/interceptor/AuthInterceptor.java
@@ -42,7 +42,9 @@ public class AuthInterceptor implements HandlerInterceptor {
                 requestURI.equals("/api/v1/notes/artists") ||
                 requestURI.equals("/api/v1/notes/songs") ||
                 requestURI.matches("/api/v1/songs/.*") ||
-                (requestURI.matches("/api/v1/events") && requestMethod.equalsIgnoreCase(HttpMethod.GET.name())) );
+                (requestURI.matches("/api/v1/events") && requestMethod.equalsIgnoreCase(HttpMethod.GET.name()))||
+                requestURI.matches("/api/v1/events/refuse") ||
+                (requestURI.matches("/api/v1/banners") && requestMethod.equalsIgnoreCase(HttpMethod.GET.name())));
     }
 
     private void setAuthContext(HttpServletRequest request) {

--- a/src/main/java/com/projectlyrics/server/domain/banner/api/BannerController.java
+++ b/src/main/java/com/projectlyrics/server/domain/banner/api/BannerController.java
@@ -2,19 +2,27 @@ package com.projectlyrics.server.domain.banner.api;
 
 import com.projectlyrics.server.domain.banner.dto.request.BannerCreateRequest;
 import com.projectlyrics.server.domain.banner.dto.response.BannerCreateResponse;
+import com.projectlyrics.server.domain.banner.dto.response.BannerGetResponse;
 import com.projectlyrics.server.domain.banner.service.BannerCommandService;
+import com.projectlyrics.server.domain.banner.service.BannerQueryService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/banners")
 @RequiredArgsConstructor
 public class BannerController {
+
     private final BannerCommandService bannerCommandService;
+    private final BannerQueryService bannerQueryService;
 
     @PostMapping
     public ResponseEntity<BannerCreateResponse> create(
@@ -24,5 +32,14 @@ public class BannerController {
 
         return ResponseEntity
                 .ok(new BannerCreateResponse(true));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<BannerGetResponse>> getAll(
+            @RequestParam(name = "size", defaultValue = "10") int size
+    ) {
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(bannerQueryService.getRecentBanners(size));
     }
 }

--- a/src/main/java/com/projectlyrics/server/domain/banner/api/BannerController.java
+++ b/src/main/java/com/projectlyrics/server/domain/banner/api/BannerController.java
@@ -1,0 +1,28 @@
+package com.projectlyrics.server.domain.banner.api;
+
+import com.projectlyrics.server.domain.banner.dto.request.BannerCreateRequest;
+import com.projectlyrics.server.domain.banner.dto.response.BannerCreateResponse;
+import com.projectlyrics.server.domain.banner.service.BannerCommandService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/banners")
+@RequiredArgsConstructor
+public class BannerController {
+    private final BannerCommandService bannerCommandService;
+
+    @PostMapping
+    public ResponseEntity<BannerCreateResponse> create(
+            @RequestBody BannerCreateRequest request
+    ) {
+        bannerCommandService.create(request);
+
+        return ResponseEntity
+                .ok(new BannerCreateResponse(true));
+    }
+}

--- a/src/main/java/com/projectlyrics/server/domain/banner/domain/Banner.java
+++ b/src/main/java/com/projectlyrics/server/domain/banner/domain/Banner.java
@@ -1,0 +1,57 @@
+package com.projectlyrics.server.domain.banner.domain;
+
+import com.projectlyrics.server.domain.common.entity.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "banners")
+@EqualsAndHashCode(of = "id", callSuper = false)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Banner extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String imageUrl;
+    private String redirectUrl;
+    private LocalDateTime dueDate;
+
+    private Banner(
+            String imageUrl,
+            String redirectUrl,
+            LocalDateTime dueDate
+    ) {
+        this.imageUrl = imageUrl;
+        this.redirectUrl = redirectUrl;
+        this.dueDate = dueDate;
+    }
+
+    public static Banner create(BannerCreate bannerCreate) {
+        return new Banner(
+                bannerCreate.imageUrl(),
+                bannerCreate.redirectUrl(),
+                bannerCreate.dueDate()
+        );
+    }
+
+    public static Banner createWithId(Long id, BannerCreate bannerCreate) {
+        return new Banner(
+                id,
+                bannerCreate.imageUrl(),
+                bannerCreate.redirectUrl(),
+                bannerCreate.dueDate()
+        );
+    }
+}

--- a/src/main/java/com/projectlyrics/server/domain/banner/domain/BannerCreate.java
+++ b/src/main/java/com/projectlyrics/server/domain/banner/domain/BannerCreate.java
@@ -1,0 +1,18 @@
+package com.projectlyrics.server.domain.banner.domain;
+
+import com.projectlyrics.server.domain.banner.dto.request.BannerCreateRequest;
+import java.time.LocalDateTime;
+
+public record BannerCreate(
+        String imageUrl,
+        String redirectUrl,
+        LocalDateTime dueDate
+) {
+    public static BannerCreate of(BannerCreateRequest request) {
+        return new BannerCreate(
+                request.imageUrl(),
+                request.redirectUrl(),
+                request.dueDate().atStartOfDay()
+        );
+    }
+}

--- a/src/main/java/com/projectlyrics/server/domain/banner/domain/BannerCreate.java
+++ b/src/main/java/com/projectlyrics/server/domain/banner/domain/BannerCreate.java
@@ -12,7 +12,7 @@ public record BannerCreate(
         return new BannerCreate(
                 request.imageUrl(),
                 request.redirectUrl(),
-                request.dueDate().atStartOfDay()
+                request.dueDate() == null ? null: request.dueDate().atStartOfDay()
         );
     }
 }

--- a/src/main/java/com/projectlyrics/server/domain/banner/dto/request/BannerCreateRequest.java
+++ b/src/main/java/com/projectlyrics/server/domain/banner/dto/request/BannerCreateRequest.java
@@ -1,0 +1,12 @@
+package com.projectlyrics.server.domain.banner.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDate;
+
+public record BannerCreateRequest(
+        String imageUrl,
+        String redirectUrl,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+        LocalDate dueDate
+) {
+}

--- a/src/main/java/com/projectlyrics/server/domain/banner/dto/response/BannerCreateResponse.java
+++ b/src/main/java/com/projectlyrics/server/domain/banner/dto/response/BannerCreateResponse.java
@@ -1,0 +1,6 @@
+package com.projectlyrics.server.domain.banner.dto.response;
+
+public record BannerCreateResponse(
+        boolean success
+) {
+}

--- a/src/main/java/com/projectlyrics/server/domain/banner/dto/response/BannerGetResponse.java
+++ b/src/main/java/com/projectlyrics/server/domain/banner/dto/response/BannerGetResponse.java
@@ -1,0 +1,17 @@
+package com.projectlyrics.server.domain.banner.dto.response;
+
+import com.projectlyrics.server.domain.banner.domain.Banner;
+
+public record BannerGetResponse (
+        Long id,
+        String imageUrl,
+        String redirectUrl
+){
+    public static BannerGetResponse of(Banner banner) {
+        return new BannerGetResponse(
+                banner.getId(),
+                banner.getImageUrl(),
+                banner.getRedirectUrl()
+        );
+    }
+}

--- a/src/main/java/com/projectlyrics/server/domain/banner/exception/BannerNotFoundException.java
+++ b/src/main/java/com/projectlyrics/server/domain/banner/exception/BannerNotFoundException.java
@@ -1,0 +1,8 @@
+package com.projectlyrics.server.domain.banner.exception;
+
+import com.projectlyrics.server.domain.common.message.ErrorCode;
+import com.projectlyrics.server.global.exception.FeelinException;
+
+public class BannerNotFoundException extends FeelinException {
+    public BannerNotFoundException() { super(ErrorCode.BANNER_NOT_FOUND);}
+}

--- a/src/main/java/com/projectlyrics/server/domain/banner/repository/BannerCommandRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/banner/repository/BannerCommandRepository.java
@@ -1,0 +1,7 @@
+package com.projectlyrics.server.domain.banner.repository;
+
+import com.projectlyrics.server.domain.banner.domain.Banner;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BannerCommandRepository extends JpaRepository<Banner, Long> {
+}

--- a/src/main/java/com/projectlyrics/server/domain/banner/repository/BannerQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/banner/repository/BannerQueryRepository.java
@@ -1,0 +1,7 @@
+package com.projectlyrics.server.domain.banner.repository;
+
+import com.projectlyrics.server.domain.banner.domain.Banner;
+
+public interface BannerQueryRepository {
+    Banner findById(Long id);
+}

--- a/src/main/java/com/projectlyrics/server/domain/banner/repository/BannerQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/banner/repository/BannerQueryRepository.java
@@ -1,7 +1,10 @@
 package com.projectlyrics.server.domain.banner.repository;
 
 import com.projectlyrics.server.domain.banner.domain.Banner;
+import java.util.List;
 
 public interface BannerQueryRepository {
     Banner findById(Long id);
+
+    List<Banner> findRecentBanners(int size);
 }

--- a/src/main/java/com/projectlyrics/server/domain/banner/repository/impl/QueryDslBannerQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/banner/repository/impl/QueryDslBannerQueryRepository.java
@@ -6,6 +6,8 @@ import com.projectlyrics.server.domain.banner.domain.Banner;
 import com.projectlyrics.server.domain.banner.exception.BannerNotFoundException;
 import com.projectlyrics.server.domain.banner.repository.BannerQueryRepository;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -25,5 +27,18 @@ public class QueryDslBannerQueryRepository implements BannerQueryRepository {
                                 banner.deletedAt.isNull())
                         .fetchFirst()
         ).orElseThrow(BannerNotFoundException::new);
+    }
+
+    @Override
+    public List<Banner> findRecentBanners(int size) {
+        return jpaQueryFactory
+                .selectFrom(banner)
+                .where(
+                        banner.dueDate.isNull().or(banner.dueDate.after(LocalDateTime.now())),
+                        banner.deletedAt.isNull()
+                )
+                .orderBy(banner.id.desc())
+                .limit(size)
+                .fetch();
     }
 }

--- a/src/main/java/com/projectlyrics/server/domain/banner/repository/impl/QueryDslBannerQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/banner/repository/impl/QueryDslBannerQueryRepository.java
@@ -1,0 +1,29 @@
+package com.projectlyrics.server.domain.banner.repository.impl;
+
+import static com.projectlyrics.server.domain.banner.domain.QBanner.banner;
+
+import com.projectlyrics.server.domain.banner.domain.Banner;
+import com.projectlyrics.server.domain.banner.exception.BannerNotFoundException;
+import com.projectlyrics.server.domain.banner.repository.BannerQueryRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class QueryDslBannerQueryRepository implements BannerQueryRepository {
+
+    private  final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Banner findById(Long id) {
+        return Optional.of(
+                jpaQueryFactory
+                        .selectFrom(banner)
+                        .where(banner.id.eq(id),
+                                banner.deletedAt.isNull())
+                        .fetchFirst()
+        ).orElseThrow(BannerNotFoundException::new);
+    }
+}

--- a/src/main/java/com/projectlyrics/server/domain/banner/service/BannerCommandService.java
+++ b/src/main/java/com/projectlyrics/server/domain/banner/service/BannerCommandService.java
@@ -1,0 +1,21 @@
+package com.projectlyrics.server.domain.banner.service;
+
+import com.projectlyrics.server.domain.banner.domain.Banner;
+import com.projectlyrics.server.domain.banner.domain.BannerCreate;
+import com.projectlyrics.server.domain.banner.dto.request.BannerCreateRequest;
+import com.projectlyrics.server.domain.banner.repository.BannerCommandRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class BannerCommandService {
+
+    private final BannerCommandRepository bannerCommandRepository;
+
+    public Banner create(BannerCreateRequest request) {
+        return bannerCommandRepository.save(Banner.create(BannerCreate.of(request)));
+    }
+}

--- a/src/main/java/com/projectlyrics/server/domain/banner/service/BannerQueryService.java
+++ b/src/main/java/com/projectlyrics/server/domain/banner/service/BannerQueryService.java
@@ -1,0 +1,4 @@
+package com.projectlyrics.server.domain.banner.service;
+
+public class BannerQueryService {
+}

--- a/src/main/java/com/projectlyrics/server/domain/banner/service/BannerQueryService.java
+++ b/src/main/java/com/projectlyrics/server/domain/banner/service/BannerQueryService.java
@@ -1,4 +1,25 @@
 package com.projectlyrics.server.domain.banner.service;
 
+import com.projectlyrics.server.domain.banner.dto.response.BannerGetResponse;
+import com.projectlyrics.server.domain.banner.repository.BannerQueryRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
 public class BannerQueryService {
+
+    private final BannerQueryRepository bannerQueryRepository;
+
+    public List<BannerGetResponse> getRecentBanners(
+            int size
+    ) {
+        return bannerQueryRepository.findRecentBanners(size)
+                .stream()
+                .map(BannerGetResponse::of)
+                .toList();
+    }
 }

--- a/src/main/java/com/projectlyrics/server/domain/common/message/ErrorCode.java
+++ b/src/main/java/com/projectlyrics/server/domain/common/message/ErrorCode.java
@@ -117,6 +117,9 @@ public enum ErrorCode {
     // Event
     EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "17000", "해당 이벤트를 조회할 수 없습니다."),
     EVENT_REFUSAL_NOT_FOUND(HttpStatus.NOT_FOUND, "17001", "해당 이벤트 수신 거절 내역을 조회할 수 없습니다."),
+
+    //Banner
+    BANNER_NOT_FOUND(HttpStatus.NOT_FOUND, "18000", "해당 배너를 조회할 수 없습니다."),
     ;
 
     private final HttpStatus responseStatus;

--- a/src/test/java/com/projectlyrics/server/domain/artist/api/ArtistControllerTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/artist/api/ArtistControllerTest.java
@@ -1,35 +1,36 @@
 package com.projectlyrics.server.domain.artist.api;
 
-import com.epages.restdocs.apispec.ParameterDescriptorWithType;
-import com.epages.restdocs.apispec.ResourceSnippetParameters;
-import com.epages.restdocs.apispec.Schema;
-import com.epages.restdocs.apispec.SimpleType;
-import com.projectlyrics.server.domain.artist.dto.request.ArtistCreateRequest;
-import com.projectlyrics.server.domain.artist.dto.response.ArtistGetResponse;
-import com.projectlyrics.server.domain.common.dto.util.CursorBasePaginatedResponse;
-import com.projectlyrics.server.domain.artist.dto.request.ArtistUpdateRequest;
-import com.projectlyrics.server.domain.common.dto.util.OffsetBasePaginatedResponse;
-import com.projectlyrics.server.support.RestDocsTest;
-import com.projectlyrics.server.support.fixture.ArtistFixture;
-import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
-import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
-import org.springframework.restdocs.payload.JsonFieldType;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-
 import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.epages.restdocs.apispec.ParameterDescriptorWithType;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+import com.epages.restdocs.apispec.SimpleType;
+import com.projectlyrics.server.domain.artist.dto.request.ArtistCreateRequest;
+import com.projectlyrics.server.domain.artist.dto.request.ArtistUpdateRequest;
+import com.projectlyrics.server.domain.artist.dto.response.ArtistGetResponse;
+import com.projectlyrics.server.domain.common.dto.util.OffsetBasePaginatedResponse;
+import com.projectlyrics.server.support.RestDocsTest;
+import com.projectlyrics.server.support.fixture.ArtistFixture;
+import java.util.ArrayList;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.payload.JsonFieldType;
 
 class ArtistControllerTest extends RestDocsTest {
 
@@ -167,7 +168,7 @@ class ArtistControllerTest extends RestDocsTest {
                 resource(ResourceSnippetParameters.builder()
                         .tag("Artist API")
                         .summary("아티스트 단건 조회 API")
-                        .requestHeaders(getAuthorizationHeader())
+                        .requestHeaders(getAuthorizationHeader().optional())
                         .pathParameters(
                                 parameterWithName("artistId").type(SimpleType.NUMBER)
                                         .description("아티스트 id")
@@ -219,7 +220,7 @@ class ArtistControllerTest extends RestDocsTest {
                 resource(ResourceSnippetParameters.builder()
                         .tag("Artist API")
                         .summary("아티스트 리스트 조회 API")
-                        .requestHeaders(getAuthorizationHeader())
+                        .requestHeaders(getAuthorizationHeader().optional())
                         .queryParameters(getOffsetBasePagingQueryParameters())
                         .responseFields(
                                 fieldWithPath("pageNumber").type(JsonFieldType.NUMBER)
@@ -285,7 +286,7 @@ class ArtistControllerTest extends RestDocsTest {
                 resource(ResourceSnippetParameters.builder()
                         .tag("Artist API")
                         .summary("아티스트 검색 API")
-                        .requestHeaders(getAuthorizationHeader())
+                        .requestHeaders(getAuthorizationHeader().optional())
                         .queryParameters(queryParams)
                         .responseFields(
                                 fieldWithPath("pageNumber").type(JsonFieldType.NUMBER)

--- a/src/test/java/com/projectlyrics/server/domain/banner/api/BannerControllerTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/banner/api/BannerControllerTest.java
@@ -1,0 +1,63 @@
+package com.projectlyrics.server.domain.banner.api;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+import com.projectlyrics.server.domain.banner.dto.request.BannerCreateRequest;
+import com.projectlyrics.server.support.RestDocsTest;
+import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+public class BannerControllerTest extends RestDocsTest {
+
+    @Test
+    void 배너를_저장하면_200응답을_해야_한다() throws Exception {
+        // given
+        BannerCreateRequest request = new BannerCreateRequest(
+                "imageUrl",
+                "redirectUrl",
+                LocalDate.now()
+        );
+
+        // when, then
+        mockMvc.perform(post("/api/v1/banners")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andDo(getCreateBannerDocument());
+    }
+
+    private RestDocumentationResultHandler getCreateBannerDocument() {
+        return restDocs.document(
+                resource(ResourceSnippetParameters.builder()
+                        .tag("Event API")
+                        .summary("배너 등록 API")
+                        .requestHeaders(getAuthorizationHeader())
+                        .requestFields(
+                                fieldWithPath("imageUrl").type(JsonFieldType.STRING)
+                                        .description("이미지 URL"),
+                                fieldWithPath("redirectUrl").type(JsonFieldType.STRING)
+                                        .description("리다이렉트 URL"),
+                                fieldWithPath("dueDate").type(JsonFieldType.STRING)
+                                        .description("배너 노출 마감일")
+                                        .optional()
+                        )
+                        .requestSchema(Schema.schema("Create Banner Request"))
+                        .responseFields(
+                                fieldWithPath("success").type(JsonFieldType.BOOLEAN)
+                                        .description("성공 여부")
+                        )
+                        .responseSchema(Schema.schema("Create Banner Response"))
+                        .build())
+        );
+    }
+}

--- a/src/test/java/com/projectlyrics/server/domain/banner/api/BannerControllerTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/banner/api/BannerControllerTest.java
@@ -1,15 +1,23 @@
 package com.projectlyrics.server.domain.banner.api;
 
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
+import com.projectlyrics.server.domain.banner.domain.Banner;
 import com.projectlyrics.server.domain.banner.dto.request.BannerCreateRequest;
+import com.projectlyrics.server.domain.banner.dto.response.BannerGetResponse;
 import com.projectlyrics.server.support.RestDocsTest;
+import com.projectlyrics.server.support.fixture.BannerFixture;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -59,5 +67,48 @@ public class BannerControllerTest extends RestDocsTest {
                         .responseSchema(Schema.schema("Create Banner Response"))
                         .build())
         );
+    }
+
+    @Test
+    void 배너_리스트를_조회하면_데이터와_200응답을_해야_한다() throws Exception{
+        // given
+        List<BannerGetResponse> response = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            Banner banner = BannerFixture.create();
+            response.add(BannerGetResponse.of(banner));
+        }
+
+        given(bannerQueryService.getRecentBanners(anyInt()))
+                .willReturn(response);
+
+        // when, then
+        mockMvc.perform(get("/api/v1/banners")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .param("size", "10")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(getAllExceptRefusedDocument());
+    }
+
+    private RestDocumentationResultHandler getAllExceptRefusedDocument() {
+
+        RestDocumentationResultHandler document = restDocs.document(
+                resource(ResourceSnippetParameters.builder()
+                        .tag("Banner API")
+                        .summary("최신 배너 리스트 조회 API")
+                        .requestHeaders(getAuthorizationHeader().optional())
+                        .responseFields(
+                                fieldWithPath("[].id").type(JsonFieldType.NUMBER)
+                                        .description("배너 Id"),
+                                fieldWithPath("[].imageUrl").type(JsonFieldType.STRING)
+                                        .description("배너 url"),
+                                fieldWithPath("[].redirectUrl").type(JsonFieldType.STRING)
+                                        .description("리다이렉트 url")
+                        )
+                        .responseSchema(Schema.schema("Banner List Response"))
+                        .build()
+                )
+        );
+        return document;
     }
 }

--- a/src/test/java/com/projectlyrics/server/domain/banner/service/BannerCommandServiceTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/banner/service/BannerCommandServiceTest.java
@@ -1,0 +1,59 @@
+package com.projectlyrics.server.domain.banner.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.projectlyrics.server.domain.banner.domain.Banner;
+import com.projectlyrics.server.domain.banner.dto.request.BannerCreateRequest;
+import com.projectlyrics.server.domain.banner.repository.BannerQueryRepository;
+import com.projectlyrics.server.domain.user.repository.UserCommandRepository;
+import com.projectlyrics.server.support.IntegrationTest;
+import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class BannerCommandServiceTest extends IntegrationTest {
+
+    @Autowired
+    UserCommandRepository userCommandRepository;
+
+    @Autowired
+    BannerQueryRepository bannerQueryRepository;
+
+    @Autowired
+    BannerCommandService sut;
+
+    @Test
+    void 배너를_발행해야_한다() {
+        // given
+        BannerCreateRequest request = new BannerCreateRequest("imageUrl", "redirectUrl", LocalDate.now());
+
+        // when
+        Banner banner = sut.create(request);
+
+        // then
+        Banner result = bannerQueryRepository.findById(banner.getId());
+        assertAll(
+                () -> assertThat(result.getImageUrl()).isEqualTo(request.imageUrl()),
+                () -> assertThat(result.getRedirectUrl()).isEqualTo(request.redirectUrl()),
+                () -> assertThat(result.getDueDate()).isEqualTo(request.dueDate().atStartOfDay())
+        );
+    }
+
+    @Test
+    void 마감일자_없이도_배너를_발행해야_한다() {
+        // given
+        BannerCreateRequest request = new BannerCreateRequest("imageUrl", "redirectUrl", null);
+
+        // when
+        Banner banner = sut.create(request);
+
+        // then
+        Banner result = bannerQueryRepository.findById(banner.getId());
+        assertAll(
+                () -> assertThat(result.getImageUrl()).isEqualTo(request.imageUrl()),
+                () -> assertThat(result.getRedirectUrl()).isEqualTo(request.redirectUrl()),
+                () -> assertThat(result.getDueDate()).isNull()
+        );
+    }
+}

--- a/src/test/java/com/projectlyrics/server/domain/banner/service/BannerQueryServiceTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/banner/service/BannerQueryServiceTest.java
@@ -1,0 +1,134 @@
+package com.projectlyrics.server.domain.banner.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.projectlyrics.server.domain.banner.domain.Banner;
+import com.projectlyrics.server.domain.banner.domain.BannerCreate;
+import com.projectlyrics.server.domain.banner.dto.request.BannerCreateRequest;
+import com.projectlyrics.server.domain.banner.dto.response.BannerGetResponse;
+import com.projectlyrics.server.domain.banner.repository.BannerCommandRepository;
+import com.projectlyrics.server.domain.banner.repository.BannerQueryRepository;
+import com.projectlyrics.server.domain.user.entity.User;
+import com.projectlyrics.server.domain.user.repository.UserCommandRepository;
+import com.projectlyrics.server.support.IntegrationTest;
+import com.projectlyrics.server.support.fixture.UserFixture;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class BannerQueryServiceTest extends IntegrationTest {
+
+    @Autowired
+    UserCommandRepository userCommandRepository;
+
+    @Autowired
+    BannerQueryRepository bannerQueryRepository;
+
+    @Autowired
+    BannerCommandRepository bannerCommandRepository;
+
+    @Autowired
+    BannerQueryService sut;
+
+    private User user;
+
+    private BannerCreateRequest activeBannerCreateRequest;
+    private BannerCreateRequest expiredBannerCreateRequest;
+    private BannerCreateRequest bannerCreateRequest;
+
+    @BeforeEach
+    void setUp() {
+        user = userCommandRepository.save(UserFixture.create());
+        activeBannerCreateRequest = new BannerCreateRequest(
+                "imageUrl",
+                "redirectUrl",
+                LocalDate.now().plusDays(1)
+        );
+        expiredBannerCreateRequest = new BannerCreateRequest(
+                "imageUrl",
+                "redirectUrl",
+                LocalDate.now().minusDays(1)
+        );
+        bannerCreateRequest = new BannerCreateRequest(
+                "imageUrl",
+                "redirectUrl",
+                null
+        );
+    }
+
+    @Test
+    void 배너를_특정_개수만큼_최신순으로_조회해야_한다() {
+        // given
+        List<Banner> banners = new ArrayList<>();
+        for (int i=0; i<5; i++) {
+            banners.add(bannerCommandRepository.save(Banner.create(BannerCreate.of(activeBannerCreateRequest))));
+        }
+
+        // when
+        List<BannerGetResponse> result = sut.getRecentBanners(5);
+
+        // then
+        assertAll(
+                () -> assertThat(result.size()).isEqualTo(5),
+                () -> assertThat(result.get(0).id()).isEqualTo(banners.get(4).getId()),
+                () -> assertThat(result.get(1).id()).isEqualTo(banners.get(3).getId()),
+                () -> assertThat(result.get(2).id()).isEqualTo(banners.get(2).getId()),
+                () -> assertThat(result.get(3).id()).isEqualTo(banners.get(1).getId()),
+                () -> assertThat(result.get(4).id()).isEqualTo(banners.get(0).getId())
+        );
+    }
+
+    @Test
+    void 배너_리스트_조회시_주어진_개수만큼의_배너가_없으면_최대한_많은_배너를_조회해야_한다() {
+        // given
+        List<Banner> banners = new ArrayList<>();
+        for (int i=0; i<5; i++) {
+            banners.add(bannerCommandRepository.save(Banner.create(BannerCreate.of(activeBannerCreateRequest))));
+        }
+
+        // when
+        List<BannerGetResponse> result = sut.getRecentBanners(10);
+
+        // then
+        assertAll(
+                () -> assertThat(result.size()).isEqualTo(5),
+                () -> assertThat(result.get(0).id()).isEqualTo(banners.get(4).getId()),
+                () -> assertThat(result.get(1).id()).isEqualTo(banners.get(3).getId()),
+                () -> assertThat(result.get(2).id()).isEqualTo(banners.get(2).getId()),
+                () -> assertThat(result.get(3).id()).isEqualTo(banners.get(1).getId()),
+                () -> assertThat(result.get(4).id()).isEqualTo(banners.get(0).getId())
+        );
+    }
+
+    @Test
+    void 배너_리스트_조회시_마감기한이_이미_지난_배너는_제외해야_한다() {
+        // given
+        List<Banner> banners = new ArrayList<>();
+        for (int i=0; i<3; i++) {
+            banners.add(bannerCommandRepository.save(Banner.create(BannerCreate.of(activeBannerCreateRequest))));
+        }
+        for (int i=0; i<2; i++) {
+            banners.add(bannerCommandRepository.save(Banner.create(BannerCreate.of(bannerCreateRequest))));
+        }
+        for (int i=0; i<5; i++) {
+            banners.add(bannerCommandRepository.save(Banner.create(BannerCreate.of(expiredBannerCreateRequest))));
+        }
+
+        // when
+        List<BannerGetResponse> result = sut.getRecentBanners(10);
+
+        // then
+        assertAll(
+                () -> assertThat(result.size()).isEqualTo(5),
+                () -> assertThat(result.get(0).id()).isEqualTo(banners.get(4).getId()),
+                () -> assertThat(result.get(1).id()).isEqualTo(banners.get(3).getId()),
+                () -> assertThat(result.get(2).id()).isEqualTo(banners.get(2).getId()),
+                () -> assertThat(result.get(3).id()).isEqualTo(banners.get(1).getId()),
+                () -> assertThat(result.get(4).id()).isEqualTo(banners.get(0).getId())
+        );
+    }
+}

--- a/src/test/java/com/projectlyrics/server/domain/event/api/EventControllerTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/event/api/EventControllerTest.java
@@ -95,7 +95,7 @@ class EventControllerTest extends RestDocsTest {
                 resource(ResourceSnippetParameters.builder()
                         .tag("Event API")
                         .summary("이벤트 거부 API")
-                        .requestHeaders(getAuthorizationHeader())
+                        .requestHeaders(getAuthorizationHeader().optional())
                         .queryParameters(parameterWithName("eventId").type(SimpleType.NUMBER)
                                 .description("거부할 이벤트 ID")
                         )
@@ -143,7 +143,7 @@ class EventControllerTest extends RestDocsTest {
                 resource(ResourceSnippetParameters.builder()
                         .tag("Event API")
                         .summary("진행 중인 모든 이벤트 리스트 조회 API (사용자가 거부한 이벤트 제외)")
-                        .requestHeaders(getAuthorizationHeader())
+                        .requestHeaders(getAuthorizationHeader().optional())
                         .responseFields(
                                 fieldWithPath("refusalPeriod").type(JsonFieldType.NUMBER)
                                         .description("거절 기간(1:하루동안 보지 않기/7:일주일간 보지 않기)"),

--- a/src/test/java/com/projectlyrics/server/domain/note/api/NoteControllerTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/note/api/NoteControllerTest.java
@@ -1,5 +1,18 @@
 package com.projectlyrics.server.domain.note.api;
 
+import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.epages.restdocs.apispec.ParameterDescriptorWithType;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
@@ -15,25 +28,20 @@ import com.projectlyrics.server.domain.note.entity.NoteStatus;
 import com.projectlyrics.server.domain.user.entity.ProfileCharacter;
 import com.projectlyrics.server.domain.user.entity.User;
 import com.projectlyrics.server.support.RestDocsTest;
-import com.projectlyrics.server.support.fixture.*;
+import com.projectlyrics.server.support.fixture.ArtistFixture;
+import com.projectlyrics.server.support.fixture.CommentFixture;
+import com.projectlyrics.server.support.fixture.NoteFixture;
+import com.projectlyrics.server.support.fixture.SongFixture;
+import com.projectlyrics.server.support.fixture.UserFixture;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.restdocs.payload.JsonFieldType;
-
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
-import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
-import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 class NoteControllerTest extends RestDocsTest {
 
@@ -190,7 +198,7 @@ class NoteControllerTest extends RestDocsTest {
                 resource(ResourceSnippetParameters.builder()
                         .tag("Note API")
                         .summary("노트 단건 조회 API")
-                        .requestHeaders(getAuthorizationHeader())
+                        .requestHeaders(getAuthorizationHeader().optional())
                         .pathParameters(
                                 parameterWithName("noteId").type(SimpleType.NUMBER)
                                         .description("노트 ID")
@@ -506,7 +514,7 @@ class NoteControllerTest extends RestDocsTest {
                 resource(ResourceSnippetParameters.builder()
                         .tag("Note API")
                         .summary("특정 아티스트와 관련된 노트 리스트 조회 API")
-                        .requestHeaders(getAuthorizationHeader())
+                        .requestHeaders(getAuthorizationHeader().optional())
                         .queryParameters(queryParams)
                         .responseFields(
                                 fieldWithPath("nextCursor").type(JsonFieldType.NUMBER)
@@ -609,7 +617,7 @@ class NoteControllerTest extends RestDocsTest {
                 resource(ResourceSnippetParameters.builder()
                         .tag("Note API")
                         .summary("특정 곡과 관련된 노트 리스트 조회 API")
-                        .requestHeaders(getAuthorizationHeader())
+                        .requestHeaders(getAuthorizationHeader().optional())
                         .queryParameters(queryParams)
                         .responseFields(
                                 fieldWithPath("nextCursor").type(JsonFieldType.NUMBER)

--- a/src/test/java/com/projectlyrics/server/domain/song/api/SongControllerTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/song/api/SongControllerTest.java
@@ -75,7 +75,7 @@ SongControllerTest extends RestDocsTest {
                 resource(ResourceSnippetParameters.builder()
                         .tag("Song API")
                         .summary("노트 개수 역순 정렬 곡 검색 API")
-                        .requestHeaders(getAuthorizationHeader())
+                        .requestHeaders(getAuthorizationHeader().optional())
                         .queryParameters(queryParams)
                         .responseFields(
                                 fieldWithPath("pageNumber").type(JsonFieldType.NUMBER)
@@ -152,7 +152,7 @@ SongControllerTest extends RestDocsTest {
                 resource(ResourceSnippetParameters.builder()
                         .tag("Song API")
                         .summary("아티스트 id 기반 최신순 정렬 곡 검색 API")
-                        .requestHeaders(getAuthorizationHeader())
+                        .requestHeaders(getAuthorizationHeader().optional())
                         .queryParameters(queryParams)
                         .responseFields(
                                 fieldWithPath("nextCursor").type(JsonFieldType.NUMBER)
@@ -200,7 +200,7 @@ SongControllerTest extends RestDocsTest {
                 resource(ResourceSnippetParameters.builder()
                         .tag("Song API")
                         .summary("곡 id로 곡 정보 검색 API")
-                        .requestHeaders(getAuthorizationHeader())
+                        .requestHeaders(getAuthorizationHeader().optional())
                         .pathParameters(
                                 parameterWithName("songId").type(SimpleType.NUMBER)
                                         .description("곡 ID")

--- a/src/test/java/com/projectlyrics/server/support/ControllerTest.java
+++ b/src/test/java/com/projectlyrics/server/support/ControllerTest.java
@@ -10,6 +10,8 @@ import com.projectlyrics.server.domain.auth.authentication.jwt.JwtExtractor;
 import com.projectlyrics.server.domain.auth.authentication.jwt.JwtProvider;
 import com.projectlyrics.server.domain.auth.service.AuthCommandService;
 import com.projectlyrics.server.domain.auth.service.AuthQueryService;
+import com.projectlyrics.server.domain.banner.service.BannerCommandService;
+import com.projectlyrics.server.domain.banner.service.BannerQueryService;
 import com.projectlyrics.server.domain.block.service.BlockCommandService;
 import com.projectlyrics.server.domain.bookmark.service.BookmarkCommandService;
 import com.projectlyrics.server.domain.comment.service.CommentCommandService;
@@ -129,6 +131,12 @@ public abstract class ControllerTest {
 
     @MockBean
     protected EventQueryService eventQueryService;
+
+    @MockBean
+    protected BannerCommandService bannerCommandService;
+
+    @MockBean
+    protected BannerQueryService bannerQueryService;
 
     public String accessToken;
     public String refreshToken;

--- a/src/test/java/com/projectlyrics/server/support/fixture/BannerFixture.java
+++ b/src/test/java/com/projectlyrics/server/support/fixture/BannerFixture.java
@@ -1,25 +1,22 @@
 package com.projectlyrics.server.support.fixture;
 
-import com.projectlyrics.server.domain.event.domain.Event;
-import com.projectlyrics.server.domain.event.domain.EventCreate;
+import com.projectlyrics.server.domain.banner.domain.Banner;
+import com.projectlyrics.server.domain.banner.domain.BannerCreate;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
-public class EventFixture extends BaseFixture{
-
+public class BannerFixture extends BaseFixture{
     private Long id;
     private String imageUrl = "imageUrl";
     private String redirectUrl = "redirectUrl";
-    private String buttonText = "button";
     private LocalDateTime dueDate = LocalDate.now().atTime(23, 59, 59);
 
-    public static Event create() {
-        return Event.createWithId(
+    public static Banner create() {
+        return Banner.createWithId(
                 getUniqueId(),
-                new EventCreate(
-                      "imageUrl",
+                new BannerCreate(
+                        "imageUrl",
                         "redirectUrl",
-                        "button",
                         LocalDate.now().plusDays(1).atTime(23, 59, 59)
                 )
         );


### PR DESCRIPTION
# 🍃 **Pull Requests**

## ⛳️ **작업한 브랜치**
- Resolved: [SCRUM-199]

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- banner 도메인 생성
- banner 생성 API 추가
- 배너 목록 조회 API 작성
- 배너 관련 테스트 작성

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 배너의 경우 정해진 개수만큼만 클라이언트에 제공하면 될 것이라고 생각해 일단 페이지네이션이 아닌 리스트의 형태로 목록 조회 api를 구현했습니다.
- 배너는 마감기한이 있는 경우(ex: 이벤트 배너), 마감기한이 없는 경우(ex: 아티스트 추천)으로 나누어서 개발했습니다.
- 테스트를 작성하면서 기존에 토큰이 필요없는 api를 스웨거에 따로 표시하지 않았던 부분을 수정보완했습니다.

[SCRUM-199]: https://projectlyrics.atlassian.net/browse/SCRUM-199
