### PR TITLE
[SCRUM-261] feat: 노트 타입별별로 검색 결과를 제공하는 api 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ application*.yml
 
 gradle.properties
 src/main/resources/firebase-key.json
+*.lck
+*.part

--- a/src/main/java/com/projectlyrics/server/domain/note/api/NoteController.java
+++ b/src/main/java/com/projectlyrics/server/domain/note/api/NoteController.java
@@ -10,6 +10,7 @@ import com.projectlyrics.server.domain.note.dto.response.NoteDeleteResponse;
 import com.projectlyrics.server.domain.note.dto.response.NoteDetailResponse;
 import com.projectlyrics.server.domain.note.dto.response.NoteGetResponse;
 import com.projectlyrics.server.domain.note.dto.response.NoteUpdateResponse;
+import com.projectlyrics.server.domain.note.entity.NoteType;
 import com.projectlyrics.server.domain.note.service.NoteCommandService;
 import com.projectlyrics.server.domain.note.service.NoteQueryService;
 import com.projectlyrics.server.domain.view.service.ViewCommandService;
@@ -96,10 +97,11 @@ public class NoteController {
             @Authenticated AuthContext authContext,
             @RequestParam(name = "hasLyrics") boolean hasLyrics,
             @RequestParam(name = "artistId", required = false) Long artistId,
+            @RequestParam(name = "noteType", required = false) NoteType noteType,
             @RequestParam(name = "cursor", required = false) Long cursor,
             @RequestParam(name = "size", defaultValue = "10") int size
     ) {
-        CursorBasePaginatedResponse<NoteGetResponse> response = noteQueryService.getNotesByUserId(hasLyrics, artistId, authContext.getId(), cursor, size);
+        CursorBasePaginatedResponse<NoteGetResponse> response = noteQueryService.getNotesByUserId(hasLyrics, artistId, noteType, authContext.getId(), cursor, size);
 
         return ResponseEntity
                 .status(HttpStatus.OK)
@@ -111,10 +113,11 @@ public class NoteController {
             @Authenticated AuthContext authContext,
             @RequestParam(name = "hasLyrics") boolean hasLyrics,
             @RequestParam(name = "isFavoriteArtistsOnly", defaultValue = "false") boolean isFavoriteArtistsOnly,
+            @RequestParam(name = "noteType", required = false) NoteType noteType,
             @RequestParam(name = "cursor", required = false) Long cursor,
             @RequestParam(name = "size", defaultValue = "10") int size
     ) {
-        CursorBasePaginatedResponse<NoteGetResponse> response = noteQueryService.getNotes(hasLyrics, isFavoriteArtistsOnly, authContext.getId(), cursor, size);
+        CursorBasePaginatedResponse<NoteGetResponse> response = noteQueryService.getNotes(hasLyrics, isFavoriteArtistsOnly, noteType, authContext.getId(), cursor, size);
 
         return ResponseEntity
                 .status(HttpStatus.OK)
@@ -126,10 +129,11 @@ public class NoteController {
             @Authenticated AuthContext authContext,
             @RequestParam(name = "hasLyrics") boolean hasLyrics,
             @RequestParam(name = "artistId") Long artistId,
+            @RequestParam(name = "noteType", required = false) NoteType noteType,
             @RequestParam(name = "cursor", required = false) Long cursor,
             @RequestParam(name = "size", defaultValue = "10") int size
     ) {
-        CursorBasePaginatedResponse<NoteGetResponse> response = noteQueryService.getNotesByArtistId(hasLyrics, artistId, authContext.getId(), cursor, size);
+        CursorBasePaginatedResponse<NoteGetResponse> response = noteQueryService.getNotesByArtistId(hasLyrics, artistId, noteType, authContext.getId(), cursor, size);
 
         return ResponseEntity
                 .status(HttpStatus.OK)
@@ -141,10 +145,11 @@ public class NoteController {
             @Authenticated AuthContext authContext,
             @RequestParam(name = "hasLyrics") boolean hasLyrics,
             @RequestParam(name = "songId") Long songId,
+            @RequestParam(name = "noteType", required = false) NoteType noteType,
             @RequestParam(name = "cursor", required = false) Long cursor,
             @RequestParam(name = "size", defaultValue = "10") int size
     ) {
-        CursorBasePaginatedResponse<NoteGetResponse> response = noteQueryService.getNotesBySongId(hasLyrics, songId, authContext.getId(), cursor, size);
+        CursorBasePaginatedResponse<NoteGetResponse> response = noteQueryService.getNotesBySongId(hasLyrics, songId, noteType, authContext.getId(), cursor, size);
 
         return ResponseEntity
                 .status(HttpStatus.OK)
@@ -156,10 +161,11 @@ public class NoteController {
             @Authenticated AuthContext authContext,
             @RequestParam(name = "hasLyrics") boolean hasLyrics,
             @RequestParam(name = "artistId", required = false) Long artistId,
+            @RequestParam(name = "noteType", required = false) NoteType noteType,
             @RequestParam(name = "cursor", required = false) Long cursor,
             @RequestParam(name = "size", defaultValue = "10") int size
     ) {
-        CursorBasePaginatedResponse<NoteGetResponse> response = noteQueryService.getBookmarkedNotes(hasLyrics, artistId, authContext.getId(), cursor, size);
+        CursorBasePaginatedResponse<NoteGetResponse> response = noteQueryService.getBookmarkedNotes(hasLyrics, artistId, noteType, authContext.getId(), cursor, size);
 
         return ResponseEntity
                 .status(HttpStatus.OK)

--- a/src/main/java/com/projectlyrics/server/domain/note/entity/NoteType.java
+++ b/src/main/java/com/projectlyrics/server/domain/note/entity/NoteType.java
@@ -24,7 +24,7 @@ public enum NoteType {
     @JsonCreator
     public static NoteType of(String type) {
         return Arrays.stream(NoteType.values())
-                .filter(noteType -> noteType.type.equals(type))
+                .filter(noteType -> noteType.type.equalsIgnoreCase(type))
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("Invalid NoteType: " + type));
     }

--- a/src/main/java/com/projectlyrics/server/domain/note/repository/NoteQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/note/repository/NoteQueryRepository.java
@@ -1,5 +1,6 @@
 package com.projectlyrics.server.domain.note.repository;
 
+import com.projectlyrics.server.domain.note.entity.NoteType;
 import com.projectlyrics.server.domain.note.entity.Note;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -10,12 +11,12 @@ public interface NoteQueryRepository {
 
     Note findById(Long id);
 
-    Slice<Note> findAllByUserId(boolean hasLyrics, Long artistId, Long userId, Long cursorId, Pageable pageable);
-    Slice<Note> findAllByArtistIds(boolean hasLyrics, List<Long> artistsIds, Long userId, Long cursorId, Pageable pageable);
-    Slice<Note> findAll(boolean hasLyrics, List<Long> artistsIds, Long userId, Long cursorId, Pageable pageable);
-    Slice<Note> findAllByArtistId(boolean hasLyrics, Long artistId, Long userId, Long cursorId, Pageable pageable);
-    Slice<Note> findAllBookmarkedAndByArtistId(boolean hasLyrics, Long artistId, Long userId, Long cursorId, Pageable pageable);
-    Slice<Note> findAllBySongId(boolean hasLyrics, Long songId, Long userId, Long cursorId, Pageable pageable);
+    Slice<Note> findAllByUserId(boolean hasLyrics, Long artistId, NoteType noteType, Long userId, Long cursorId, Pageable pageable);
+    Slice<Note> findAllByArtistIds(boolean hasLyrics, List<Long> artistsIds, NoteType noteType, Long userId, Long cursorId, Pageable pageable);
+    Slice<Note> findAll(boolean hasLyrics, List<Long> artistsIds, NoteType noteType, Long userId, Long cursorId, Pageable pageable);
+    Slice<Note> findAllByArtistId(boolean hasLyrics, Long artistId, NoteType noteType, Long userId, Long cursorId, Pageable pageable);
+    Slice<Note> findAllBookmarkedAndByArtistId(boolean hasLyrics, Long artistId, NoteType noteType, Long userId, Long cursorId, Pageable pageable);
+    Slice<Note> findAllBySongId(boolean hasLyrics, Long songId, NoteType noteType, Long userId, Long cursorId, Pageable pageable);
 
     long countDraftNotesByUserId(Long userId);
 }

--- a/src/main/java/com/projectlyrics/server/domain/note/repository/impl/QueryDslNoteQueryRepository.java
+++ b/src/main/java/com/projectlyrics/server/domain/note/repository/impl/QueryDslNoteQueryRepository.java
@@ -11,8 +11,10 @@ import static com.projectlyrics.server.domain.song.entity.QSong.song;
 import com.projectlyrics.server.domain.common.util.QueryDslUtils;
 import com.projectlyrics.server.domain.note.entity.Note;
 import com.projectlyrics.server.domain.note.entity.NoteStatus;
+import com.projectlyrics.server.domain.note.entity.NoteType;
 import com.projectlyrics.server.domain.note.exception.NoteNotFoundException;
 import com.projectlyrics.server.domain.note.repository.NoteQueryRepository;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
@@ -50,7 +52,7 @@ public class QueryDslNoteQueryRepository implements NoteQueryRepository {
     }
 
     @Override
-    public Slice<Note> findAllByUserId(boolean hasLyrics, Long artistId, Long userId, Long cursorId, Pageable pageable) {
+    public Slice<Note> findAllByUserId(boolean hasLyrics, Long artistId, NoteType noteType, Long userId, Long cursorId, Pageable pageable) {
         List<Note> content = jpaQueryFactory
                 .selectFrom(note)
                 .leftJoin(note.lyrics).fetchJoin()
@@ -61,6 +63,7 @@ public class QueryDslNoteQueryRepository implements NoteQueryRepository {
                 .where(
                         hasLyrics(hasLyrics),
                         artistId == null ? null : artist.id.eq(artistId),
+                        hasNoteType(noteType),
                         note.publisher.deletedAt.isNull(),
                         note.publisher.id.eq(userId),
                         note.deletedAt.isNull(),
@@ -79,7 +82,7 @@ public class QueryDslNoteQueryRepository implements NoteQueryRepository {
     }
 
     @Override
-    public Slice<Note> findAllByArtistIds(boolean hasLyrics, List<Long> artistsIds, Long userId, Long cursorId, Pageable pageable) {
+    public Slice<Note> findAllByArtistIds(boolean hasLyrics, List<Long> artistsIds, NoteType noteType, Long userId, Long cursorId, Pageable pageable) {
         List<Note> content = jpaQueryFactory
                 .selectFrom(note)
                 .leftJoin(note.lyrics).fetchJoin()
@@ -90,6 +93,7 @@ public class QueryDslNoteQueryRepository implements NoteQueryRepository {
                 .where(
                         hasLyrics(hasLyrics),
                         note.song.artist.id.in(artistsIds),
+                        hasNoteType(noteType),
                         note.deletedAt.isNull(),
                         QueryDslUtils.ltCursorId(cursorId, note.id),
                         note.publisher.notIn(
@@ -106,7 +110,7 @@ public class QueryDslNoteQueryRepository implements NoteQueryRepository {
     }
 
     @Override
-    public Slice<Note> findAll(boolean hasLyrics, List<Long> artistsIds, Long userId, Long cursorId, Pageable pageable) {
+    public Slice<Note> findAll(boolean hasLyrics, List<Long> artistsIds, NoteType noteType, Long userId, Long cursorId, Pageable pageable) {
         List<Note> content = jpaQueryFactory
                 .selectFrom(note)
                 .leftJoin(note.lyrics).fetchJoin()
@@ -117,6 +121,7 @@ public class QueryDslNoteQueryRepository implements NoteQueryRepository {
                 .where(
                         hasLyrics(hasLyrics),
                         artistsIds == null || artistsIds.isEmpty() ? null : note.song.artist.id.in(artistsIds),
+                        hasNoteType(noteType),
                         note.deletedAt.isNull(),
                         QueryDslUtils.ltCursorId(cursorId, note.id),
                         note.publisher.notIn(
@@ -133,7 +138,7 @@ public class QueryDslNoteQueryRepository implements NoteQueryRepository {
     }
 
     @Override
-    public Slice<Note> findAllByArtistId(boolean hasLyrics, Long artistId, Long userId, Long cursorId, Pageable pageable) {
+    public Slice<Note> findAllByArtistId(boolean hasLyrics, Long artistId, NoteType noteType, Long userId, Long cursorId, Pageable pageable) {
         List<Note> content = jpaQueryFactory
                 .selectFrom(note)
                 .leftJoin(note.lyrics).fetchJoin()
@@ -144,6 +149,7 @@ public class QueryDslNoteQueryRepository implements NoteQueryRepository {
                 .where(
                         hasLyrics(hasLyrics),
                         note.song.artist.id.eq(artistId),
+                        hasNoteType(noteType),
                         note.deletedAt.isNull(),
                         QueryDslUtils.ltCursorId(cursorId, note.id),
                         note.publisher.notIn(
@@ -160,7 +166,7 @@ public class QueryDslNoteQueryRepository implements NoteQueryRepository {
     }
 
     @Override
-    public Slice<Note> findAllBySongId(boolean hasLyrics, Long songId, Long userId, Long cursorId, Pageable pageable) {
+    public Slice<Note> findAllBySongId(boolean hasLyrics, Long songId, NoteType noteType, Long userId, Long cursorId, Pageable pageable) {
         List<Note> content = jpaQueryFactory
                 .selectFrom(note)
                 .leftJoin(note.lyrics).fetchJoin()
@@ -171,6 +177,7 @@ public class QueryDslNoteQueryRepository implements NoteQueryRepository {
                 .where(
                         hasLyrics(hasLyrics),
                         note.song.id.eq(songId),
+                        hasNoteType(noteType),
                         note.deletedAt.isNull(),
                         QueryDslUtils.ltCursorId(cursorId, note.id),
                         note.publisher.notIn(
@@ -187,7 +194,7 @@ public class QueryDslNoteQueryRepository implements NoteQueryRepository {
     }
 
     @Override
-    public Slice<Note> findAllBookmarkedAndByArtistId(boolean hasLyrics, Long artistId, Long userId, Long cursorId, Pageable pageable) {
+    public Slice<Note> findAllBookmarkedAndByArtistId(boolean hasLyrics, Long artistId, NoteType noteType, Long userId, Long cursorId, Pageable pageable) {
         List<Note> content = jpaQueryFactory
                 .selectFrom(note)
                 .leftJoin(note.lyrics).fetchJoin()
@@ -200,6 +207,7 @@ public class QueryDslNoteQueryRepository implements NoteQueryRepository {
                                 .and(bookmark.deletedAt.isNull()),
                         hasLyrics(hasLyrics),
                         artistId == null ? null : note.song.artist.id.eq(artistId),
+                        hasNoteType(noteType),
                         note.deletedAt.isNull(),
                         QueryDslUtils.ltCursorId(cursorId, note.id),
                         note.publisher.notIn(
@@ -228,5 +236,9 @@ public class QueryDslNoteQueryRepository implements NoteQueryRepository {
                         )
                         .fetchOne()
         ).orElse(0L);
+    }
+
+    private BooleanExpression hasNoteType(NoteType noteType) {
+        return noteType == null ? null : note.noteType.eq(noteType);
     }
 }

--- a/src/main/java/com/projectlyrics/server/domain/note/service/NoteQueryService.java
+++ b/src/main/java/com/projectlyrics/server/domain/note/service/NoteQueryService.java
@@ -7,6 +7,7 @@ import com.projectlyrics.server.domain.favoriteartist.repository.FavoriteArtistQ
 import com.projectlyrics.server.domain.note.dto.response.NoteDetailResponse;
 import com.projectlyrics.server.domain.note.dto.response.NoteGetResponse;
 import com.projectlyrics.server.domain.note.entity.Note;
+import com.projectlyrics.server.domain.note.entity.NoteType;
 import com.projectlyrics.server.domain.note.repository.NoteQueryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -32,14 +33,14 @@ public class NoteQueryService {
         return NoteDetailResponse.of(note, comments, userId);
     }
 
-    public CursorBasePaginatedResponse<NoteGetResponse> getNotesByUserId(boolean hasLyrics, Long artistId, Long userId, Long cursor, int size) {
-        Slice<NoteGetResponse> notes = noteQueryRepository.findAllByUserId(hasLyrics, artistId, userId, cursor, PageRequest.ofSize(size))
+    public CursorBasePaginatedResponse<NoteGetResponse> getNotesByUserId(boolean hasLyrics, Long artistId, NoteType noteType, Long userId, Long cursor, int size) {
+        Slice<NoteGetResponse> notes = noteQueryRepository.findAllByUserId(hasLyrics, artistId, noteType, userId, cursor, PageRequest.ofSize(size))
                 .map(note -> NoteGetResponse.of(note, userId));
 
         return CursorBasePaginatedResponse.of(notes);
     }
 
-    public CursorBasePaginatedResponse<NoteGetResponse> getNotes(boolean hasLyrics, boolean isFavoriteArtistsOnly, Long userId, Long cursor, int size) {
+    public CursorBasePaginatedResponse<NoteGetResponse> getNotes(boolean hasLyrics, boolean isFavoriteArtistsOnly, NoteType noteType, Long userId, Long cursor, int size) {
         List<Long> artistsIds = null;
         if (isFavoriteArtistsOnly) {
             artistsIds = favoriteArtistQueryRepository.findAllByUserIdFetchArtist(userId)
@@ -48,28 +49,28 @@ public class NoteQueryService {
                     .toList();
         }
 
-        Slice<NoteGetResponse> notes = noteQueryRepository.findAll(hasLyrics, artistsIds, userId, cursor, PageRequest.ofSize(size))
+        Slice<NoteGetResponse> notes = noteQueryRepository.findAll(hasLyrics, artistsIds, noteType, userId, cursor, PageRequest.ofSize(size))
                 .map(note -> NoteGetResponse.of(note, userId));
 
         return CursorBasePaginatedResponse.of(notes);
     }
 
-    public CursorBasePaginatedResponse<NoteGetResponse> getNotesByArtistId(boolean hasLyrics, Long artistId, Long userId, Long cursor, int size) {
-        Slice<NoteGetResponse> notes = noteQueryRepository.findAllByArtistId(hasLyrics, artistId, userId, cursor, PageRequest.ofSize(size))
+    public CursorBasePaginatedResponse<NoteGetResponse> getNotesByArtistId(boolean hasLyrics, Long artistId, NoteType noteType, Long userId, Long cursor, int size) {
+        Slice<NoteGetResponse> notes = noteQueryRepository.findAllByArtistId(hasLyrics, artistId, noteType, userId, cursor, PageRequest.ofSize(size))
                 .map(note -> NoteGetResponse.of(note, userId));
 
         return CursorBasePaginatedResponse.of(notes);
     }
 
-    public CursorBasePaginatedResponse<NoteGetResponse> getNotesBySongId(boolean hasLyrics, Long songId, Long userId, Long cursor, int size) {
-        Slice<NoteGetResponse> notes = noteQueryRepository.findAllBySongId(hasLyrics, songId, userId, cursor, PageRequest.ofSize(size))
+    public CursorBasePaginatedResponse<NoteGetResponse> getNotesBySongId(boolean hasLyrics, Long songId, NoteType noteType, Long userId, Long cursor, int size) {
+        Slice<NoteGetResponse> notes = noteQueryRepository.findAllBySongId(hasLyrics, songId, noteType, userId, cursor, PageRequest.ofSize(size))
                 .map(note -> NoteGetResponse.of(note, userId));
 
         return CursorBasePaginatedResponse.of(notes);
     }
 
-    public CursorBasePaginatedResponse<NoteGetResponse> getBookmarkedNotes(boolean hasLyrics, Long artistId, Long userId, Long cursor, int size) {
-        Slice<NoteGetResponse> notes = noteQueryRepository.findAllBookmarkedAndByArtistId(hasLyrics, artistId, userId, cursor, PageRequest.ofSize(size))
+    public CursorBasePaginatedResponse<NoteGetResponse> getBookmarkedNotes(boolean hasLyrics, Long artistId, NoteType noteType, Long userId, Long cursor, int size) {
+        Slice<NoteGetResponse> notes = noteQueryRepository.findAllBookmarkedAndByArtistId(hasLyrics, artistId, noteType, userId, cursor, PageRequest.ofSize(size))
                 .map(note -> NoteGetResponse.of(note, userId));
 
         return CursorBasePaginatedResponse.of(notes);

--- a/src/main/java/com/projectlyrics/server/global/configuration/WebConfig.java
+++ b/src/main/java/com/projectlyrics/server/global/configuration/WebConfig.java
@@ -6,6 +6,7 @@ import com.projectlyrics.server.domain.auth.authentication.interceptor.DeviceIdI
 import com.projectlyrics.server.global.slack.interceptor.SlackInterceptor;
 import com.projectlyrics.server.domain.auth.authentication.interceptor.AdminInterceptor;
 import com.projectlyrics.server.domain.auth.authentication.interceptor.VersionVerificationInterceptor;
+import com.projectlyrics.server.global.converter.NoteTypeConverter;
 import com.projectlyrics.server.global.converter.ProfileCharacterConverter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -75,6 +76,7 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addFormatters(FormatterRegistry registry) {
+        registry.addConverter(new NoteTypeConverter());
         registry.addConverter(new ProfileCharacterConverter());
     }
 }

--- a/src/main/java/com/projectlyrics/server/global/converter/NoteTypeConverter.java
+++ b/src/main/java/com/projectlyrics/server/global/converter/NoteTypeConverter.java
@@ -1,0 +1,11 @@
+package com.projectlyrics.server.global.converter;
+
+import com.projectlyrics.server.domain.note.entity.NoteType;
+import org.springframework.core.convert.converter.Converter;
+
+public class NoteTypeConverter implements Converter<String, NoteType> {
+    @Override
+    public NoteType convert(String source) {
+        return NoteType.of(source);
+    }
+}

--- a/src/test/java/com/projectlyrics/server/domain/note/api/NoteControllerTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/note/api/NoteControllerTest.java
@@ -287,7 +287,7 @@ class NoteControllerTest extends RestDocsTest {
                 data
         );
 
-        given(noteQueryService.getNotesByUserId(anyBoolean(), any(), any(), any(), anyInt()))
+        given(noteQueryService.getNotesByUserId(anyBoolean(), any(), any(), any(), any(), anyInt()))
                 .willReturn(response);
 
         // when, then
@@ -391,7 +391,7 @@ class NoteControllerTest extends RestDocsTest {
                 data
         );
 
-        given(noteQueryService.getNotes(anyBoolean(), anyBoolean(), any(), any(), anyInt()))
+        given(noteQueryService.getNotes(anyBoolean(), anyBoolean(), any(), any(), any(), anyInt()))
                 .willReturn(response);
 
         // when, then
@@ -495,7 +495,7 @@ class NoteControllerTest extends RestDocsTest {
                 data
         );
 
-        given(noteQueryService.getNotesByArtistId(anyBoolean(), any(), any(), any(), anyInt()))
+        given(noteQueryService.getNotesByArtistId(anyBoolean(), any(), any(), any(), any(), anyInt()))
                 .willReturn(response);
 
         // when, then
@@ -598,7 +598,7 @@ class NoteControllerTest extends RestDocsTest {
                 data
         );
 
-        given(noteQueryService.getNotesBySongId(anyBoolean(), any(), any(), any(), anyInt()))
+        given(noteQueryService.getNotesBySongId(anyBoolean(), any(), any(), any(), any(), anyInt()))
                 .willReturn(response);
 
         // when, then
@@ -701,7 +701,7 @@ class NoteControllerTest extends RestDocsTest {
                 data
         );
 
-        given(noteQueryService.getBookmarkedNotes(anyBoolean(), any(), any(), any(), anyInt()))
+        given(noteQueryService.getBookmarkedNotes(anyBoolean(), any(), any(), any(), any(), anyInt()))
                 .willReturn(response);
 
         // when, then

--- a/src/test/java/com/projectlyrics/server/domain/note/entity/NoteTypeCaseInsensitiveTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/note/entity/NoteTypeCaseInsensitiveTest.java
@@ -1,0 +1,22 @@
+package com.projectlyrics.server.domain.note.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class NoteTypeCaseInsensitiveTest {
+
+    @Test
+    void 소문자_문자열도_노트타입으로_변환한다() {
+        NoteType result = NoteType.of("free");
+
+        assertThat(result).isEqualTo(NoteType.FREE);
+    }
+
+    @Test
+    void 혼합_대소문자_문자열도_노트타입으로_변환한다() {
+        NoteType result = NoteType.of("lyrics_analysis");
+
+        assertThat(result).isEqualTo(NoteType.LYRICS_ANALYSIS);
+    }
+}

--- a/src/test/java/com/projectlyrics/server/domain/note/entity/NoteTypeTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/note/entity/NoteTypeTest.java
@@ -37,7 +37,7 @@ class NoteTypeTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"INVALID", "free", "question", "", " "})
+    @ValueSource(strings = {"INVALID", "FREEE", "QUESTIONS", "", " ", "lyrics-analysis"})
     void 유효하지_않은_문자열에_대해_예외를_발생시켜야_한다(String invalidType) {
         // when & then
         assertThatThrownBy(() -> NoteType.of(invalidType))

--- a/src/test/java/com/projectlyrics/server/domain/note/service/NoteCommandServiceTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/note/service/NoteCommandServiceTest.java
@@ -72,7 +72,7 @@ class NoteCommandServiceTest extends IntegrationTest {
         Note note = sut.create(request, user.getId());
 
         // then
-        Slice<Note> result = noteQueryRepository.findAllByUserId(true, null, user.getId(), null, PageRequest.ofSize(5));
+        Slice<Note> result = noteQueryRepository.findAllByUserId(true, null, null, user.getId(), null, PageRequest.ofSize(5));
         assertAll(
                 () -> assertThat(result.getContent().size()).isEqualTo(1),
                 () -> assertThat(result.getContent().getFirst().getId()).isEqualTo(note.getId()),
@@ -127,9 +127,9 @@ class NoteCommandServiceTest extends IntegrationTest {
         Note note = sut.create(request, user.getId());
 
         // when
-        Slice<Note> beforeResult = noteQueryRepository.findAllByUserId(true, null, user.getId(), null, PageRequest.ofSize(5));
+        Slice<Note> beforeResult = noteQueryRepository.findAllByUserId(true, null, null, user.getId(), null, PageRequest.ofSize(5));
         sut.delete(user.getId(), note.getId());
-        Slice<Note> afterResult = noteQueryRepository.findAllByUserId(true, null, user.getId(), null, PageRequest.ofSize(5));
+        Slice<Note> afterResult = noteQueryRepository.findAllByUserId(true, null, null, user.getId(), null, PageRequest.ofSize(5));
 
         // then
         assertAll(

--- a/src/test/java/com/projectlyrics/server/domain/note/service/NoteQueryServiceTest.java
+++ b/src/test/java/com/projectlyrics/server/domain/note/service/NoteQueryServiceTest.java
@@ -35,6 +35,8 @@ import java.util.List;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.springframework.beans.factory.annotation.Autowired;
 
 class NoteQueryServiceTest extends IntegrationTest {
@@ -184,7 +186,8 @@ class NoteQueryServiceTest extends IntegrationTest {
                 });
 
         // when
-        CursorBasePaginatedResponse<NoteGetResponse> result = sut.getNotesByUserId(true, null, user.getId(), null, 10);
+        CursorBasePaginatedResponse<NoteGetResponse> result = sut.getNotesByUserId(true, null, null, user.getId(), null,
+                10);
 
         // then
         assertAll(
@@ -207,7 +210,8 @@ class NoteQueryServiceTest extends IntegrationTest {
                 });
 
         // when
-        CursorBasePaginatedResponse<NoteGetResponse> result = sut.getNotesByUserId(false, null, user.getId(), null, 10);
+        CursorBasePaginatedResponse<NoteGetResponse> result = sut.getNotesByUserId(false, null, null, user.getId(),
+                null, 10);
 
         // then
         assertAll(
@@ -230,7 +234,7 @@ class NoteQueryServiceTest extends IntegrationTest {
         Note likedArtistSongNote3 = noteCommandService.create(likedArtistSongNoteRequest, user.getId());
 
         // when
-        CursorBasePaginatedResponse<NoteGetResponse> result = sut.getNotes(true, true, user.getId(), null, 5);
+        CursorBasePaginatedResponse<NoteGetResponse> result = sut.getNotes(true, true, null, user.getId(), null, 5);
 
         // then
         assertAll(
@@ -255,7 +259,7 @@ class NoteQueryServiceTest extends IntegrationTest {
         blockCommandRepository.save(BlockFixture.create(user, user1));
 
         // when
-        CursorBasePaginatedResponse<NoteGetResponse> result = sut.getNotes(true, true, user.getId(), null, 5);
+        CursorBasePaginatedResponse<NoteGetResponse> result = sut.getNotes(true, true, null, user.getId(), null, 5);
 
         // then
         assertAll(
@@ -273,8 +277,10 @@ class NoteQueryServiceTest extends IntegrationTest {
         Note note3 = noteCommandService.create(likedArtistSongNoteRequest, user.getId());
 
         // when
-        CursorBasePaginatedResponse<NoteGetResponse> result1 = sut.getNotesByArtistId(false, likedArtist.getId(), user.getId(), null, 5);
-        CursorBasePaginatedResponse<NoteGetResponse> result2 = sut.getNotesByArtistId(false, unlikedArtistSong.getId(), user.getId(), null, 5);
+        CursorBasePaginatedResponse<NoteGetResponse> result1 = sut.getNotesByArtistId(false, likedArtist.getId(), null,
+                user.getId(), null, 5);
+        CursorBasePaginatedResponse<NoteGetResponse> result2 = sut.getNotesByArtistId(false, unlikedArtistSong.getId(),
+                null, user.getId(), null, 5);
 
         // then
         assertAll(
@@ -303,7 +309,8 @@ class NoteQueryServiceTest extends IntegrationTest {
         Note note3 = noteCommandService.create(likedArtistSongNoteRequest, user.getId());
 
         // when
-        CursorBasePaginatedResponse<NoteGetResponse> result = sut.getNotesByArtistId(true, likedArtist.getId(), user.getId(), null, 5);
+        CursorBasePaginatedResponse<NoteGetResponse> result = sut.getNotesByArtistId(true, likedArtist.getId(), null,
+                user.getId(), null, 5);
 
         // then
         assertAll(
@@ -323,7 +330,8 @@ class NoteQueryServiceTest extends IntegrationTest {
         blockCommandRepository.save(BlockFixture.create(user, user1));
 
         // when
-        CursorBasePaginatedResponse<NoteGetResponse> result = sut.getNotesByArtistId(false, likedArtist.getId(), user.getId(), null, 5);
+        CursorBasePaginatedResponse<NoteGetResponse> result = sut.getNotesByArtistId(false, likedArtist.getId(), null,
+                user.getId(), null, 5);
 
         // then
         assertAll(
@@ -341,8 +349,10 @@ class NoteQueryServiceTest extends IntegrationTest {
         Note note3 = noteCommandService.create(likedArtistSongNoteRequest, user.getId());
 
         // when
-        CursorBasePaginatedResponse<NoteGetResponse> result1 = sut.getNotesBySongId(false, likedArtistSong.getId(), user.getId(), null, 5);
-        CursorBasePaginatedResponse<NoteGetResponse> result2 = sut.getNotesBySongId(false, unlikedArtistSong.getId(), user.getId(), null, 5);
+        CursorBasePaginatedResponse<NoteGetResponse> result1 = sut.getNotesBySongId(false, likedArtistSong.getId(),
+                null, user.getId(), null, 5);
+        CursorBasePaginatedResponse<NoteGetResponse> result2 = sut.getNotesBySongId(false, unlikedArtistSong.getId(),
+                null, user.getId(), null, 5);
 
         // then
         assertAll(
@@ -364,7 +374,8 @@ class NoteQueryServiceTest extends IntegrationTest {
         blockCommandRepository.save(BlockFixture.create(user, user1));
 
         // when
-        CursorBasePaginatedResponse<NoteGetResponse> result = sut.getNotesBySongId(false, likedArtistSong.getId(), user.getId(), null, 5);
+        CursorBasePaginatedResponse<NoteGetResponse> result = sut.getNotesBySongId(false, likedArtistSong.getId(), null,
+                user.getId(), null, 5);
 
         // then
         assertAll(
@@ -385,7 +396,8 @@ class NoteQueryServiceTest extends IntegrationTest {
         bookmarkCommandRepository.save(BookmarkFixture.create(user, bookmarkedNote2));
 
         // when
-        CursorBasePaginatedResponse<NoteGetResponse> result = sut.getBookmarkedNotes(true, likedArtist.getId(), user.getId(), null, 5);
+        CursorBasePaginatedResponse<NoteGetResponse> result = sut.getBookmarkedNotes(true, likedArtist.getId(), null,
+                user.getId(), null, 5);
 
         // then
         assertAll(
@@ -405,7 +417,8 @@ class NoteQueryServiceTest extends IntegrationTest {
         bookmarkCommandRepository.save(BookmarkFixture.create(user, bookmarkedNoteOfUnlikedArtist));
 
         // when
-        CursorBasePaginatedResponse<NoteGetResponse> result = sut.getBookmarkedNotes(true, likedArtist.getId(), user.getId(), null, 5);
+        CursorBasePaginatedResponse<NoteGetResponse> result = sut.getBookmarkedNotes(true, likedArtist.getId(), null,
+                user.getId(), null, 5);
 
         // then
         assertAll(
@@ -424,7 +437,8 @@ class NoteQueryServiceTest extends IntegrationTest {
         bookmarkCommandRepository.save(BookmarkFixture.create(user, unlikedArtistNote));
 
         // when
-        CursorBasePaginatedResponse<NoteGetResponse> result = sut.getBookmarkedNotes(true, likedArtist.getId(), user.getId(), null, 5);
+        CursorBasePaginatedResponse<NoteGetResponse> result = sut.getBookmarkedNotes(true, likedArtist.getId(), null,
+                user.getId(), null, 5);
 
         // then
         assertAll(
@@ -450,7 +464,8 @@ class NoteQueryServiceTest extends IntegrationTest {
         blockCommandRepository.save(BlockFixture.create(user, user1));
 
         // when
-        CursorBasePaginatedResponse<NoteGetResponse> result = sut.getBookmarkedNotes(true, likedArtist.getId(), user.getId(), null, 5);
+        CursorBasePaginatedResponse<NoteGetResponse> result = sut.getBookmarkedNotes(true, likedArtist.getId(), null,
+                user.getId(), null, 5);
 
         // then
         assertAll(
@@ -458,5 +473,135 @@ class NoteQueryServiceTest extends IntegrationTest {
                 () -> assertThat(result.data().get(0).id()).isEqualTo(bookmarkedNote4.getId()),
                 () -> assertThat(result.data().get(1).id()).isEqualTo(bookmarkedNote3.getId())
         );
+    }
+
+    @ParameterizedTest
+    @EnumSource(NoteType.class)
+    void 노트_타입으로_사용자_노트를_조회할_수_있다(NoteType noteType) {
+        // given
+        Note expectedNote = noteCommandService.create(createNoteRequestByType(likedArtistSong.getId(), noteType),
+                user.getId());
+        noteCommandService.create(createNoteRequestByType(likedArtistSong.getId(), getAnotherType(noteType)),
+                user.getId());
+
+        // when
+        CursorBasePaginatedResponse<NoteGetResponse> result = sut.getNotesByUserId(true, null, noteType, user.getId(),
+                null, 10);
+
+        // then
+        assertAll(
+                () -> assertThat(result.data()).hasSize(1),
+                () -> assertThat(result.data().getFirst().id()).isEqualTo(expectedNote.getId()),
+                () -> assertThat(result.data().getFirst().noteType()).isEqualTo(noteType.getType())
+        );
+    }
+
+    @ParameterizedTest
+    @EnumSource(NoteType.class)
+    void 노트_타입으로_좋아하는_아티스트_노트를_조회할_수_있다(NoteType noteType) {
+        // given
+        favoriteArtistCommandRepository.save(FavoriteArtistFixture.create(user, likedArtist));
+        Note expectedNote = noteCommandService.create(createNoteRequestByType(likedArtistSong.getId(), noteType),
+                user.getId());
+        noteCommandService.create(createNoteRequestByType(likedArtistSong.getId(), getAnotherType(noteType)),
+                user.getId());
+        noteCommandService.create(createNoteRequestByType(unlikedArtistSong.getId(), noteType), user.getId());
+
+        // when
+        CursorBasePaginatedResponse<NoteGetResponse> result = sut.getNotes(true, true, noteType, user.getId(), null,
+                10);
+
+        // then
+        assertAll(
+                () -> assertThat(result.data()).hasSize(1),
+                () -> assertThat(result.data().getFirst().id()).isEqualTo(expectedNote.getId()),
+                () -> assertThat(result.data().getFirst().noteType()).isEqualTo(noteType.getType())
+        );
+    }
+
+    @ParameterizedTest
+    @EnumSource(NoteType.class)
+    void 노트_타입으로_아티스트별_노트를_조회할_수_있다(NoteType noteType) {
+        // given
+        Note expectedNote = noteCommandService.create(createNoteRequestByType(likedArtistSong.getId(), noteType),
+                user.getId());
+        noteCommandService.create(createNoteRequestByType(likedArtistSong.getId(), getAnotherType(noteType)),
+                user.getId());
+        noteCommandService.create(createNoteRequestByType(unlikedArtistSong.getId(), noteType), user.getId());
+
+        // when
+        CursorBasePaginatedResponse<NoteGetResponse> result = sut.getNotesByArtistId(true, likedArtist.getId(),
+                noteType, user.getId(), null, 10);
+
+        // then
+        assertAll(
+                () -> assertThat(result.data()).hasSize(1),
+                () -> assertThat(result.data().getFirst().id()).isEqualTo(expectedNote.getId()),
+                () -> assertThat(result.data().getFirst().noteType()).isEqualTo(noteType.getType())
+        );
+    }
+
+    @ParameterizedTest
+    @EnumSource(NoteType.class)
+    void 노트_타입으로_곡별_노트를_조회할_수_있다(NoteType noteType) {
+        // given
+        Note expectedNote = noteCommandService.create(createNoteRequestByType(likedArtistSong.getId(), noteType),
+                user.getId());
+        noteCommandService.create(createNoteRequestByType(likedArtistSong.getId(), getAnotherType(noteType)),
+                user.getId());
+
+        // when
+        CursorBasePaginatedResponse<NoteGetResponse> result = sut.getNotesBySongId(true, likedArtistSong.getId(),
+                noteType, user.getId(), null, 10);
+
+        // then
+        assertAll(
+                () -> assertThat(result.data()).hasSize(1),
+                () -> assertThat(result.data().getFirst().id()).isEqualTo(expectedNote.getId()),
+                () -> assertThat(result.data().getFirst().noteType()).isEqualTo(noteType.getType())
+        );
+    }
+
+    @ParameterizedTest
+    @EnumSource(NoteType.class)
+    void 노트_타입으로_북마크한_노트를_조회할_수_있다(NoteType noteType) {
+        // given
+        Note expectedNote = noteCommandService.create(createNoteRequestByType(likedArtistSong.getId(), noteType),
+                user.getId());
+        Note anotherTypeNote = noteCommandService.create(
+                createNoteRequestByType(likedArtistSong.getId(), getAnotherType(noteType)), user.getId());
+
+        bookmarkCommandRepository.save(BookmarkFixture.create(user, expectedNote));
+        bookmarkCommandRepository.save(BookmarkFixture.create(user, anotherTypeNote));
+
+        // when
+        CursorBasePaginatedResponse<NoteGetResponse> result = sut.getBookmarkedNotes(true, likedArtist.getId(),
+                noteType, user.getId(), null, 10);
+
+        // then
+        assertAll(
+                () -> assertThat(result.data()).hasSize(1),
+                () -> assertThat(result.data().getFirst().id()).isEqualTo(expectedNote.getId()),
+                () -> assertThat(result.data().getFirst().noteType()).isEqualTo(noteType.getType())
+        );
+    }
+
+    private NoteCreateRequest createNoteRequestByType(Long songId, NoteType noteType) {
+        return new NoteCreateRequest(
+                "content",
+                "lyrics",
+                NoteBackground.DEFAULT,
+                NoteStatus.PUBLISHED,
+                noteType,
+                songId
+        );
+    }
+
+    private NoteType getAnotherType(NoteType noteType) {
+        return switch (noteType) {
+            case FREE -> NoteType.QUESTION;
+            case QUESTION -> NoteType.LYRICS_ANALYSIS;
+            case LYRICS_ANALYSIS -> NoteType.FREE;
+        };
     }
 }


### PR DESCRIPTION
# 🍃 **Pull Requests**

## ⛳️ **작업한 브랜치**
- Resolved:  #[SCRUM-261]

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
노트 타입별로 검색 결과를 제공할 수 있도록
  - /api/v1/users/notes                  
  - /api/v1/notes                        
  - /api/v1/notes/artists                
  - /api/v1/notes/songs                  
  - /api/v1/notes/bookmarked   
  에 노트 타입 필터를 추가했어요

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
간단한 작업이라서 ai로 구현했습니다. 검토를 진행해보기는 했는데 문제가 있으면 알려주세요
사실 홈화면 필터링에 대해 프런트엔드와 이야기를 직접 나눈게 아니라서 일단 get 관련 api에 다 추가했었는데, 필요없는 api 있다면 알려주세요
[SCRUM-261]: https://projectlyrics.atlassian.net/browse/SCRUM-261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ