### PR TITLE
배너 생성시 필요에 따라 기존 배너 숨길 수 있도록 수정

### DIFF
--- a/src/main/java/com/projectlyrics/server/domain/banner/domain/Banner.java
+++ b/src/main/java/com/projectlyrics/server/domain/banner/domain/Banner.java
@@ -27,14 +27,17 @@ public class Banner extends BaseEntity {
     private String imageUrl;
     private String redirectUrl;
     private LocalDateTime dueDate;
+    private LocalDateTime startDate;
 
     private Banner(
             String imageUrl,
             String redirectUrl,
+            LocalDateTime startDate,
             LocalDateTime dueDate
     ) {
         this.imageUrl = imageUrl;
         this.redirectUrl = redirectUrl;
+        this.startDate = startDate;
         this.dueDate = dueDate;
     }
 
@@ -42,6 +45,7 @@ public class Banner extends BaseEntity {
         return new Banner(
                 bannerCreate.imageUrl(),
                 bannerCreate.redirectUrl(),
+                bannerCreate.startDate(),
                 bannerCreate.dueDate()
         );
     }
@@ -51,6 +55,7 @@ public class Banner extends BaseEntity {
                 id,
                 bannerCreate.imageUrl(),
                 bannerCreate.redirectUrl(),
+                bannerCreate.startDate(),
                 bannerCreate.dueDate()
         );
     }

--- a/src/main/java/com/projectlyrics/server/domain/banner/domain/Banner.java
+++ b/src/main/java/com/projectlyrics/server/domain/banner/domain/Banner.java
@@ -12,6 +12,7 @@ import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @Entity
@@ -26,8 +27,9 @@ public class Banner extends BaseEntity {
 
     private String imageUrl;
     private String redirectUrl;
-    private LocalDateTime dueDate;
+    @Setter
     private LocalDateTime startDate;
+    private LocalDateTime dueDate;
 
     private Banner(
             String imageUrl,

--- a/src/main/java/com/projectlyrics/server/domain/banner/domain/BannerCreate.java
+++ b/src/main/java/com/projectlyrics/server/domain/banner/domain/BannerCreate.java
@@ -6,12 +6,14 @@ import java.time.LocalDateTime;
 public record BannerCreate(
         String imageUrl,
         String redirectUrl,
+        LocalDateTime startDate,
         LocalDateTime dueDate
 ) {
     public static BannerCreate of(BannerCreateRequest request) {
         return new BannerCreate(
                 request.imageUrl(),
                 request.redirectUrl(),
+                request.startDate() == null ? null: request.startDate().atStartOfDay(),
                 request.dueDate() == null ? null: request.dueDate().atStartOfDay()
         );
     }

--- a/src/main/java/com/projectlyrics/server/domain/banner/dto/request/BannerCreateRequest.java
+++ b/src/main/java/com/projectlyrics/server/domain/banner/dto/request/BannerCreateRequest.java
@@ -7,6 +7,9 @@ public record BannerCreateRequest(
         String imageUrl,
         String redirectUrl,
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+        LocalDate startDate,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
         LocalDate dueDate
+
 ) {
 }

--- a/src/main/java/com/projectlyrics/server/domain/banner/dto/request/BannerCreateRequest.java
+++ b/src/main/java/com/projectlyrics/server/domain/banner/dto/request/BannerCreateRequest.java
@@ -9,7 +9,9 @@ public record BannerCreateRequest(
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
         LocalDate startDate,
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
-        LocalDate dueDate
+        LocalDate dueDate,
+        boolean hide,
+        Long hiddenBannerId
 
 ) {
 }

--- a/src/main/java/com/projectlyrics/server/domain/banner/dto/request/BannerCreateRequest.java
+++ b/src/main/java/com/projectlyrics/server/domain/banner/dto/request/BannerCreateRequest.java
@@ -10,7 +10,7 @@ public record BannerCreateRequest(
         LocalDate startDate,
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
         LocalDate dueDate,
-        boolean hide,
+        boolean hideOther,
         Long hiddenBannerId
 
 ) {

--- a/src/main/java/com/projectlyrics/server/domain/banner/repository/impl/QueryDslBannerQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/banner/repository/impl/QueryDslBannerQueryRepository.java
@@ -20,7 +20,7 @@ public class QueryDslBannerQueryRepository implements BannerQueryRepository {
 
     @Override
     public Banner findById(Long id) {
-        return Optional.of(
+        return Optional.ofNullable(
                 jpaQueryFactory
                         .selectFrom(banner)
                         .where(banner.id.eq(id),

--- a/src/main/java/com/projectlyrics/server/domain/banner/repository/impl/QueryDslBannerQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/banner/repository/impl/QueryDslBannerQueryRepository.java
@@ -34,6 +34,7 @@ public class QueryDslBannerQueryRepository implements BannerQueryRepository {
         return jpaQueryFactory
                 .selectFrom(banner)
                 .where(
+                        banner.startDate.isNull().or(banner.startDate.before(LocalDateTime.now())),
                         banner.dueDate.isNull().or(banner.dueDate.after(LocalDateTime.now())),
                         banner.deletedAt.isNull()
                 )

--- a/src/main/java/com/projectlyrics/server/domain/banner/service/BannerCommandService.java
+++ b/src/main/java/com/projectlyrics/server/domain/banner/service/BannerCommandService.java
@@ -4,7 +4,9 @@ import com.projectlyrics.server.domain.banner.domain.Banner;
 import com.projectlyrics.server.domain.banner.domain.BannerCreate;
 import com.projectlyrics.server.domain.banner.dto.request.BannerCreateRequest;
 import com.projectlyrics.server.domain.banner.repository.BannerCommandRepository;
+import com.projectlyrics.server.domain.banner.repository.BannerQueryRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,9 +15,18 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class BannerCommandService {
 
+    private final BannerQueryRepository bannerQueryRepository;
     private final BannerCommandRepository bannerCommandRepository;
 
+    @Value("${default_banner_id}")
+    private Long defaultBannerId;
+
     public Banner create(BannerCreateRequest request) {
+        if (request.hide()) {
+            Long hiddenBannerId = request.hiddenBannerId() == null ? defaultBannerId : request.hiddenBannerId();
+            Banner hiddenBanner =  bannerQueryRepository.findById(hiddenBannerId);
+            hiddenBanner.setStartDate(request.dueDate() == null ? null : request.dueDate().atStartOfDay());
+        }
         return bannerCommandRepository.save(Banner.create(BannerCreate.of(request)));
     }
 }

--- a/src/main/java/com/projectlyrics/server/domain/banner/service/BannerCommandService.java
+++ b/src/main/java/com/projectlyrics/server/domain/banner/service/BannerCommandService.java
@@ -22,7 +22,7 @@ public class BannerCommandService {
     private Long defaultBannerId;
 
     public Banner create(BannerCreateRequest request) {
-        if (request.hide()) {
+        if (request.hideOther()) {
             Long hiddenBannerId = request.hiddenBannerId() == null ? defaultBannerId : request.hiddenBannerId();
             Banner hiddenBanner =  bannerQueryRepository.findById(hiddenBannerId);
             hiddenBanner.setStartDate(request.dueDate() == null ? null : request.dueDate().atStartOfDay());

--- a/src/test/java/com/projectlyrics/server/domain/banner/api/BannerControllerTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/banner/api/BannerControllerTest.java
@@ -32,6 +32,7 @@ public class BannerControllerTest extends RestDocsTest {
         BannerCreateRequest request = new BannerCreateRequest(
                 "imageUrl",
                 "redirectUrl",
+                LocalDate.now(),
                 LocalDate.now()
         );
 
@@ -55,6 +56,9 @@ public class BannerControllerTest extends RestDocsTest {
                                         .description("이미지 URL"),
                                 fieldWithPath("redirectUrl").type(JsonFieldType.STRING)
                                         .description("리다이렉트 URL"),
+                                fieldWithPath("startDate").type(JsonFieldType.STRING)
+                                        .description("배너 노출 시작일")
+                                        .optional(),
                                 fieldWithPath("dueDate").type(JsonFieldType.STRING)
                                         .description("배너 노출 마감일")
                                         .optional()

--- a/src/test/java/com/projectlyrics/server/domain/banner/api/BannerControllerTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/banner/api/BannerControllerTest.java
@@ -33,7 +33,9 @@ public class BannerControllerTest extends RestDocsTest {
                 "imageUrl",
                 "redirectUrl",
                 LocalDate.now(),
-                LocalDate.now()
+                LocalDate.now(),
+                false,
+                null
         );
 
         // when, then
@@ -61,6 +63,11 @@ public class BannerControllerTest extends RestDocsTest {
                                         .optional(),
                                 fieldWithPath("dueDate").type(JsonFieldType.STRING)
                                         .description("배너 노출 마감일")
+                                        .optional(),
+                                fieldWithPath("hideOther").type(JsonFieldType.BOOLEAN)
+                                        .description("다른 배너를 가릴지 여부"),
+                                fieldWithPath("hiddenBannerId").type(JsonFieldType.NUMBER)
+                                        .description("가릴 배너 Id (hideOther가 true일 때만 필요. 또한 입력하지 않을시 yml값 적용됨)")
                                         .optional()
                         )
                         .requestSchema(Schema.schema("Create Banner Request"))

--- a/src/test/java/com/projectlyrics/server/domain/banner/service/BannerCommandServiceTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/banner/service/BannerCommandServiceTest.java
@@ -26,7 +26,7 @@ public class BannerCommandServiceTest extends IntegrationTest {
     @Test
     void 배너를_발행해야_한다() {
         // given
-        BannerCreateRequest request = new BannerCreateRequest("imageUrl", "redirectUrl", LocalDate.now(), LocalDate.now());
+        BannerCreateRequest request = new BannerCreateRequest("imageUrl", "redirectUrl", LocalDate.now(), LocalDate.now(), false, null);
 
         // when
         Banner banner = sut.create(request);
@@ -36,14 +36,48 @@ public class BannerCommandServiceTest extends IntegrationTest {
         assertAll(
                 () -> assertThat(result.getImageUrl()).isEqualTo(request.imageUrl()),
                 () -> assertThat(result.getRedirectUrl()).isEqualTo(request.redirectUrl()),
+                () -> assertThat(result.getStartDate()).isEqualTo(request.startDate().atStartOfDay()),
                 () -> assertThat(result.getDueDate()).isEqualTo(request.dueDate().atStartOfDay())
+        );
+    }
+
+    @Test
+    void 배너_발행시_필요에_따라_다른_배너의_startDate를_바꿀_수_있어야_한다() {
+        // given
+        Banner hiddenBanner = sut.create(new BannerCreateRequest("imageUrl", "redirectUrl", LocalDate.now().minusDays(2), LocalDate.now(), false, null));
+        BannerCreateRequest request = new BannerCreateRequest("imageUrl", "redirectUrl", LocalDate.now(), LocalDate.now().plusDays(1), true, hiddenBanner.getId());
+
+        // when
+        sut.create(request);
+
+        // then
+        Banner result = bannerQueryRepository.findById(hiddenBanner.getId());
+        assertAll(
+                () -> assertThat(result.getStartDate()).isEqualTo(request.dueDate().atStartOfDay())
+        );
+    }
+
+    @Test
+    void 배너_발행시_hiddenBannerId가_주어지지_않으면_기본_배너의_startDate를_변경해야_한다() {
+        // given
+        // yml에 기본 배너의 id 1로 지정
+        sut.create(new BannerCreateRequest("imageUrl", "redirectUrl", LocalDate.now().minusDays(2), LocalDate.now(), false, null));
+        BannerCreateRequest request = new BannerCreateRequest("imageUrl", "redirectUrl", LocalDate.now(), LocalDate.now().plusDays(1), true, null);
+
+        // when
+        sut.create(request);
+
+        // then
+        Banner result = bannerQueryRepository.findById(1L);
+        assertAll(
+                () -> assertThat(result.getStartDate()).isEqualTo(request.dueDate().atStartOfDay())
         );
     }
 
     @Test
     void 시작일자_없이도_배너를_발행해야_한다() {
         // given
-        BannerCreateRequest request = new BannerCreateRequest("imageUrl", "redirectUrl", null, LocalDate.now());
+        BannerCreateRequest request = new BannerCreateRequest("imageUrl", "redirectUrl", null, LocalDate.now(), false, null);
 
         // when
         Banner banner = sut.create(request);
@@ -61,7 +95,7 @@ public class BannerCommandServiceTest extends IntegrationTest {
     @Test
     void 마감일자_없이도_배너를_발행해야_한다() {
         // given
-        BannerCreateRequest request = new BannerCreateRequest("imageUrl", "redirectUrl", LocalDate.now(), null);
+        BannerCreateRequest request = new BannerCreateRequest("imageUrl", "redirectUrl", LocalDate.now(), null, false, null);
 
         // when
         Banner banner = sut.create(request);

--- a/src/test/java/com/projectlyrics/server/domain/banner/service/BannerCommandServiceTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/banner/service/BannerCommandServiceTest.java
@@ -26,7 +26,7 @@ public class BannerCommandServiceTest extends IntegrationTest {
     @Test
     void 배너를_발행해야_한다() {
         // given
-        BannerCreateRequest request = new BannerCreateRequest("imageUrl", "redirectUrl", LocalDate.now());
+        BannerCreateRequest request = new BannerCreateRequest("imageUrl", "redirectUrl", LocalDate.now(), LocalDate.now());
 
         // when
         Banner banner = sut.create(request);
@@ -41,9 +41,9 @@ public class BannerCommandServiceTest extends IntegrationTest {
     }
 
     @Test
-    void 마감일자_없이도_배너를_발행해야_한다() {
+    void 시작일자_없이도_배너를_발행해야_한다() {
         // given
-        BannerCreateRequest request = new BannerCreateRequest("imageUrl", "redirectUrl", null);
+        BannerCreateRequest request = new BannerCreateRequest("imageUrl", "redirectUrl", null, LocalDate.now());
 
         // when
         Banner banner = sut.create(request);
@@ -53,6 +53,25 @@ public class BannerCommandServiceTest extends IntegrationTest {
         assertAll(
                 () -> assertThat(result.getImageUrl()).isEqualTo(request.imageUrl()),
                 () -> assertThat(result.getRedirectUrl()).isEqualTo(request.redirectUrl()),
+                () -> assertThat(result.getStartDate()).isNull(),
+                () -> assertThat(result.getDueDate()).isEqualTo(request.dueDate().atStartOfDay())
+        );
+    }
+
+    @Test
+    void 마감일자_없이도_배너를_발행해야_한다() {
+        // given
+        BannerCreateRequest request = new BannerCreateRequest("imageUrl", "redirectUrl", LocalDate.now(), null);
+
+        // when
+        Banner banner = sut.create(request);
+
+        // then
+        Banner result = bannerQueryRepository.findById(banner.getId());
+        assertAll(
+                () -> assertThat(result.getImageUrl()).isEqualTo(request.imageUrl()),
+                () -> assertThat(result.getRedirectUrl()).isEqualTo(request.redirectUrl()),
+                () -> assertThat(result.getStartDate()).isEqualTo(request.startDate().atStartOfDay()),
                 () -> assertThat(result.getDueDate()).isNull()
         );
     }

--- a/src/test/java/com/projectlyrics/server/domain/banner/service/BannerQueryServiceTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/banner/service/BannerQueryServiceTest.java
@@ -9,10 +9,8 @@ import com.projectlyrics.server.domain.banner.dto.request.BannerCreateRequest;
 import com.projectlyrics.server.domain.banner.dto.response.BannerGetResponse;
 import com.projectlyrics.server.domain.banner.repository.BannerCommandRepository;
 import com.projectlyrics.server.domain.banner.repository.BannerQueryRepository;
-import com.projectlyrics.server.domain.user.entity.User;
 import com.projectlyrics.server.domain.user.repository.UserCommandRepository;
 import com.projectlyrics.server.support.IntegrationTest;
-import com.projectlyrics.server.support.fixture.UserFixture;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -34,8 +32,6 @@ public class BannerQueryServiceTest extends IntegrationTest {
     @Autowired
     BannerQueryService sut;
 
-    private User user;
-
     private BannerCreateRequest activeBannerCreateRequest;
     private BannerCreateRequest expiredBannerCreateRequest;
     private BannerCreateRequest upcomingBannerCreateRequest;
@@ -43,29 +39,36 @@ public class BannerQueryServiceTest extends IntegrationTest {
 
     @BeforeEach
     void setUp() {
-        user = userCommandRepository.save(UserFixture.create());
         activeBannerCreateRequest = new BannerCreateRequest(
                 "imageUrl",
                 "redirectUrl",
                 LocalDate.now(),
-                LocalDate.now().plusDays(1)
+                LocalDate.now().plusDays(1),
+                false,
+                null
         );
         expiredBannerCreateRequest = new BannerCreateRequest(
                 "imageUrl",
                 "redirectUrl",
                 LocalDate.now().minusDays(2),
-                LocalDate.now().minusDays(1)
+                LocalDate.now().minusDays(1),
+                false,
+                null
         );
         upcomingBannerCreateRequest = new BannerCreateRequest(
                 "imageUrl",
                 "redirectUrl",
                 LocalDate.now().plusDays(1),
-                LocalDate.now().plusDays(2)
+                LocalDate.now().plusDays(2),
+                false,
+                null
         );
                 bannerCreateRequest = new BannerCreateRequest(
                 "imageUrl",
                 "redirectUrl",
                 null,
+                null,
+                false,
                 null
         );
     }

--- a/src/test/java/com/projectlyrics/server/domain/banner/service/BannerQueryServiceTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/banner/service/BannerQueryServiceTest.java
@@ -38,6 +38,7 @@ public class BannerQueryServiceTest extends IntegrationTest {
 
     private BannerCreateRequest activeBannerCreateRequest;
     private BannerCreateRequest expiredBannerCreateRequest;
+    private BannerCreateRequest upcomingBannerCreateRequest;
     private BannerCreateRequest bannerCreateRequest;
 
     @BeforeEach
@@ -46,16 +47,25 @@ public class BannerQueryServiceTest extends IntegrationTest {
         activeBannerCreateRequest = new BannerCreateRequest(
                 "imageUrl",
                 "redirectUrl",
+                LocalDate.now(),
                 LocalDate.now().plusDays(1)
         );
         expiredBannerCreateRequest = new BannerCreateRequest(
                 "imageUrl",
                 "redirectUrl",
+                LocalDate.now().minusDays(2),
                 LocalDate.now().minusDays(1)
         );
-        bannerCreateRequest = new BannerCreateRequest(
+        upcomingBannerCreateRequest = new BannerCreateRequest(
                 "imageUrl",
                 "redirectUrl",
+                LocalDate.now().plusDays(1),
+                LocalDate.now().plusDays(2)
+        );
+                bannerCreateRequest = new BannerCreateRequest(
+                "imageUrl",
+                "redirectUrl",
+                null,
                 null
         );
     }
@@ -105,7 +115,7 @@ public class BannerQueryServiceTest extends IntegrationTest {
     }
 
     @Test
-    void 배너_리스트_조회시_마감기한이_이미_지난_배너는_제외해야_한다() {
+    void 배너_리스트_조회시_시작기한이_남았거나_마감기한이_이미_지난_배너는_제외해야_한다() {
         // given
         List<Banner> banners = new ArrayList<>();
         for (int i=0; i<3; i++) {
@@ -116,6 +126,9 @@ public class BannerQueryServiceTest extends IntegrationTest {
         }
         for (int i=0; i<5; i++) {
             banners.add(bannerCommandRepository.save(Banner.create(BannerCreate.of(expiredBannerCreateRequest))));
+        }
+        for (int i=0; i<3; i++) {
+            banners.add(bannerCommandRepository.save(Banner.create(BannerCreate.of(upcomingBannerCreateRequest))));
         }
 
         // when

--- a/src/test/java/com/projectlyrics/server/support/fixture/BannerFixture.java
+++ b/src/test/java/com/projectlyrics/server/support/fixture/BannerFixture.java
@@ -17,6 +17,7 @@ public class BannerFixture extends BaseFixture{
                 new BannerCreate(
                         "imageUrl",
                         "redirectUrl",
+                        LocalDate.now().minusDays(1).atTime(23, 59, 59),
                         LocalDate.now().plusDays(1).atTime(23, 59, 59)
                 )
         );

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -35,6 +35,8 @@ admin: 1
 
 version: 0.0.1
 
+default_banner_id : 1
+
 search:
   api:
     host: host


### PR DESCRIPTION
# 🍃 **Pull Requests**

## ⛳️ **작업한 브랜치**
- Resolved: [SCRUM-201]

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 클라측에서, 이벤트 배너가 끝나고 나면 기본 배너가 보일 수 있도록 하는 자동화 기능을 요청하여 그에 맞게 코드를 수정했습니다. (1번 이벤트 배너 기간 동안은 2번 배너가 보이지 않았다가, 1번 이벤트 배너의 기간이 끝나면 자동으로 2번 배너가 노출되도록 자동화 요청)
![image](https://github.com/user-attachments/assets/49b20183-4d36-4db9-b11d-2fadb40a7dc5)
![image](https://github.com/user-attachments/assets/631a8f0d-46f6-408b-8f4f-5ab334d5771c)
- 배너의 노출 시작일인 startDate를 추가하고, 배너 생성시 필요에 따라 기존 배너의 startDate를 새롭게 생성되는 배너의 dueDate로 설정했습니다.
    - 배너 목록 조회시 현재 시간이 startDate와 dueDate 사이인 이벤트만 조회됩니다.
    - 또한 숨길 배너의  id가 요청에 주어지지 않으면 yml 속 값을 참조하여 기본 배너가 숨겨지게 됩니다.


## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- yml이 업데이트 되었습니다.
- 더 좋은 함수나 변수 네이밍, 로직이 있다면 추천해주세요!! :punch:

[SCRUM-201]: https://projectlyrics.atlassian.net/browse/SCRUM-201