### PR TITLE
중복로그인 검사 로직 변경

### DIFF
--- a/src/main/java/com/projectlyrics/server/domain/auth/authentication/interceptor/DeviceIdInterceptor.java
+++ b/src/main/java/com/projectlyrics/server/domain/auth/authentication/interceptor/DeviceIdInterceptor.java
@@ -3,6 +3,8 @@ package com.projectlyrics.server.domain.auth.authentication.interceptor;
 import com.projectlyrics.server.domain.auth.authentication.AuthContext;
 import com.projectlyrics.server.domain.auth.exception.NotRegisteredDeviceException;
 import com.projectlyrics.server.domain.auth.repository.AuthRepository;
+import com.projectlyrics.server.domain.user.exception.UserNotFoundException;
+import com.projectlyrics.server.domain.user.repository.UserQueryRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +21,7 @@ import org.springframework.web.servlet.HandlerInterceptor;
 public class DeviceIdInterceptor implements HandlerInterceptor {
 
     private final AuthRepository authRepository;
+    private final UserQueryRepository userQueryRepository;
     private final AuthContext authContext;
 
     @Override
@@ -56,6 +59,9 @@ public class DeviceIdInterceptor implements HandlerInterceptor {
     }
 
     private boolean isOldDevice(String deviceId) {
-        return authRepository.findByDeviceId(deviceId).isEmpty();
+        return userQueryRepository.findById(authContext.getId())
+                .map(user -> authRepository.findBySocialIdAndDeviceId(user.getSocialInfo().getSocialId(), deviceId))
+                .orElseThrow(() -> new UserNotFoundException())
+                .isEmpty();
     }
 }

--- a/src/main/java/com/projectlyrics/server/domain/auth/repository/AuthRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/auth/repository/AuthRepository.java
@@ -9,4 +9,5 @@ public interface AuthRepository extends CrudRepository<Auth, String> {
 
     Optional<Auth> findByRefreshToken(String refreshToken);
     Optional<Auth> findByDeviceId(String deviceId);
+    Optional<Auth> findBySocialIdAndDeviceId(String socialId, String deviceId);
 }


### PR DESCRIPTION


# 🍃 **Pull Requests**

## ⛳️ **작업한 브랜치**
- Resolved: [SCRUM-202]

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- A기기에서 userC로 로그인하고, 다시  userD로 로그인, 그다음 B기기에서 userD로 로그인하면, A기기에서 userD 정보로 서비스 접속시  findByDeviceId가 empty가 아니여서 중복 로그인 체크가 안되는 상황이 발생합니다. 
- 따라서 socialId와 deviceId의 조합으로 중복 로그인 체크를 할 수 있도록 수정했습니다.

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

[SCRUM-202]: https://projectlyrics.atlassian.net/browse/SCRUM-202
