### PR TITLE
MongoDB Atlas search 사용하도록 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,6 +85,9 @@ dependencies {
     implementation("org.opensearch.client:opensearch-rest-client:2.11.0")
     implementation("org.opensearch.client:opensearch-java:2.7.0")
     implementation("jakarta.json:jakarta.json-api")
+
+    // MongoDB AtlasSearch
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 }
 
 swaggerSources {

--- a/src/main/java/com/projectlyrics/server/domain/artist/entity/ArtistMongo.java
+++ b/src/main/java/com/projectlyrics/server/domain/artist/entity/ArtistMongo.java
@@ -1,0 +1,33 @@
+package com.projectlyrics.server.domain.artist.entity;
+
+import jakarta.persistence.Id;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+@Document(collection = "artists")
+public class ArtistMongo {
+    @Id
+    private final Long id;
+
+    @Field("search_names")
+    private final String searchNames;
+
+    private ArtistMongo(Long id, String searchNames) {
+        this.id = id;
+        this.searchNames = searchNames;
+    }
+
+    public static ArtistMongo of(Artist artist) {
+        String searchNames = Stream.of(
+                        artist.getName(),
+                        artist.getSecondName(),
+                        artist.getThirdName())
+                .filter(Objects::nonNull)
+                .collect(Collectors.joining(" "));
+        return new ArtistMongo(artist.getId(), searchNames);
+    }
+}
+

--- a/src/main/java/com/projectlyrics/server/domain/artist/entity/ArtistMongo.java
+++ b/src/main/java/com/projectlyrics/server/domain/artist/entity/ArtistMongo.java
@@ -1,7 +1,6 @@
 package com.projectlyrics.server.domain.artist.entity;
 
 import jakarta.persistence.Id;
-import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.springframework.data.mongodb.core.mapping.Document;
@@ -25,7 +24,7 @@ public class ArtistMongo {
                         artist.getName(),
                         artist.getSecondName(),
                         artist.getThirdName())
-                .filter(Objects::nonNull)
+                .filter(s -> s != null && !s.isBlank())
                 .collect(Collectors.joining(" "));
         return new ArtistMongo(artist.getId(), searchNames);
     }

--- a/src/main/java/com/projectlyrics/server/domain/artist/repository/ArtistMongoCommandRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/artist/repository/ArtistMongoCommandRepository.java
@@ -1,9 +1,15 @@
 package com.projectlyrics.server.domain.artist.repository;
 
 import com.projectlyrics.server.domain.artist.entity.ArtistMongo;
-import org.springframework.data.mongodb.repository.MongoRepository;
-import org.springframework.stereotype.Repository;
+import java.util.List;
 
-@Repository
-public interface ArtistMongoCommandRepository extends MongoRepository<ArtistMongo, Long> {
+public interface ArtistMongoCommandRepository {
+    ArtistMongo save(ArtistMongo artist);
+
+    <S extends ArtistMongo> List<S> saveAll(Iterable<S> artists);
+
+    void delete(ArtistMongo artist);
+
+    void deleteAll();
 }
+

--- a/src/main/java/com/projectlyrics/server/domain/artist/repository/ArtistMongoCommandRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/artist/repository/ArtistMongoCommandRepository.java
@@ -6,7 +6,7 @@ import java.util.List;
 public interface ArtistMongoCommandRepository {
     ArtistMongo save(ArtistMongo artist);
 
-    <S extends ArtistMongo> List<S> saveAll(Iterable<S> artists);
+    List<ArtistMongo> saveAll(List<ArtistMongo> artists);
 
     void delete(ArtistMongo artist);
 

--- a/src/main/java/com/projectlyrics/server/domain/artist/repository/ArtistMongoCommandRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/artist/repository/ArtistMongoCommandRepository.java
@@ -1,0 +1,9 @@
+package com.projectlyrics.server.domain.artist.repository;
+
+import com.projectlyrics.server.domain.artist.entity.ArtistMongo;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ArtistMongoCommandRepository extends MongoRepository<ArtistMongo, Long> {
+}

--- a/src/main/java/com/projectlyrics/server/domain/artist/repository/ArtistMongoQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/artist/repository/ArtistMongoQueryRepository.java
@@ -1,0 +1,7 @@
+package com.projectlyrics.server.domain.artist.repository;
+
+import com.projectlyrics.server.domain.common.dto.util.IdsWithHasNext;
+
+public interface ArtistMongoQueryRepository {
+    IdsWithHasNext searchArtistIdsByName(String query, int offset, int limit);
+}

--- a/src/main/java/com/projectlyrics/server/domain/artist/repository/ArtistQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/artist/repository/ArtistQueryRepository.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
-public interface ArtistQueryRepository{
+public interface ArtistQueryRepository {
 
     Optional<Artist> findById(Long artistId);
 
@@ -20,5 +20,5 @@ public interface ArtistQueryRepository{
 
     List<Artist> findAllByIds(List<Long> artistIds);
 
-    List<Artist> findAllByIdsInOrder(List<Long> artistIds);
+    List<Artist> findAllByIdsInListOrder(List<Long> artistIds);
 }

--- a/src/main/java/com/projectlyrics/server/domain/artist/repository/ArtistQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/artist/repository/ArtistQueryRepository.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
-public interface ArtistQueryRepository {
+public interface ArtistQueryRepository{
 
     Optional<Artist> findById(Long artistId);
 
@@ -19,4 +19,6 @@ public interface ArtistQueryRepository {
     List<Artist> findAll();
 
     List<Artist> findAllByIds(List<Long> artistIds);
+
+    List<Artist> findAllByIdsInOrder(List<Long> artistIds);
 }

--- a/src/main/java/com/projectlyrics/server/domain/artist/repository/impl/AritstMongoDelegateRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/artist/repository/impl/AritstMongoDelegateRepository.java
@@ -1,0 +1,9 @@
+package com.projectlyrics.server.domain.artist.repository.impl;
+
+import com.projectlyrics.server.domain.artist.entity.ArtistMongo;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AritstMongoDelegateRepository extends MongoRepository<ArtistMongo, Long> {
+}

--- a/src/main/java/com/projectlyrics/server/domain/artist/repository/impl/ArtistMongoCommandRepositoryImpl.java
+++ b/src/main/java/com/projectlyrics/server/domain/artist/repository/impl/ArtistMongoCommandRepositoryImpl.java
@@ -1,0 +1,36 @@
+package com.projectlyrics.server.domain.artist.repository.impl;
+
+import com.projectlyrics.server.domain.artist.entity.ArtistMongo;
+import com.projectlyrics.server.domain.artist.repository.ArtistMongoCommandRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@Profile({"dev", "prod"})
+@RequiredArgsConstructor
+public class ArtistMongoCommandRepositoryImpl implements ArtistMongoCommandRepository {
+
+    private final AritstMongoDelegateRepository delegate;
+
+    @Override
+    public ArtistMongo save(ArtistMongo artist) {
+        return delegate.save(artist);
+    }
+
+    @Override
+    public <S extends ArtistMongo> List<S> saveAll(Iterable<S> artists) {
+        return delegate.saveAll(artists);
+    }
+
+    @Override
+    public void delete(ArtistMongo artist) {
+        delegate.delete(artist);
+    }
+
+    @Override
+    public void deleteAll() {
+        delegate.deleteAll();
+    }
+}

--- a/src/main/java/com/projectlyrics/server/domain/artist/repository/impl/ArtistMongoCommandRepositoryImpl.java
+++ b/src/main/java/com/projectlyrics/server/domain/artist/repository/impl/ArtistMongoCommandRepositoryImpl.java
@@ -20,7 +20,7 @@ public class ArtistMongoCommandRepositoryImpl implements ArtistMongoCommandRepos
     }
 
     @Override
-    public <S extends ArtistMongo> List<S> saveAll(Iterable<S> artists) {
+    public List<ArtistMongo> saveAll(List<ArtistMongo> artists) {
         return delegate.saveAll(artists);
     }
 

--- a/src/main/java/com/projectlyrics/server/domain/artist/repository/impl/ArtistMongoQueryRepositoryImpl.java
+++ b/src/main/java/com/projectlyrics/server/domain/artist/repository/impl/ArtistMongoQueryRepositoryImpl.java
@@ -1,0 +1,55 @@
+package com.projectlyrics.server.domain.artist.repository.impl;
+
+import com.projectlyrics.server.domain.artist.repository.ArtistMongoQueryRepository;
+import com.projectlyrics.server.domain.common.dto.util.IdsWithHasNext;
+import java.util.List;
+import org.bson.Document;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.AggregationOperation;
+import org.springframework.data.mongodb.core.aggregation.AggregationResults;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class ArtistMongoQueryRepositoryImpl implements ArtistMongoQueryRepository {
+
+    private final MongoTemplate mongoTemplate;
+
+    public ArtistMongoQueryRepositoryImpl(MongoTemplate mongoTemplate) {
+        this.mongoTemplate = mongoTemplate;
+    }
+
+    public IdsWithHasNext searchArtistIdsByName(String query, int offset, int limit) {
+        // edgeGram autocomplete
+        AggregationOperation searchStage = context -> new Document("$search",
+                new Document("index", "artists_search_index")
+                        .append("autocomplete", new Document()
+                                .append("query", query)
+                                .append("path", "search_names")
+                                .append("tokenOrder", "any")
+                        )
+        );
+
+        AggregationOperation projectStage = Aggregation.project("_id");
+        AggregationOperation skipStage = Aggregation.skip(offset);
+        AggregationOperation limitStage = Aggregation.limit(limit + 1);
+
+        Aggregation aggregation = Aggregation.newAggregation(searchStage, projectStage, skipStage, limitStage);
+
+        AggregationResults<Document> results =
+                mongoTemplate.aggregate(aggregation, "artists", Document.class);
+
+        List<Long> ids = results.getMappedResults().stream()
+                .map(doc -> doc.get("_id", Long.class))
+                .toList();
+
+        boolean hasNext = ids.size() > limit;
+
+        if (hasNext) {
+            ids = ids.subList(0, limit);
+        }
+
+        return new IdsWithHasNext(ids, hasNext);
+    }
+}
+

--- a/src/main/java/com/projectlyrics/server/domain/artist/repository/impl/ArtistMongoQueryRepositoryImpl.java
+++ b/src/main/java/com/projectlyrics/server/domain/artist/repository/impl/ArtistMongoQueryRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.projectlyrics.server.domain.artist.repository.ArtistMongoQueryReposit
 import com.projectlyrics.server.domain.common.dto.util.IdsWithHasNext;
 import java.util.List;
 import org.bson.Document;
+import org.springframework.context.annotation.Profile;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
 import org.springframework.data.mongodb.core.aggregation.AggregationOperation;
@@ -11,6 +12,7 @@ import org.springframework.data.mongodb.core.aggregation.AggregationResults;
 import org.springframework.stereotype.Repository;
 
 @Repository
+@Profile({"dev", "prod"})
 public class ArtistMongoQueryRepositoryImpl implements ArtistMongoQueryRepository {
 
     private final MongoTemplate mongoTemplate;

--- a/src/main/java/com/projectlyrics/server/domain/artist/repository/impl/QueryDslArtistQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/artist/repository/impl/QueryDslArtistQueryRepository.java
@@ -1,6 +1,6 @@
 package com.projectlyrics.server.domain.artist.repository.impl;
 
-import static com.projectlyrics.server.domain.artist.entity.QArtist.*;
+import static com.projectlyrics.server.domain.artist.entity.QArtist.artist;
 import static com.querydsl.core.types.dsl.Expressions.anyOf;
 
 import com.projectlyrics.server.domain.artist.entity.Artist;
@@ -8,11 +8,11 @@ import com.projectlyrics.server.domain.artist.repository.ArtistQueryRepository;
 import com.projectlyrics.server.domain.common.util.QueryDslUtils;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-
 import java.util.List;
 import java.util.Optional;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -95,5 +95,19 @@ public class QueryDslArtistQueryRepository implements ArtistQueryRepository {
                 .fetch();
 
         return new SliceImpl<>(content, pageable, QueryDslUtils.checkIfHasNext(pageable, content));
+    }
+
+    @Override
+    public List<Artist> findAllByIdsInOrder(List<Long> artistIds) {
+
+        NumberExpression<Integer> orderExpression =
+                Expressions.numberTemplate(Integer.class, "FIELD({0}, {1})", artist.id,
+                        artistIds.stream().map(String::valueOf).toArray());
+
+        return jpaQueryFactory
+                .selectFrom(artist)
+                .where(artist.id.in(artistIds))
+                .orderBy(orderExpression.asc())
+                .fetch();
     }
 }

--- a/src/main/java/com/projectlyrics/server/domain/artist/repository/impl/QueryDslArtistQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/artist/repository/impl/QueryDslArtistQueryRepository.java
@@ -98,7 +98,7 @@ public class QueryDslArtistQueryRepository implements ArtistQueryRepository {
     }
 
     @Override
-    public List<Artist> findAllByIdsInOrder(List<Long> artistIds) {
+    public List<Artist> findAllByIdsInListOrder(List<Long> artistIds) {
 
         NumberExpression<Integer> orderExpression =
                 Expressions.numberTemplate(Integer.class, "FIELD({0}, {1})", artist.id,

--- a/src/main/java/com/projectlyrics/server/domain/artist/repository/noop/NoOpArtistMongoCommandRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/artist/repository/noop/NoOpArtistMongoCommandRepository.java
@@ -16,7 +16,7 @@ public class NoOpArtistMongoCommandRepository implements ArtistMongoCommandRepos
     }
 
     @Override
-    public <S extends ArtistMongo> List<S> saveAll(Iterable<S> artists) {
+    public List<ArtistMongo> saveAll(List<ArtistMongo> artists) {
         return List.of();
     }
 

--- a/src/main/java/com/projectlyrics/server/domain/artist/repository/noop/NoOpArtistMongoCommandRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/artist/repository/noop/NoOpArtistMongoCommandRepository.java
@@ -1,0 +1,31 @@
+package com.projectlyrics.server.domain.artist.repository.noop;
+
+import com.projectlyrics.server.domain.artist.entity.ArtistMongo;
+import com.projectlyrics.server.domain.artist.repository.ArtistMongoCommandRepository;
+import java.util.List;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@Profile({"!dev", "!prod"})
+public class NoOpArtistMongoCommandRepository implements ArtistMongoCommandRepository {
+
+    @Override
+    public ArtistMongo save(ArtistMongo artist) {
+        return artist;
+    }
+
+    @Override
+    public <S extends ArtistMongo> List<S> saveAll(Iterable<S> artists) {
+        return List.of();
+    }
+
+    @Override
+    public void delete(ArtistMongo artist) {
+    }
+
+    @Override
+    public void deleteAll() {
+    }
+}
+

--- a/src/main/java/com/projectlyrics/server/domain/artist/repository/noop/NoOpArtistMongoQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/artist/repository/noop/NoOpArtistMongoQueryRepository.java
@@ -1,0 +1,16 @@
+package com.projectlyrics.server.domain.artist.repository.noop;
+
+import com.projectlyrics.server.domain.artist.repository.ArtistMongoQueryRepository;
+import com.projectlyrics.server.domain.common.dto.util.IdsWithHasNext;
+import java.util.List;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@Profile({"!dev", "!prod"})
+public class NoOpArtistMongoQueryRepository implements ArtistMongoQueryRepository {
+    @Override
+    public IdsWithHasNext searchArtistIdsByName(String query, int offset, int limit) {
+        return new IdsWithHasNext(List.of(), false);
+    }
+}

--- a/src/main/java/com/projectlyrics/server/domain/artist/service/ArtistCommandService.java
+++ b/src/main/java/com/projectlyrics/server/domain/artist/service/ArtistCommandService.java
@@ -4,18 +4,20 @@ import com.projectlyrics.server.domain.artist.dto.request.ArtistCreateRequest;
 import com.projectlyrics.server.domain.artist.dto.request.ArtistUpdateRequest;
 import com.projectlyrics.server.domain.artist.entity.Artist;
 import com.projectlyrics.server.domain.artist.entity.ArtistCreate;
+import com.projectlyrics.server.domain.artist.entity.ArtistMongo;
 import com.projectlyrics.server.domain.artist.entity.ArtistUpdate;
 import com.projectlyrics.server.domain.artist.exception.ArtistNotFoundException;
 import com.projectlyrics.server.domain.artist.repository.ArtistCommandRepository;
+import com.projectlyrics.server.domain.artist.repository.ArtistMongoCommandRepository;
 import com.projectlyrics.server.domain.artist.repository.ArtistQueryRepository;
-
 import java.time.Clock;
 import java.time.LocalDateTime;
-
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @RequiredArgsConstructor
 @Transactional
 @Service
@@ -23,16 +25,31 @@ public class ArtistCommandService {
 
     private final ArtistCommandRepository artistCommandRepository;
     private final ArtistQueryRepository artistQueryRepository;
+    private final ArtistMongoCommandRepository artistMongoCommandRepository;
 
     public Artist create(ArtistCreateRequest request) {
-        return artistCommandRepository.save(Artist.create(ArtistCreate.from(request)));
+        Artist artist = artistCommandRepository.save(Artist.create(ArtistCreate.from(request)));
+
+        try {
+            artistMongoCommandRepository.save(ArtistMongo.of(artist));
+        } catch (Exception e) {
+            log.warn("MongoDB create failed for artist id {}: {}", artist.getId(), e.getMessage());
+        }
+        return artist;
     }
 
     public Artist update(Long artistId, ArtistUpdateRequest request) {
         Artist artist = artistQueryRepository.findById(artistId)
                 .orElseThrow(ArtistNotFoundException::new);
 
-        return artist.update(ArtistUpdate.from(request));
+        Artist updatedArtist = artist.update(ArtistUpdate.from(request));
+
+        try {
+            artistMongoCommandRepository.save(ArtistMongo.of(updatedArtist));
+        } catch (Exception e) {
+            log.warn("MongoDB update failed for artist id {}: {}", artistId, e.getMessage());
+        }
+        return updatedArtist;
     }
 
     public void delete(Long artistId, Long deletedBy) {
@@ -40,5 +57,10 @@ public class ArtistCommandService {
                 .orElseThrow(ArtistNotFoundException::new);
 
         artist.delete(deletedBy, LocalDateTime.now(Clock.systemDefaultZone()));
+        try {
+            artistMongoCommandRepository.delete(ArtistMongo.of(artist));
+        } catch (Exception e) {
+            log.warn("MongoDB delete failed for artist id {}: {}", artist.getId(), e.getMessage());
+        }
     }
 }

--- a/src/main/java/com/projectlyrics/server/domain/artist/service/ArtistQueryService.java
+++ b/src/main/java/com/projectlyrics/server/domain/artist/service/ArtistQueryService.java
@@ -47,7 +47,7 @@ public class ArtistQueryService {
             return searchArtistsWithLike(query, pageable);
         }
 
-        List<ArtistGetResponse> artists = artistQueryRepository.findAllByIdsInOrder(artistIds).stream()
+        List<ArtistGetResponse> artists = artistQueryRepository.findAllByIdsInListOrder(artistIds).stream()
                 .map(ArtistGetResponse::of)
                 .toList();
 

--- a/src/main/java/com/projectlyrics/server/domain/artist/service/ArtistQueryService.java
+++ b/src/main/java/com/projectlyrics/server/domain/artist/service/ArtistQueryService.java
@@ -3,8 +3,11 @@ package com.projectlyrics.server.domain.artist.service;
 import com.projectlyrics.server.domain.artist.dto.response.ArtistGetResponse;
 import com.projectlyrics.server.domain.artist.entity.Artist;
 import com.projectlyrics.server.domain.artist.exception.ArtistNotFoundException;
+import com.projectlyrics.server.domain.artist.repository.ArtistMongoQueryRepository;
 import com.projectlyrics.server.domain.artist.repository.ArtistQueryRepository;
+import com.projectlyrics.server.domain.common.dto.util.IdsWithHasNext;
 import com.projectlyrics.server.domain.common.dto.util.OffsetBasePaginatedResponse;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -17,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ArtistQueryService {
 
     private final ArtistQueryRepository artistQueryRepository;
+    private final ArtistMongoQueryRepository artistMongoQueryRepository;
 
     public Artist getArtistById(long artistId) {
         return artistQueryRepository.findById(artistId)
@@ -31,9 +35,28 @@ public class ArtistQueryService {
     }
 
     public OffsetBasePaginatedResponse<ArtistGetResponse> searchArtists(String query, Pageable pageable) {
-        Slice<ArtistGetResponse> searchedArtists = artistQueryRepository.findAllByQuery(query, pageable)
-                .map(ArtistGetResponse::of);
+        IdsWithHasNext idsWithHasNext = artistMongoQueryRepository.searchArtistIdsByName(
+                query,
+                (int) pageable.getOffset(),
+                pageable.getPageSize()
+        );
 
-        return OffsetBasePaginatedResponse.of(searchedArtists);
+        List<Long> artistIds = idsWithHasNext.ids();
+
+        if (artistIds.size() == 0 && pageable.getOffset() == 0) {
+            Slice<ArtistGetResponse> searchedArtists = artistQueryRepository.findAllByQuery(query, pageable)
+                    .map(ArtistGetResponse::of);
+            return OffsetBasePaginatedResponse.of(searchedArtists);
+        }
+
+        List<ArtistGetResponse> artists = artistQueryRepository.findAllByIdsInOrder(artistIds).stream()
+                .map(ArtistGetResponse::of)
+                .toList();
+
+        return OffsetBasePaginatedResponse.of(
+                pageable.getPageNumber(),
+                idsWithHasNext.hasNext(),
+                artists
+        );
     }
 }

--- a/src/main/java/com/projectlyrics/server/domain/artist/service/ArtistQueryService.java
+++ b/src/main/java/com/projectlyrics/server/domain/artist/service/ArtistQueryService.java
@@ -44,9 +44,7 @@ public class ArtistQueryService {
         List<Long> artistIds = idsWithHasNext.ids();
 
         if (artistIds.size() == 0 && pageable.getOffset() == 0) {
-            Slice<ArtistGetResponse> searchedArtists = artistQueryRepository.findAllByQuery(query, pageable)
-                    .map(ArtistGetResponse::of);
-            return OffsetBasePaginatedResponse.of(searchedArtists);
+            return searchArtistsWithLike(query, pageable);
         }
 
         List<ArtistGetResponse> artists = artistQueryRepository.findAllByIdsInOrder(artistIds).stream()
@@ -60,7 +58,6 @@ public class ArtistQueryService {
         );
     }
 
-    // 테스트용. 기존 search
     public OffsetBasePaginatedResponse<ArtistGetResponse> searchArtistsWithLike(String query, Pageable pageable) {
         Slice<ArtistGetResponse> searchedArtists = artistQueryRepository.findAllByQuery(query, pageable)
                 .map(ArtistGetResponse::of);

--- a/src/main/java/com/projectlyrics/server/domain/artist/service/ArtistQueryService.java
+++ b/src/main/java/com/projectlyrics/server/domain/artist/service/ArtistQueryService.java
@@ -59,4 +59,11 @@ public class ArtistQueryService {
                 artists
         );
     }
+
+    // 테스트용. 기존 search
+    public OffsetBasePaginatedResponse<ArtistGetResponse> searchArtistsWithLike(String query, Pageable pageable) {
+        Slice<ArtistGetResponse> searchedArtists = artistQueryRepository.findAllByQuery(query, pageable)
+                .map(ArtistGetResponse::of);
+        return OffsetBasePaginatedResponse.of(searchedArtists);
+    }
 }

--- a/src/main/java/com/projectlyrics/server/domain/auth/authentication/interceptor/DeviceIdInterceptor.java
+++ b/src/main/java/com/projectlyrics/server/domain/auth/authentication/interceptor/DeviceIdInterceptor.java
@@ -3,7 +3,6 @@ package com.projectlyrics.server.domain.auth.authentication.interceptor;
 import com.projectlyrics.server.domain.auth.authentication.AuthContext;
 import com.projectlyrics.server.domain.auth.exception.NotRegisteredDeviceException;
 import com.projectlyrics.server.domain.auth.repository.AuthRepository;
-import com.projectlyrics.server.domain.user.exception.UserNotFoundException;
 import com.projectlyrics.server.domain.user.repository.UserQueryRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -59,9 +58,6 @@ public class DeviceIdInterceptor implements HandlerInterceptor {
     }
 
     private boolean isOldDevice(String deviceId) {
-        return userQueryRepository.findById(authContext.getId())
-                .map(user -> authRepository.findBySocialIdAndDeviceId(user.getSocialInfo().getSocialId(), deviceId))
-                .orElseThrow(() -> new UserNotFoundException())
-                .isEmpty();
+        return authRepository.findByDeviceId(deviceId).isEmpty();
     }
 }

--- a/src/main/java/com/projectlyrics/server/domain/common/dto/util/IdsWithHasNext.java
+++ b/src/main/java/com/projectlyrics/server/domain/common/dto/util/IdsWithHasNext.java
@@ -1,0 +1,6 @@
+package com.projectlyrics.server.domain.common.dto.util;
+
+import java.util.List;
+
+public record IdsWithHasNext(List<Long> ids, boolean hasNext) {}
+

--- a/src/main/java/com/projectlyrics/server/domain/common/dto/util/OffsetBasePaginatedResponse.java
+++ b/src/main/java/com/projectlyrics/server/domain/common/dto/util/OffsetBasePaginatedResponse.java
@@ -25,4 +25,8 @@ public record OffsetBasePaginatedResponse<T>(
 
         return new OffsetBasePaginatedResponse<>(pageNumber, false, data);
     }
+
+    public  static  <T> OffsetBasePaginatedResponse<T> of(int pageNumber, boolean hasNext, List<T> data) {
+        return new OffsetBasePaginatedResponse<>(pageNumber, hasNext, data);
+    }
 }

--- a/src/main/java/com/projectlyrics/server/domain/song/entity/Song.java
+++ b/src/main/java/com/projectlyrics/server/domain/song/entity/Song.java
@@ -5,15 +5,23 @@ import com.projectlyrics.server.domain.common.entity.BaseEntity;
 import com.projectlyrics.server.domain.note.entity.Note;
 import com.projectlyrics.server.global.dev.cron.dto.Album;
 import com.projectlyrics.server.global.dev.cron.dto.Track;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
+import lombok.Setter;
 
 @Getter
 @Entity
@@ -24,6 +32,7 @@ public class Song extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Setter
     private Long id;
 
     @Column(unique = true, nullable = false)

--- a/src/main/java/com/projectlyrics/server/domain/song/entity/SongMongo.java
+++ b/src/main/java/com/projectlyrics/server/domain/song/entity/SongMongo.java
@@ -11,19 +11,15 @@ public class SongMongo {
     @Getter
     private final Long id;
 
-    @Field("artist_id")
-    private final Long artistId;
-
     @Field("name")
     private final String name;
 
-    private SongMongo(Long id, Long artistId, String name) {
+    private SongMongo(Long id, String name) {
         this.id = id;
-        this.artistId = artistId;
         this.name = name;
     }
 
     public static SongMongo of(Song song) {
-        return new SongMongo(song.getId(), song.getArtist().getId(), song.getName());
+        return new SongMongo(song.getId(), song.getName());
     }
 }

--- a/src/main/java/com/projectlyrics/server/domain/song/entity/SongMongo.java
+++ b/src/main/java/com/projectlyrics/server/domain/song/entity/SongMongo.java
@@ -1,12 +1,14 @@
 package com.projectlyrics.server.domain.song.entity;
 
 import jakarta.persistence.Id;
+import lombok.Getter;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 
 @Document(collection = "songs")
 public class SongMongo {
     @Id
+    @Getter
     private final Long id;
 
     @Field("artist_id")

--- a/src/main/java/com/projectlyrics/server/domain/song/entity/SongMongo.java
+++ b/src/main/java/com/projectlyrics/server/domain/song/entity/SongMongo.java
@@ -1,0 +1,23 @@
+package com.projectlyrics.server.domain.song.entity;
+
+import jakarta.persistence.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+@Document(collection = "songs")
+public class SongMongo {
+    @Id
+    private final Long id;
+
+    @Field("artist_id")
+    private final Long artistId;
+
+    @Field("name")
+    private final String name;
+
+    public SongMongo(Long id, Long artistId, String name) {
+        this.id = id;
+        this.artistId = artistId;
+        this.name = name;
+    }
+}

--- a/src/main/java/com/projectlyrics/server/domain/song/entity/SongMongo.java
+++ b/src/main/java/com/projectlyrics/server/domain/song/entity/SongMongo.java
@@ -15,9 +15,13 @@ public class SongMongo {
     @Field("name")
     private final String name;
 
-    public SongMongo(Long id, Long artistId, String name) {
+    private SongMongo(Long id, Long artistId, String name) {
         this.id = id;
         this.artistId = artistId;
         this.name = name;
+    }
+
+    public static SongMongo of(Song song) {
+        return new SongMongo(song.getId(), song.getArtist().getId(), song.getName());
     }
 }

--- a/src/main/java/com/projectlyrics/server/domain/song/repository/SongCommandRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/song/repository/SongCommandRepository.java
@@ -7,5 +7,6 @@ import java.util.List;
 public interface SongCommandRepository {
 
     Song save(Song song);
-    void saveAll(List<Song> songs);
+
+    List<Song> saveAll(List<Song> songs);
 }

--- a/src/main/java/com/projectlyrics/server/domain/song/repository/SongCommandRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/song/repository/SongCommandRepository.java
@@ -9,4 +9,6 @@ public interface SongCommandRepository {
     Song save(Song song);
 
     List<Song> saveAll(List<Song> songs);
+
+    void deleteAll();
 }

--- a/src/main/java/com/projectlyrics/server/domain/song/repository/SongMongoCommandRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/song/repository/SongMongoCommandRepository.java
@@ -6,7 +6,7 @@ import java.util.List;
 public interface SongMongoCommandRepository {
     SongMongo save(SongMongo song);
 
-    <S extends SongMongo> List<S> saveAll(Iterable<S> songs);
+    List<SongMongo> saveAll(List<SongMongo> songs);
 
     void deleteAll();
 }

--- a/src/main/java/com/projectlyrics/server/domain/song/repository/SongMongoCommandRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/song/repository/SongMongoCommandRepository.java
@@ -1,0 +1,9 @@
+package com.projectlyrics.server.domain.song.repository;
+
+import com.projectlyrics.server.domain.song.entity.SongMongo;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SongMongoCommandRepository extends MongoRepository<SongMongo, Long> {
+}

--- a/src/main/java/com/projectlyrics/server/domain/song/repository/SongMongoCommandRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/song/repository/SongMongoCommandRepository.java
@@ -1,9 +1,12 @@
 package com.projectlyrics.server.domain.song.repository;
 
 import com.projectlyrics.server.domain.song.entity.SongMongo;
-import org.springframework.data.mongodb.repository.MongoRepository;
-import org.springframework.stereotype.Repository;
+import java.util.List;
 
-@Repository
-public interface SongMongoCommandRepository extends MongoRepository<SongMongo, Long> {
+public interface SongMongoCommandRepository {
+    SongMongo save(SongMongo song);
+
+    <S extends SongMongo> List<S> saveAll(Iterable<S> songs);
+
+    void deleteAll();
 }

--- a/src/main/java/com/projectlyrics/server/domain/song/repository/SongMongoQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/song/repository/SongMongoQueryRepository.java
@@ -1,0 +1,7 @@
+package com.projectlyrics.server.domain.song.repository;
+
+import com.projectlyrics.server.domain.common.dto.util.IdsWithHasNext;
+
+public interface SongMongoQueryRepository {
+    IdsWithHasNext searchSongsByName(String query, int offset, int limit);
+}

--- a/src/main/java/com/projectlyrics/server/domain/song/repository/SongMongoQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/song/repository/SongMongoQueryRepository.java
@@ -1,7 +1,10 @@
 package com.projectlyrics.server.domain.song.repository;
 
 import com.projectlyrics.server.domain.common.dto.util.IdsWithHasNext;
+import java.util.List;
 
 public interface SongMongoQueryRepository {
     IdsWithHasNext searchSongsByName(String query, int offset, int limit);
+
+    List<Long> findAllIdByIdIn(List<Long> ids);
 }

--- a/src/main/java/com/projectlyrics/server/domain/song/repository/SongMongoQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/song/repository/SongMongoQueryRepository.java
@@ -6,5 +6,5 @@ import java.util.List;
 public interface SongMongoQueryRepository {
     IdsWithHasNext searchSongsByName(String query, int offset, int limit);
 
-    List<Long> findAllIdByIdIn(List<Long> ids);
+    List<Long> findAllByIdsIn(List<Long> ids);
 }

--- a/src/main/java/com/projectlyrics/server/domain/song/repository/SongQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/song/repository/SongQueryRepository.java
@@ -20,6 +20,8 @@ public interface SongQueryRepository {
 
     List<Song> findAll();
 
+    Slice<Song> findAll(Pageable pageable);
+
     List<Song> findAllByIds(List<Long> ids);
 
     List<Song> findAllByIdsInOrder(List<Long> songIds);

--- a/src/main/java/com/projectlyrics/server/domain/song/repository/SongQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/song/repository/SongQueryRepository.java
@@ -1,7 +1,6 @@
 package com.projectlyrics.server.domain.song.repository;
 
 import com.projectlyrics.server.domain.song.entity.Song;
-
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
@@ -10,9 +9,16 @@ import org.springframework.data.domain.Slice;
 public interface SongQueryRepository {
 
     Optional<Song> findById(Long id);
+
     Optional<Song> findBySpotifyId(String spotifyId);
+
     Slice<Song> findAllOrderByNoteCountDesc(Pageable pageable);
+
+    Slice<Song> findAllByQuery(String query, Pageable pageable);
+
     Slice<Song> findAllByQueryAndArtistId(Long artistId, String query, Long cursor, Pageable pageable);
+
     List<Song> findAll();
+
     List<Song> findAllByIds(List<Long> ids);
 }

--- a/src/main/java/com/projectlyrics/server/domain/song/repository/SongQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/song/repository/SongQueryRepository.java
@@ -21,4 +21,6 @@ public interface SongQueryRepository {
     List<Song> findAll();
 
     List<Song> findAllByIds(List<Long> ids);
+
+    List<Song> findAllByIdsInOrder(List<Long> songIds);
 }

--- a/src/main/java/com/projectlyrics/server/domain/song/repository/SongQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/song/repository/SongQueryRepository.java
@@ -24,5 +24,5 @@ public interface SongQueryRepository {
 
     List<Song> findAllByIds(List<Long> ids);
 
-    List<Song> findAllByIdsInOrder(List<Long> songIds);
+    List<Song> findAllByIdsInListOrder(List<Long> songIds);
 }

--- a/src/main/java/com/projectlyrics/server/domain/song/repository/impl/JdbcSongCommandRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/song/repository/impl/JdbcSongCommandRepository.java
@@ -22,6 +22,7 @@ public class JdbcSongCommandRepository implements SongCommandRepository {
     private final JdbcTemplate jdbcTemplate;
     private final String insertQuery = "INSERT INTO songs (artist_id, spotify_id, name, release_date, album_name, image_url, created_at, created_by, status, updated_by) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
     private final String insertQueryWithId = "INSERT INTO songs (id, artist_id, spotify_id, name, release_date, album_name, image_url, created_at, created_by, status, updated_by) VALUES (?, ?, ?, ?, ?, ?, ?, ? ,? ,?, ?)";
+    private final String deleteQuery = "DELETE FROM songs";
 
     @Override
     public Song save(Song song) {
@@ -98,5 +99,10 @@ public class JdbcSongCommandRepository implements SongCommandRepository {
         });
 
         return songs;
+    }
+
+    @Override
+    public void deleteAll() {
+        jdbcTemplate.update(deleteQuery);
     }
 }

--- a/src/main/java/com/projectlyrics/server/domain/song/repository/impl/QueryDslSongQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/song/repository/impl/QueryDslSongQueryRepository.java
@@ -68,6 +68,21 @@ public class QueryDslSongQueryRepository implements SongQueryRepository {
     }
 
     @Override
+    public Slice<Song> findAllByQuery(String query, Pageable pageable) {
+        List<Song> content = jpaQueryFactory
+                .selectFrom(song)
+                .where(
+                        songNameContains(query)
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
+                .orderBy(song.id.desc())
+                .fetch();
+
+        return new SliceImpl<>(content, pageable, QueryDslUtils.checkIfHasNext(pageable, content));
+    }
+
+    @Override
     public Slice<Song> findAllByQueryAndArtistId(Long artistId, String query, Long cursor, Pageable pageable) {
         List<Song> content = jpaQueryFactory
                 .selectFrom(song)

--- a/src/main/java/com/projectlyrics/server/domain/song/repository/impl/QueryDslSongQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/song/repository/impl/QueryDslSongQueryRepository.java
@@ -116,6 +116,17 @@ public class QueryDslSongQueryRepository implements SongQueryRepository {
     }
 
     @Override
+    public Slice<Song> findAll(Pageable pageable) {
+        List<Song> content = jpaQueryFactory
+                .selectFrom(song)
+                .orderBy(song.id.asc())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+
+        return new SliceImpl<>(content, pageable, QueryDslUtils.checkIfHasNext(pageable, content));
+    }
+
+    @Override
     public List<Song> findAllByIds(List<Long> ids) {
         return jpaQueryFactory
                 .selectFrom(song)

--- a/src/main/java/com/projectlyrics/server/domain/song/repository/impl/QueryDslSongQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/song/repository/impl/QueryDslSongQueryRepository.java
@@ -9,6 +9,7 @@ import com.projectlyrics.server.domain.song.entity.Song;
 import com.projectlyrics.server.domain.song.repository.SongQueryRepository;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import java.util.Objects;
@@ -121,6 +122,21 @@ public class QueryDslSongQueryRepository implements SongQueryRepository {
                 .leftJoin(song.notes, note).fetchJoin()
                 .join(song.artist, artist).fetchJoin()
                 .where(song.id.in(ids))
+                .fetch();
+    }
+
+    @Override
+    public List<Song> findAllByIdsInOrder(List<Long> songIds) {
+        NumberExpression<Integer> orderExpression =
+                Expressions.numberTemplate(Integer.class, "FIELD({0}, {1})", song.id,
+                        songIds.stream().map(String::valueOf).toArray());
+
+        return jpaQueryFactory
+                .selectFrom(song)
+                .leftJoin(song.notes, note).fetchJoin()
+                .join(song.artist, artist).fetchJoin()
+                .where(song.id.in(songIds))
+                .orderBy(orderExpression.asc())
                 .fetch();
     }
 }

--- a/src/main/java/com/projectlyrics/server/domain/song/repository/impl/QueryDslSongQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/song/repository/impl/QueryDslSongQueryRepository.java
@@ -137,7 +137,7 @@ public class QueryDslSongQueryRepository implements SongQueryRepository {
     }
 
     @Override
-    public List<Song> findAllByIdsInOrder(List<Long> songIds) {
+    public List<Song> findAllByIdsInListOrder(List<Long> songIds) {
         NumberExpression<Integer> orderExpression =
                 Expressions.numberTemplate(Integer.class, "FIELD({0}, {1})", song.id,
                         songIds.stream().map(String::valueOf).toArray());

--- a/src/main/java/com/projectlyrics/server/domain/song/repository/impl/SongMongoCommandRepositoryImpl.java
+++ b/src/main/java/com/projectlyrics/server/domain/song/repository/impl/SongMongoCommandRepositoryImpl.java
@@ -20,7 +20,7 @@ public class SongMongoCommandRepositoryImpl implements SongMongoCommandRepositor
     }
 
     @Override
-    public <S extends SongMongo> List<S> saveAll(Iterable<S> songs) {
+    public List<SongMongo> saveAll(List<SongMongo> songs) {
         return delegate.saveAll(songs);
     }
 

--- a/src/main/java/com/projectlyrics/server/domain/song/repository/impl/SongMongoCommandRepositoryImpl.java
+++ b/src/main/java/com/projectlyrics/server/domain/song/repository/impl/SongMongoCommandRepositoryImpl.java
@@ -1,0 +1,32 @@
+package com.projectlyrics.server.domain.song.repository.impl;
+
+import com.projectlyrics.server.domain.song.entity.SongMongo;
+import com.projectlyrics.server.domain.song.repository.SongMongoCommandRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@Profile({"dev", "prod"})
+@RequiredArgsConstructor
+public class SongMongoCommandRepositoryImpl implements SongMongoCommandRepository {
+
+    private final SongMongoDelegateRepository delegate;
+
+    @Override
+    public SongMongo save(SongMongo song) {
+        return delegate.save(song);
+    }
+
+    @Override
+    public <S extends SongMongo> List<S> saveAll(Iterable<S> songs) {
+        return delegate.saveAll(songs);
+    }
+
+    @Override
+    public void deleteAll() {
+        delegate.deleteAll();
+    }
+}
+

--- a/src/main/java/com/projectlyrics/server/domain/song/repository/impl/SongMongoDelegateRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/song/repository/impl/SongMongoDelegateRepository.java
@@ -1,0 +1,10 @@
+package com.projectlyrics.server.domain.song.repository.impl;
+
+import com.projectlyrics.server.domain.song.entity.SongMongo;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SongMongoDelegateRepository extends MongoRepository<SongMongo, Long> {
+}
+

--- a/src/main/java/com/projectlyrics/server/domain/song/repository/impl/SongMongoQueryRepositoryImpl.java
+++ b/src/main/java/com/projectlyrics/server/domain/song/repository/impl/SongMongoQueryRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.projectlyrics.server.domain.song.repository.impl;
 
 import com.projectlyrics.server.domain.common.dto.util.IdsWithHasNext;
+import com.projectlyrics.server.domain.song.entity.SongMongo;
 import com.projectlyrics.server.domain.song.repository.SongMongoQueryRepository;
 import java.util.Arrays;
 import java.util.List;
@@ -9,6 +10,8 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
 import org.springframework.data.mongodb.core.aggregation.AggregationOperation;
 import org.springframework.data.mongodb.core.aggregation.AggregationResults;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -75,5 +78,14 @@ public class SongMongoQueryRepositoryImpl implements SongMongoQueryRepository {
         }
 
         return new IdsWithHasNext(ids, hasNext);
+    }
+
+    public List<Long> findAllIdByIdIn(List<Long> ids) {
+        Query query = new Query(Criteria.where("_id").in(ids));
+        query.fields().include("_id");
+        return mongoTemplate.find(query, SongMongo.class)
+                .stream()
+                .map(SongMongo::getId)
+                .toList();
     }
 }

--- a/src/main/java/com/projectlyrics/server/domain/song/repository/impl/SongMongoQueryRepositoryImpl.java
+++ b/src/main/java/com/projectlyrics/server/domain/song/repository/impl/SongMongoQueryRepositoryImpl.java
@@ -6,6 +6,7 @@ import com.projectlyrics.server.domain.song.repository.SongMongoQueryRepository;
 import java.util.Arrays;
 import java.util.List;
 import org.bson.Document;
+import org.springframework.context.annotation.Profile;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
 import org.springframework.data.mongodb.core.aggregation.AggregationOperation;
@@ -15,6 +16,7 @@ import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
+@Profile({"dev", "prod"})
 public class SongMongoQueryRepositoryImpl implements SongMongoQueryRepository {
 
     private final MongoTemplate mongoTemplate;

--- a/src/main/java/com/projectlyrics/server/domain/song/repository/impl/SongMongoQueryRepositoryImpl.java
+++ b/src/main/java/com/projectlyrics/server/domain/song/repository/impl/SongMongoQueryRepositoryImpl.java
@@ -1,0 +1,79 @@
+package com.projectlyrics.server.domain.song.repository.impl;
+
+import com.projectlyrics.server.domain.common.dto.util.IdsWithHasNext;
+import com.projectlyrics.server.domain.song.repository.SongMongoQueryRepository;
+import java.util.Arrays;
+import java.util.List;
+import org.bson.Document;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.AggregationOperation;
+import org.springframework.data.mongodb.core.aggregation.AggregationResults;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class SongMongoQueryRepositoryImpl implements SongMongoQueryRepository {
+
+    private final MongoTemplate mongoTemplate;
+
+    public SongMongoQueryRepositoryImpl(MongoTemplate mongoTemplate) {
+        this.mongoTemplate = mongoTemplate;
+    }
+
+    @Override
+    public IdsWithHasNext searchSongsByName(String query, int offset, int limit) {
+        // nori + english + edgeGram autocomplete
+        int queryLength = query.length();
+
+        // 길이에 따라 가중치 동적 조정
+        int autocompleteBoost = queryLength <= 3 ? 2 : 1;
+        int textBoost = queryLength <= 3 ? 1 : 2;
+
+        AggregationOperation searchStage = context -> new Document("$search",
+                new Document("index", "songs_search_index")
+                        .append("compound", new Document("should", Arrays.asList(
+                                new Document("text", new Document()
+                                        .append("query", query)
+                                        .append("path", Arrays.asList(
+                                                "name",
+                                                new Document("value", "name").append("multi", "englishAnalyzer")
+                                        ))
+                                        .append("score", new Document("boost", new Document("value", textBoost)))
+                                ),
+                                new Document("autocomplete", new Document()
+                                        .append("query", query)
+                                        .append("path", "name")
+                                        .append("tokenOrder", "any")
+                                        .append("score",
+                                                new Document("boost", new Document("value", autocompleteBoost)))
+                                )
+                        )))
+        );
+
+        AggregationOperation projectStage = Aggregation.project("_id");
+        AggregationOperation skipStage = Aggregation.skip(offset);
+        AggregationOperation limitStage = Aggregation.limit(limit + 1);
+
+        Aggregation aggregation = Aggregation.newAggregation(
+                searchStage,
+                projectStage,
+                skipStage,
+                limitStage
+        );
+
+        AggregationResults<Document> results =
+                mongoTemplate.aggregate(aggregation, "songs", Document.class);
+
+        List<Long> ids = results.getMappedResults().stream()
+                .map(doc -> doc.get("_id", Long.class))
+                .toList();
+
+        boolean hasNext = ids.size() > limit;
+
+        if (hasNext) {
+            ids = ids.subList(0, limit);
+        }
+
+        return new IdsWithHasNext(ids, hasNext);
+    }
+}

--- a/src/main/java/com/projectlyrics/server/domain/song/repository/impl/SongMongoQueryRepositoryImpl.java
+++ b/src/main/java/com/projectlyrics/server/domain/song/repository/impl/SongMongoQueryRepositoryImpl.java
@@ -82,7 +82,7 @@ public class SongMongoQueryRepositoryImpl implements SongMongoQueryRepository {
         return new IdsWithHasNext(ids, hasNext);
     }
 
-    public List<Long> findAllIdByIdIn(List<Long> ids) {
+    public List<Long> findAllByIdsIn(List<Long> ids) {
         Query query = new Query(Criteria.where("_id").in(ids));
         query.fields().include("_id");
         return mongoTemplate.find(query, SongMongo.class)

--- a/src/main/java/com/projectlyrics/server/domain/song/repository/noop/NoOpSongMongoCommandRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/song/repository/noop/NoOpSongMongoCommandRepository.java
@@ -16,7 +16,7 @@ public class NoOpSongMongoCommandRepository implements SongMongoCommandRepositor
     }
 
     @Override
-    public <S extends SongMongo> List<S> saveAll(Iterable<S> songs) {
+    public List<SongMongo> saveAll(List<SongMongo> songs) {
         return List.of();
     }
 

--- a/src/main/java/com/projectlyrics/server/domain/song/repository/noop/NoOpSongMongoCommandRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/song/repository/noop/NoOpSongMongoCommandRepository.java
@@ -1,0 +1,26 @@
+package com.projectlyrics.server.domain.song.repository.noop;
+
+import com.projectlyrics.server.domain.song.entity.SongMongo;
+import com.projectlyrics.server.domain.song.repository.SongMongoCommandRepository;
+import java.util.List;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@Profile({"!dev", "!prod"})
+public class NoOpSongMongoCommandRepository implements SongMongoCommandRepository {
+
+    @Override
+    public SongMongo save(SongMongo song) {
+        return song;
+    }
+
+    @Override
+    public <S extends SongMongo> List<S> saveAll(Iterable<S> songs) {
+        return List.of();
+    }
+
+    @Override
+    public void deleteAll() {
+    }
+}

--- a/src/main/java/com/projectlyrics/server/domain/song/repository/noop/NoOpSongMongoQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/song/repository/noop/NoOpSongMongoQueryRepository.java
@@ -15,7 +15,7 @@ public class NoOpSongMongoQueryRepository implements SongMongoQueryRepository {
     }
 
     @Override
-    public List<Long> findAllIdByIdIn(List<Long> ids) {
+    public List<Long> findAllByIdsIn(List<Long> ids) {
         return List.of();
     }
 }

--- a/src/main/java/com/projectlyrics/server/domain/song/repository/noop/NoOpSongMongoQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/song/repository/noop/NoOpSongMongoQueryRepository.java
@@ -1,0 +1,21 @@
+package com.projectlyrics.server.domain.song.repository.noop;
+
+import com.projectlyrics.server.domain.common.dto.util.IdsWithHasNext;
+import com.projectlyrics.server.domain.song.repository.SongMongoQueryRepository;
+import java.util.List;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Repository;
+
+@Profile({"!dev", "!prod"})
+@Repository
+public class NoOpSongMongoQueryRepository implements SongMongoQueryRepository {
+    @Override
+    public IdsWithHasNext searchSongsByName(String query, int offset, int limit) {
+        return new IdsWithHasNext(List.of(), false);
+    }
+
+    @Override
+    public List<Long> findAllIdByIdIn(List<Long> ids) {
+        return List.of();
+    }
+}

--- a/src/main/java/com/projectlyrics/server/domain/song/service/SongCommandService.java
+++ b/src/main/java/com/projectlyrics/server/domain/song/service/SongCommandService.java
@@ -6,11 +6,15 @@ import com.projectlyrics.server.domain.artist.repository.ArtistQueryRepository;
 import com.projectlyrics.server.domain.song.dto.request.SongCreateRequest;
 import com.projectlyrics.server.domain.song.entity.Song;
 import com.projectlyrics.server.domain.song.entity.SongCreate;
+import com.projectlyrics.server.domain.song.entity.SongMongo;
 import com.projectlyrics.server.domain.song.repository.SongCommandRepository;
+import com.projectlyrics.server.domain.song.repository.SongMongoCommandRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -18,11 +22,18 @@ public class SongCommandService {
 
     private final SongCommandRepository songCommandRepository;
     private final ArtistQueryRepository artistQueryRepository;
+    private final SongMongoCommandRepository songMongoCommandRepository;
 
     public Song create(SongCreateRequest request) {
         Artist artist = artistQueryRepository.findById(request.artistId())
                 .orElseThrow(ArtistNotFoundException::new);
+        Song song = songCommandRepository.save(Song.create(SongCreate.from(request, artist)));
 
-        return songCommandRepository.save(Song.create(SongCreate.from(request, artist)));
+        try {
+            songMongoCommandRepository.save(SongMongo.of(song));
+        } catch (Exception e) {
+            log.warn("MongoDB create failed for song id {}: {}", song.getId(), e.getMessage());
+        }
+        return song;
     }
 }

--- a/src/main/java/com/projectlyrics/server/domain/song/service/SongQueryService.java
+++ b/src/main/java/com/projectlyrics/server/domain/song/service/SongQueryService.java
@@ -3,21 +3,19 @@ package com.projectlyrics.server.domain.song.service;
 import com.projectlyrics.server.domain.common.dto.util.CursorBasePaginatedResponse;
 import com.projectlyrics.server.domain.common.dto.util.OffsetBasePaginatedResponse;
 import com.projectlyrics.server.domain.search.domain.SongSearch;
-import com.projectlyrics.server.domain.search.repository.SearchRepository;
 import com.projectlyrics.server.domain.song.dto.response.SongGetResponse;
 import com.projectlyrics.server.domain.song.dto.response.SongSearchResponse;
 import com.projectlyrics.server.domain.song.entity.Song;
 import com.projectlyrics.server.domain.song.exception.SongNotFoundException;
 import com.projectlyrics.server.domain.song.repository.SongQueryRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional(readOnly = true)
@@ -25,15 +23,15 @@ import java.util.stream.Collectors;
 public class SongQueryService {
 
     private final SongQueryRepository songQueryRepository;
-    private final SearchRepository searchRepository;
 
     public OffsetBasePaginatedResponse<SongSearchResponse> searchSongs(String query, int pageNumber, int pageSize) {
         if (Objects.isNull(query) || query.isEmpty()) {
             return getSongsByNoteCount(pageNumber, pageSize);
         }
 
-        List<SongSearch> searchResult = searchRepository.search(query, pageNumber, pageSize + 1);
-        List<SongSearchResponse> response = convertToResponse(searchResult);
+        List<SongSearchResponse> response = songQueryRepository.findAllByQuery(query,
+                        PageRequest.of(pageNumber, pageSize))
+                .map(SongSearchResponse::from).stream().toList();
 
         return OffsetBasePaginatedResponse.of(pageNumber, pageSize, response);
     }
@@ -60,7 +58,8 @@ public class SongQueryService {
                 .toList();
     }
 
-    public CursorBasePaginatedResponse<SongGetResponse> searchSongsByArtist(Long artistId, String query, Long cursor, int size) {
+    public CursorBasePaginatedResponse<SongGetResponse> searchSongsByArtist(Long artistId, String query, Long cursor,
+                                                                            int size) {
         return CursorBasePaginatedResponse.of(
                 songQueryRepository.findAllByQueryAndArtistId(artistId, query, cursor, PageRequest.of(0, size))
                         .map(SongGetResponse::from)

--- a/src/main/java/com/projectlyrics/server/domain/song/service/SongQueryService.java
+++ b/src/main/java/com/projectlyrics/server/domain/song/service/SongQueryService.java
@@ -45,7 +45,7 @@ public class SongQueryService {
             return searchSongsWithLike(query, PageRequest.of(pageNumber, pageSize));
         }
 
-        List<SongSearchResponse> songs = songQueryRepository.findAllByIdsInOrder(songsIds).stream()
+        List<SongSearchResponse> songs = songQueryRepository.findAllByIdsInListOrder(songsIds).stream()
                 .map(SongSearchResponse::from)
                 .toList();
 

--- a/src/main/java/com/projectlyrics/server/domain/song/service/SongQueryService.java
+++ b/src/main/java/com/projectlyrics/server/domain/song/service/SongQueryService.java
@@ -16,6 +16,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -41,10 +42,7 @@ public class SongQueryService {
         List<Long> songsIds = idsWithHasNext.ids();
 
         if (songsIds.size() == 0 && pageNumber == 0) {
-            return OffsetBasePaginatedResponse.of(songQueryRepository.findAllByQuery(query,
-                            PageRequest.of(pageNumber, pageSize))
-                    .map(SongSearchResponse::from)
-            );
+            return searchSongsWithLike(query, PageRequest.of(pageNumber, pageSize));
         }
 
         List<SongSearchResponse> songs = songQueryRepository.findAllByIdsInOrder(songsIds).stream()
@@ -55,6 +53,12 @@ public class SongQueryService {
                 pageNumber,
                 idsWithHasNext.hasNext(),
                 songs
+        );
+    }
+
+    public OffsetBasePaginatedResponse<SongSearchResponse> searchSongsWithLike(String query, Pageable pageable) {
+        return OffsetBasePaginatedResponse.of(songQueryRepository.findAllByQuery(query, pageable)
+                .map(SongSearchResponse::from)
         );
     }
 

--- a/src/main/java/com/projectlyrics/server/global/dev/DummyDataInitializer.java
+++ b/src/main/java/com/projectlyrics/server/global/dev/DummyDataInitializer.java
@@ -6,7 +6,9 @@ import com.projectlyrics.server.domain.artist.entity.ArtistCreate;
 import com.projectlyrics.server.domain.artist.repository.ArtistCommandRepository;
 import com.projectlyrics.server.domain.song.entity.Song;
 import com.projectlyrics.server.domain.song.entity.SongCreate;
+import com.projectlyrics.server.domain.song.entity.SongMongo;
 import com.projectlyrics.server.domain.song.repository.SongCommandRepository;
+import com.projectlyrics.server.domain.song.repository.SongMongoCommandRepository;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -26,6 +28,7 @@ public class DummyDataInitializer {
 
     private final ArtistCommandRepository artistCommandRepository;
     private final SongCommandRepository songCommandRepository;
+    private final SongMongoCommandRepository songMongoCommandRepository;
 
     @PostConstruct
     public void init() {
@@ -110,7 +113,14 @@ public class DummyDataInitializer {
             log.error("failed to read csv file", e);
         }
 
-        songCommandRepository.saveAll(songs);
+        songs = songCommandRepository.saveAll(songs);
+        try {
+            songMongoCommandRepository.saveAll(
+                    songs.stream().map(SongMongo::of).toList()
+            );
+        } catch (Exception e) {
+            log.warn("MongoDB saveAll failed for {} songs. Cause: {}. Stacktrace: ", songs.size(), e.getMessage(), e);
+        }
     }
 
     private LocalDate parse(String date) {

--- a/src/main/java/com/projectlyrics/server/global/dev/cron/SongCollector.java
+++ b/src/main/java/com/projectlyrics/server/global/dev/cron/SongCollector.java
@@ -4,7 +4,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.projectlyrics.server.domain.artist.entity.Artist;
 import com.projectlyrics.server.domain.artist.repository.ArtistQueryRepository;
 import com.projectlyrics.server.domain.song.entity.Song;
+import com.projectlyrics.server.domain.song.entity.SongMongo;
 import com.projectlyrics.server.domain.song.repository.SongCommandRepository;
+import com.projectlyrics.server.domain.song.repository.SongMongoCommandRepository;
 import com.projectlyrics.server.domain.song.repository.SongQueryRepository;
 import com.projectlyrics.server.global.dev.cron.dto.Album;
 import com.projectlyrics.server.global.dev.cron.dto.AlbumListResponse;
@@ -12,6 +14,11 @@ import com.projectlyrics.server.global.dev.cron.dto.Track;
 import com.projectlyrics.server.global.dev.cron.dto.TrackListResponse;
 import com.projectlyrics.server.global.slack.domain.SlackResponseBuilder;
 import com.projectlyrics.server.global.slack.service.SlackService;
+import java.net.http.HttpResponse;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -19,12 +26,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-
-import java.net.http.HttpResponse;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -34,6 +35,7 @@ public class SongCollector {
     private final ArtistQueryRepository artistQueryRepository;
     private final SongCommandRepository songCommandRepository;
     private final SongQueryRepository songQueryRepository;
+    private final SongMongoCommandRepository songMongoCommandRepository;
     private static final ObjectMapper objectMapper = new ObjectMapper();
     private final SlackService slackService;
 
@@ -52,7 +54,15 @@ public class SongCollector {
                     .filter(this::notRegistered)
                     .toList();
 
-            songCommandRepository.saveAll(newSongs);
+            newSongs = songCommandRepository.saveAll(newSongs);
+            try {
+                songMongoCommandRepository.saveAll(
+                        newSongs.stream().map(SongMongo::of).toList()
+                );
+            } catch (Exception e) {
+                log.warn("MongoDB saveAll failed for {} songs. Cause: {}. Stacktrace: ", newSongs.size(),
+                        e.getMessage(), e);
+            }
             sendToSlack(newSongs);
         }
     }
@@ -61,7 +71,7 @@ public class SongCollector {
         if (artists.size() <= 23) {
             return artists;
         }
-        
+
         int now = LocalDateTime.now().getHour();
         int size = artists.size() / 23;
 
@@ -73,7 +83,8 @@ public class SongCollector {
 
     private static List<Song> getSongs(Artist artist) {
         HttpResponse<String> response;
-        String url = "https://api.spotify.com/v1/artists/" + artist.getSpotifyId() + "/albums?limit=50&market=KR&locale=ko_KR&include_groups=album,single";
+        String url = "https://api.spotify.com/v1/artists/" + artist.getSpotifyId()
+                + "/albums?limit=50&market=KR&locale=ko_KR&include_groups=album,single";
         List<Song> songs = new ArrayList<>();
         AlbumListResponse albumListResponse = null;
 
@@ -120,7 +131,8 @@ public class SongCollector {
                 }
             } while (isFailed(response) || hasNext(trackListResponse));
         } catch (Exception e) {
-            log.error("failed to get songs of an album {} of artist {} of id {} at all", album.getName(), album.getId(), album.getId());
+            log.error("failed to get songs of an album {} of artist {} of id {} at all", album.getName(), album.getId(),
+                    album.getId());
         }
 
         return tracks;
@@ -150,6 +162,6 @@ public class SongCollector {
 
     private void sendToSlack(List<Song> songs) {
         songs.forEach(song ->
-            slackService.sendFeedbackToSlack(SlackResponseBuilder.createSong(song), null, channelId));
+                slackService.sendFeedbackToSlack(SlackResponseBuilder.createSong(song), null, channelId));
     }
 }

--- a/src/main/java/com/projectlyrics/server/global/dev/cron/SongCollector.java
+++ b/src/main/java/com/projectlyrics/server/global/dev/cron/SongCollector.java
@@ -89,7 +89,7 @@ public class SongCollector {
                     .map(Song::getId)
                     .toList();
 
-            List<Long> existingIdsInMongo = songMongoQueryRepository.findAllIdByIdIn(batchSongIds);
+            List<Long> existingIdsInMongo = songMongoQueryRepository.findAllByIdsIn(batchSongIds);
 
             List<SongMongo> songsToSave = songPage.stream()
                     .filter(song -> !existingIdsInMongo.contains(song.getId()))

--- a/src/main/java/com/projectlyrics/server/global/dev/cron/SongCollector.java
+++ b/src/main/java/com/projectlyrics/server/global/dev/cron/SongCollector.java
@@ -23,6 +23,7 @@ import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.http.HttpStatus;
@@ -32,6 +33,7 @@ import org.springframework.stereotype.Component;
 
 @Slf4j
 @RequiredArgsConstructor
+@Profile({"prod", "dev"})
 @Component
 public class SongCollector {
 

--- a/src/test/java/com/projectlyrics/server/domain/artist/search/ArtistSearchPerformanceTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/artist/search/ArtistSearchPerformanceTest.java
@@ -1,0 +1,175 @@
+package com.projectlyrics.server.domain.artist.search;
+
+import com.projectlyrics.server.domain.artist.entity.Artist;
+import com.projectlyrics.server.domain.artist.entity.ArtistMongo;
+import com.projectlyrics.server.domain.artist.repository.ArtistCommandRepository;
+import com.projectlyrics.server.domain.artist.repository.ArtistMongoCommandRepository;
+import com.projectlyrics.server.domain.artist.repository.ArtistMongoQueryRepository;
+import com.projectlyrics.server.domain.artist.repository.ArtistQueryRepository;
+import com.projectlyrics.server.domain.artist.service.ArtistQueryService;
+import com.projectlyrics.server.support.fixture.ArtistFixture;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+
+@SpringBootTest
+@Disabled("성능 측정용이라 기본 실행에서 제외함")
+class ArtistSearchPerformanceTest {
+
+    @Autowired
+    private ArtistMongoCommandRepository artistMongoCommandRepository;
+
+    @Autowired
+    private ArtistMongoQueryRepository artistMongoQueryRepository;
+
+    @Autowired
+    private ArtistCommandRepository artistCommandRepository;
+
+    @Autowired
+    private ArtistQueryRepository artistQueryRepository;
+
+    @Autowired
+    private ArtistQueryService artistQueryService;
+
+    private final List<Artist> templates = List.of(
+            ArtistFixture.create("검정치마", "", ""), ArtistFixture.create("잔나비", "", ""),
+            ArtistFixture.create("최유리", "", ""), ArtistFixture.create("실리카겔", "Silica Gel", ""),
+            ArtistFixture.create("데이먼스 이어", "Damons year", ""), ArtistFixture.create("새소년", "", ""),
+            ArtistFixture.create("10CM", "십센치", ""), ArtistFixture.create("혁오", "HYUKOH", ""),
+            ArtistFixture.create("카더가든", "car the garden", ""), ArtistFixture.create("너드커넥션", "Nerd Connection", ""),
+            ArtistFixture.create("허회경", "", ""), ArtistFixture.create("우효", "OOHYO", ""),
+            ArtistFixture.create("백아", "Baek A", ""), ArtistFixture.create("브로콜리너마저", "Broccoli you too", ""),
+            ArtistFixture.create("쏜애플", "THORNAPPLE", ""), ArtistFixture.create("SURL", "설", ""),
+            ArtistFixture.create("한로로", "HANRORO", ""), ArtistFixture.create("윤지영", "", ""),
+            ArtistFixture.create("백예린", "Yerin Baek", ""), ArtistFixture.create("유다빈밴드", "YdBB", ""),
+            ArtistFixture.create("신지훈", "", ""), ArtistFixture.create("wave to earth", "웨이브투어스", ""),
+            ArtistFixture.create("LUCY", "루시", ""), ArtistFixture.create("터치드", "TOUCHED", ""),
+            ArtistFixture.create("하현상", "", ""), ArtistFixture.create("김사월", "", ""),
+            ArtistFixture.create("언니네 이발관", "", ""), ArtistFixture.create("나상현씨밴드", "Band Nah", ""),
+            ArtistFixture.create("박소은", "", ""), ArtistFixture.create("짙은", "", ""),
+            ArtistFixture.create("Mingginyu", "밍기뉴", ""), ArtistFixture.create("김뜻돌", "", ""),
+            ArtistFixture.create("Lacuna", "라쿠나", ""), ArtistFixture.create("CHEEZE", "치즈", ""),
+            ArtistFixture.create("김현창", "", ""), ArtistFixture.create("볼빨간사춘기", "", ""),
+            ArtistFixture.create("스텔라장", "Stella Jang", ""), ArtistFixture.create("민수", "", ""),
+            ArtistFixture.create("다섯", "Dasutt", ""), ArtistFixture.create("델리스파이스", "Delispice", ""),
+            ArtistFixture.create("소수빈", "", ""), ArtistFixture.create("가을방학", "", ""),
+            ArtistFixture.create("신인류", "", ""), ArtistFixture.create("dosii", "도시", ""),
+            ArtistFixture.create("보수동쿨러", "", ""), ArtistFixture.create("이고도", "", ""),
+            ArtistFixture.create("결", "KYUL", ""), ArtistFixture.create("정우", "", ""),
+            ArtistFixture.create("유라", "youra", ""), ArtistFixture.create("알레프", "ALEPH", "")
+    );
+
+
+    @BeforeEach
+    void setup() {
+        artistMongoCommandRepository.deleteAll();
+
+        long startBulk = System.currentTimeMillis();
+
+        // 단건 insert 주석 처리
+    /*
+    for (int i = 0; i < 20000; i++) {
+        Artist sampleTemplate = templates.get(i % templates.size());
+
+        Artist sample = ArtistFixture.create(
+                Long.valueOf(i + 1),
+                sampleTemplate.getName(),
+                sampleTemplate.getSecondName(),
+                sampleTemplate.getThirdName()
+        );
+        Artist saved = artistCommandRepository.save(sample);
+        artistMongoCommandRepository.save(ArtistMongo.of(saved));
+    }
+    */
+
+        // bulk insert
+        List<Artist> artistBatch = new java.util.ArrayList<>();
+        List<ArtistMongo> mongoBatch = new java.util.ArrayList<>();
+        for (int i = 0; i < 20000; i++) {
+            Artist sampleTemplate = templates.get(i % templates.size());
+            Artist sample = ArtistFixture.create(
+                    Long.valueOf(i + 1),
+                    sampleTemplate.getName(),
+                    sampleTemplate.getSecondName(),
+                    sampleTemplate.getThirdName()
+            );
+            artistBatch.add(sample);
+        }
+
+        // MySQL bulk save
+        List<Artist> savedArtists = artistCommandRepository.saveAll(artistBatch);
+
+        // Mongo bulk save
+        for (Artist saved : savedArtists) {
+            mongoBatch.add(ArtistMongo.of(saved));
+        }
+        artistMongoCommandRepository.saveAll(mongoBatch);
+
+        long endBulk = System.currentTimeMillis();
+        System.out.println("Bulk insert " + 20000 + "개 걸린 시간: " + (endBulk - startBulk) + " ms");
+    }
+
+    @Test
+    void searchPerformanceTest() {
+        List<String> keywords = List.of(
+                "검", "10", "하현", "보수동", "언니네 이발관",
+                "s", "St", "Stella Ja", "Mingginyu"
+        );
+
+        int runsPerKeyword = 10; // 키워드당 반복 횟수
+
+        long mongoAtlasRepositoryTotal = 0;
+        long mysqlLikeRepositoryTotal = 0;
+        long mongoAtlasServiceTotal = 0;
+        long mysqlLikeServiceTotal = 0;
+
+        // DB 캐시 / JIT 최적화 피하고 정확한 성능 측정을 위해 반복문 분리
+        for (String keyword : keywords) {
+            for (int i = 0; i < runsPerKeyword; i++) {
+                // Mongo Atlas 검색 (service)
+                long start = System.nanoTime();
+                artistQueryService.searchArtists(keyword, PageRequest.of(0, 12));
+                mongoAtlasServiceTotal += System.nanoTime() - start;
+
+                // MySQL LIKE 검색 (service)
+                start = System.nanoTime();
+                artistQueryService.searchArtistsWithLike(keyword, PageRequest.of(0, 12));
+                mysqlLikeServiceTotal += System.nanoTime() - start;
+            }
+        }
+
+        for (String keyword : keywords) {
+            for (int i = 0; i < runsPerKeyword; i++) {
+                // Mongo Atlas 검색 (repository)
+                long start = System.nanoTime();
+                artistMongoQueryRepository.searchArtistIdsByName(keyword, 0, 12);
+                mongoAtlasRepositoryTotal += System.nanoTime() - start;
+
+                // MySQL LIKE 검색 (repository)
+                start = System.nanoTime();
+                artistQueryRepository.findAllByQuery(keyword, PageRequest.of(0, 12));
+                mysqlLikeRepositoryTotal += System.nanoTime() - start;
+            }
+        }
+
+        int totalRuns = keywords.size() * runsPerKeyword;
+
+        System.out.println(
+                "Mongo Atlas Repository 평균(ms): " + mongoAtlasRepositoryTotal / (double) totalRuns / 1_000_000.0);
+        System.out.println(
+                "MySQL LIKE Repository 평균(ms): " + mysqlLikeRepositoryTotal / (double) totalRuns / 1_000_000.0);
+        System.out.println("Mongo Atlas Service 평균(ms): " + mongoAtlasServiceTotal / (double) totalRuns / 1_000_000.0);
+        System.out.println("MySQL LIKE Service 평균(ms): " + mysqlLikeServiceTotal / (double) totalRuns / 1_000_000.0);
+    }
+
+    @AfterEach
+    void cleanup() {
+        artistMongoCommandRepository.deleteAll();
+    }
+}
+

--- a/src/test/java/com/projectlyrics/server/domain/song/search/SongSearchPerformanceTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/song/search/SongSearchPerformanceTest.java
@@ -1,9 +1,7 @@
 package com.projectlyrics.server.domain.song.search;
 
-import com.projectlyrics.server.domain.artist.repository.ArtistCommandRepository;
 import com.projectlyrics.server.domain.song.entity.Song;
 import com.projectlyrics.server.domain.song.entity.SongMongo;
-import com.projectlyrics.server.domain.song.repository.SongCommandRepository;
 import com.projectlyrics.server.domain.song.repository.SongMongoCommandRepository;
 import com.projectlyrics.server.domain.song.repository.SongMongoQueryRepository;
 import com.projectlyrics.server.domain.song.repository.SongQueryRepository;
@@ -28,12 +26,6 @@ class SongSearchPerformanceTest {
 
     @Autowired
     private SongMongoQueryRepository songMongoQueryRepository;
-
-    @Autowired
-    private ArtistCommandRepository artistCommandRepository;
-
-    @Autowired
-    private SongCommandRepository songCommandRepository;
 
     @Autowired
     private SongQueryRepository songQueryRepository;

--- a/src/test/java/com/projectlyrics/server/domain/song/search/SongSearchPerformanceTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/song/search/SongSearchPerformanceTest.java
@@ -1,0 +1,139 @@
+package com.projectlyrics.server.domain.song.search;
+
+import com.projectlyrics.server.domain.artist.repository.ArtistCommandRepository;
+import com.projectlyrics.server.domain.song.entity.Song;
+import com.projectlyrics.server.domain.song.entity.SongMongo;
+import com.projectlyrics.server.domain.song.repository.SongCommandRepository;
+import com.projectlyrics.server.domain.song.repository.SongMongoCommandRepository;
+import com.projectlyrics.server.domain.song.repository.SongMongoQueryRepository;
+import com.projectlyrics.server.domain.song.repository.SongQueryRepository;
+import com.projectlyrics.server.domain.song.service.SongQueryService;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("local")
+@Disabled("성능 측정용이라 기본 실행에서 제외함")
+class SongSearchPerformanceTest {
+
+    @Autowired
+    private SongMongoCommandRepository songMongoCommandRepository;
+
+    @Autowired
+    private SongMongoQueryRepository songMongoQueryRepository;
+
+    @Autowired
+    private ArtistCommandRepository artistCommandRepository;
+
+    @Autowired
+    private SongCommandRepository songCommandRepository;
+
+    @Autowired
+    private SongQueryRepository songQueryRepository;
+
+    @Autowired
+    private SongQueryService songQueryService;
+
+
+    @BeforeEach
+    void setup() {
+        songMongoCommandRepository.deleteAll();
+
+        long startBulk = System.currentTimeMillis();
+        List<Song> existingSongs = songQueryRepository.findAll();
+        List<SongMongo> mongoBatch = existingSongs.stream()
+                .map(SongMongo::of)
+                .toList();
+
+        songMongoCommandRepository.saveAll(mongoBatch);
+
+        long endBulk = System.currentTimeMillis();
+        System.out.println("Bulk insert " + mongoBatch.size() + "개 걸린 시간: " + (endBulk - startBulk) + " ms");
+    }
+
+
+    @Test
+    void searchPerformanceTest() {
+        List<String> keywords = List.of(
+                "Flying", "Bobs", "불세례", "환상", "용맹", "발걸음",
+                "오랜만", "마지막", "black", "eres", "ai", "기사",
+                "Kidd", "joke", "Everything", "Pet", "Kite", "War",
+                "Harmony", "네 번", "여름", "21st", "Century", "Kingdom",
+                "Hollywood", "Movie", "Star", "Hope", "결국", "울었어요",
+                "NAIVE", "테니스", "몰라요", "우주선", "좋은 사람", "속물들",
+                "마술", "수성", "하루", "Rope", "What", "Say", "귀가",
+                "ㅈㅣㅂ", "어제", "당신", "꿈", "Lovegame", "lonely",
+                "정말", "오래", "마음", "스물하나", "열다섯", "구름", "날아",
+                "bad", "sunny", "Knowhow", "MP3", "Love is Dangerous", "Bully",
+                "네가 사랑한", "Instant", "Lover", "Melancholy", "말야", "사랑해",
+                "외로워", "푸훗", "Poo", "Hut", "동경", "인사", "도미노",
+                "아니어도", "이상해", "Rule", "Astronaut", "살고 싶어요", "나도",
+                "꿈에서 걸려온 전화", "이름이 없는", "유령", "save me", "Madeleine", "Love",
+                "Weather", "Report", "잠깐", "잠들어", "내려앉는", "숨", "우주를 줄게",
+                "싸운날", "Go Your Way", "Bourgeois", "Emotion", "100번째", "같은 말",
+                "좋아한다고", "옥상달빛", "무사히", "도착", "생각해봐", "Sihanoukville", "나의 왼발",
+                "Walking", "with you", "Instrumental", "이름이 맘에", "Stopwatch", "사랑이 악역을",
+                "김사월", "악역의 등장", "여울", "달", "Joy", "despair", "의자에 앉아",
+                "상견니", "얼굴", "변치 말자", "내 꿈은", "너무해", "Toss", "turn", "들불",
+                "구운듯한", "모티프", "목에게"
+        );
+
+        // 각 케이스별 latency(ms) 저장
+        List<Long> mysqlLikeServiceLatencies = new java.util.ArrayList<>();
+        List<Long> mongoAtlasServiceLatencies = new java.util.ArrayList<>();
+        List<Long> mysqlLikeRepoLatencies = new java.util.ArrayList<>();
+        List<Long> mongoAtlasRepoLatencies = new java.util.ArrayList<>();
+
+        // MySQL LIKE 테스트 - service
+        for (String keyword : keywords) {
+            long start = System.nanoTime();
+            songQueryService.searchSongsWithLike(keyword, PageRequest.of(0, 12));
+            mysqlLikeServiceLatencies.add((System.nanoTime() - start) / 1_000_000);
+        }
+
+        // Mongo Atlas Search 테스트 - service
+        for (String keyword : keywords) {
+            long start = System.nanoTime();
+            songQueryService.searchSongs(keyword, 0, 12);
+            mongoAtlasServiceLatencies.add((System.nanoTime() - start) / 1_000_000);
+        }
+
+        // MySQL LIKE 테스트 - repository
+        for (String keyword : keywords) {
+            long start = System.nanoTime();
+            songQueryRepository.findAllByQuery(keyword, PageRequest.of(0, 5));
+            mysqlLikeRepoLatencies.add((System.nanoTime() - start) / 1_000_000);
+        }
+
+        // Mongo Atlas Search 테스트 - repository
+        for (String keyword : keywords) {
+            long start = System.nanoTime();
+            songMongoQueryRepository.searchSongsByName(keyword, 0, 12);
+            mongoAtlasRepoLatencies.add((System.nanoTime() - start) / 1_000_000);
+        }
+
+        java.util.function.Function<List<Long>, String> stats = (latencies) -> {
+            latencies.sort(Long::compare);
+            double avg = latencies.stream().mapToLong(Long::longValue).average().orElse(0.0);
+            long p99 = latencies.get((int) Math.ceil(latencies.size() * 0.99) - 1);
+            return String.format("평균=%.3f ms, P99=%d ms", avg, p99);
+        };
+
+        System.out.println("MySQL LIKE Repository -> " + stats.apply(mysqlLikeRepoLatencies));
+        System.out.println("Mongo Atlas Repository -> " + stats.apply(mongoAtlasRepoLatencies));
+        System.out.println("MySQL LIKE Service -> " + stats.apply(mysqlLikeServiceLatencies));
+        System.out.println("Mongo Atlas Service -> " + stats.apply(mongoAtlasServiceLatencies));
+    }
+
+    @AfterEach
+    void cleanup() {
+        songMongoCommandRepository.deleteAll();
+    }
+}

--- a/src/test/java/com/projectlyrics/server/support/fixture/ArtistFixture.java
+++ b/src/test/java/com/projectlyrics/server/support/fixture/ArtistFixture.java
@@ -58,4 +58,15 @@ public class ArtistFixture extends BaseFixture {
                 "https://i.scdn.co/image/ab6761610000e5eb8609536d21beed6769d09d7f"
         );
     }
+
+    public static Artist create(Long id, String name, String secondName, String thirdName) {
+        return Artist.withId(
+                id,
+                name,
+                secondName,
+                thirdName,
+                "6WeDO4GynFmK4OxwkBzMW8",
+                "https://i.scdn.co/image/ab6761610000e5eb8609536d21beed6769d09d7f"
+        );
+    }
 }

--- a/src/test/java/com/projectlyrics/server/support/fixture/SongFixture.java
+++ b/src/test/java/com/projectlyrics/server/support/fixture/SongFixture.java
@@ -38,4 +38,33 @@ public class SongFixture extends BaseFixture {
                 )
         );
     }
+
+    public static Song create(String name) {
+        long id = getUniqueId();
+        return Song.create(
+                new SongCreate(
+                        id,
+                        "24ebPi6UpTNw2vdzxGbO9n" + id,
+                        name,
+                        LocalDate.parse("2022-09-15"),
+                        "TEEN TROUBLES",
+                        "https://i.scdn.co/image/ab67616d0000b2739c3a4e471c5e82a457dce2c0",
+                        ArtistFixture.create()
+                )
+        );
+    }
+
+    public static Song create(Long id, String name, Artist artist) {
+        return Song.create(
+                new SongCreate(
+                        id,
+                        "24ebPi6UpTNw2vdzxGbO9n" + id,
+                        name,
+                        LocalDate.parse("2022-09-15"),
+                        "TEEN TROUBLES",
+                        "https://i.scdn.co/image/ab67616d0000b2739c3a4e471c5e82a457dce2c0",
+                        artist
+                )
+        );
+    }
 }


### PR DESCRIPTION
# 🍃 **Pull Requests**

## ⛳️ **작업한 브랜치**
- Resolved: #213

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 몽고 db를 활용하여 가수이름 검색, 노래 검색을 구현했습니다.
   - 가수별 노래 이름 검색의 경우 like로도 충분할 것 같아 그 검색에는 MongoDB를 구현하지 않았습니다.
   - 가수 이름은 자동완성, 노래 이름은 nori+english analyzer+자동 완성 인덱스를 사용하였습니다. 또한 노래 이름의 경우에는 검색어의 길이에 따라 각각 필드에 대한 가중치를 다르게 주어 계산했습니다.
   - 첫 페이지에서 altas search를 활용한 결과를 얻을 수 없는 경우, 다시 한 번 mysql like를 시도하는 fallback구조로 작성했습니다.
   - 기존 곡 collect시 MongoDB에도 노래 데이터가 들어가도록 작성했으며, 하루에 한번은 배치 작업을 통해 MOngoDB에 없는 데이터들을 저장할 수 있도록 했습니다.
   - 성능 테스트 결과 mongoDB가 복잡한 연산+MySql에 한 번 더 조회하는 오버헤드가 있음에도 불구 p99에서 더 안정적인 모습을 보였습니다. (repository, service단 모두)
   - 이메일이 부족하여, dev,prod에 대한 Mongo Cluster만 생성한 관계로 local에서는 MongoDB repoistort가 noop으로 동작할 수 있도록 설정했습니다.

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- yml이 업데이트 되었습니다.
- 커밋 파일을 잘못 포함해서 올린 커밋이 몇 개 있습니다 ㅜㅜ 참고해주세요
- 더 자세한 내용은 https://velog.io/@elive7/%EA%B2%80%EC%83%89-like-%EA%B2%80%EC%83%89%EC%96%B4%EB%A1%9C%EB%A7%8C-%ED%95%98%EA%B3%A0-%EA%B3%84%EC%85%A8%EB%82%98%EC%9A%94-Atlas-Search-%EC%9D%B8%EB%8D%B1%EC%8B%B1-%EB%B0%8F-%EA%B2%80%EC%83%89-%EC%BF%BC%EB%A6%AC 이 벨로그에 기록해두었습니다. 
